### PR TITLE
added fix to align container version in public configs

### DIFF
--- a/central/requirements.yaml
+++ b/central/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
 #  repository: "file://../centralhub"
 #  condition: centralhub.enabled
 - name: centralledger
-  version: 3.5.0
+  version: 3.5.1
   repository: "file://../centralledger"
   condition: centralledger.enabled
 - name: centraldirectory

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -119,7 +119,7 @@ global:
 #        api:
 #          image:
 #            repository: mojaloop/central-ledger
-#            tag: v3.5.0-snapshot
+#            tag: v3.5.1-snapshot
 #            pullPolicy: Always
 #            command: '["node", "src/api/index.js"]'
 #          service:
@@ -144,7 +144,7 @@ global:
 #        admin:
 #          image:
 #            repository: mojaloop/central-ledger
-#            tag: v3.5.0-snapshot
+#            tag: v3.5.1-snapshot
 #            pullPolicy: Always
 #            command: '["node", "src/admin/index.js"]'
 #          service:
@@ -768,7 +768,7 @@ global:
 #        api:
 #          image:
 #            repository: mojaloop/central-ledger
-#            tag: v3.5.0-snapshot
+#            tag: v3.5.1-snapshot
 #            pullPolicy: Always
 #            command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
 #          service:
@@ -1397,7 +1397,7 @@ global:
 #        api:
 #          image:
 #            repository: mojaloop/central-ledger
-#            tag: v3.5.0-snapshot
+#            tag: v3.5.1-snapshot
 #            pullPolicy: Always
 #            command: '["node", "src/handlers/index.js", "handler", "--position"]'
 #          service:
@@ -2025,7 +2025,7 @@ global:
 #        api:
 #          image:
 #            repository: mojaloop/central-ledger
-#            tag: v3.5.0-snapshot
+#            tag: v3.5.1-snapshot
 #            pullPolicy: Always
 #            command: '["node", "src/handlers/index.js", "handler", "--transfer"]'
 #          service:
@@ -2654,7 +2654,7 @@ global:
 #        api:
 #          image:
 #            repository: mojaloop/central-ledger
-#            tag: v3.5.0-snapshot
+#            tag: v3.5.1-snapshot
 #            pullPolicy: Always
 #            command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
 #          service:
@@ -3983,7 +3983,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v3.5.0-snapshot
+          tag: v3.5.1-snapshot
           pullPolicy: Always
           command: '["node", "src/api/index.js"]'
         service:
@@ -4008,7 +4008,7 @@ centralledger:
       admin:
         image:
           repository: mojaloop/central-ledger
-          tag: v3.5.0-snapshot
+          tag: v3.5.1-snapshot
           pullPolicy: Always
           command: '["node", "src/admin/index.js"]'
         service:
@@ -4632,7 +4632,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v3.5.0-snapshot
+          tag: v3.5.1-snapshot
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
         service:
@@ -5261,7 +5261,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v3.5.0-snapshot
+          tag: v3.5.1-snapshot
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--position"]'
         service:
@@ -5889,7 +5889,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v3.5.0-snapshot
+          tag: v3.5.1-snapshot
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--transfer"]'
         service:
@@ -6518,7 +6518,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v3.5.0-snapshot
+          tag: v3.5.1-snapshot
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
         service:
@@ -7146,7 +7146,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v3.5.0-snapshot
+          tag: v3.5.1-snapshot
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
         service:

--- a/centralhub/values.yaml
+++ b/centralhub/values.yaml
@@ -117,7 +117,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v3.5.0-snapshot
+          tag: v3.5.1-snapshot
           pullPolicy: Always
           command: '["node", "src/api/index.js"]'
         service:
@@ -142,7 +142,7 @@ centralledger:
       admin:
         image:
           repository: mojaloop/central-ledger
-          tag: v3.5.0-snapshot
+          tag: v3.5.1-snapshot
           pullPolicy: Always
           command: '["node", "src/admin/index.js"]'
         service:
@@ -766,7 +766,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v3.5.0-snapshot
+          tag: v3.5.1-snapshot
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
         service:
@@ -1395,7 +1395,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v3.5.0-snapshot
+          tag: v3.5.1-snapshot
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--position"]'
         service:
@@ -2023,7 +2023,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v3.5.0-snapshot
+          tag: v3.5.1-snapshot
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--transfer"]'
         service:
@@ -2652,7 +2652,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v3.5.0-snapshot
+          tag: v3.5.1-snapshot
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
         service:
@@ -3280,7 +3280,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v3.5.0-snapshot
+          tag: v3.5.1-snapshot
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
         service:

--- a/centralledger/Chart.yaml
+++ b/centralledger/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Central-Ledger Helm chart for Kubernetes
 name: centralledger
-version: 3.5.0
+version: 3.5.1
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-timeout/Chart.yaml
+++ b/centralledger/chart-handler-timeout/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Central-Ledger Timeout Handler Helm chart for Kubernetes
 name: centralledger-handler-timeout
-version: 3.5.0
+version: 3.5.1
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-timeout/values.yaml
+++ b/centralledger/chart-handler-timeout/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v3.5.0-snapshot
+      tag: v3.5.1-snapshot
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--transfer"]'
     service:

--- a/centralledger/chart-handler-transfer-fulfil/Chart.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Central-Ledger Transfer Fulfil Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-fulfil
-version: 3.5.0
+version: 3.5.1
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-fulfil/values.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v3.5.0-snapshot
+      tag: v3.5.1-snapshot
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
     service:

--- a/centralledger/chart-handler-transfer-position/Chart.yaml
+++ b/centralledger/chart-handler-transfer-position/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Central-Ledger Transfer Position Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-position
-version: 3.5.0
+version: 3.5.1
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-position/values.yaml
+++ b/centralledger/chart-handler-transfer-position/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v3.5.0-snapshot
+      tag: v3.5.1-snapshot
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--position"]'
     service:

--- a/centralledger/chart-handler-transfer-prepare/Chart.yaml
+++ b/centralledger/chart-handler-transfer-prepare/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-prepare
-version: 3.5.0
+version: 3.5.1
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-prepare/values.yaml
+++ b/centralledger/chart-handler-transfer-prepare/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v3.5.0-snapshot
+      tag: v3.5.1-snapshot
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
     service:

--- a/centralledger/chart-handler-transfer-transfer/Chart.yaml
+++ b/centralledger/chart-handler-transfer-transfer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Central-Ledger Transfer Transfer Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-transfer
-version: 3.5.0
+version: 3.5.1
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-transfer/values.yaml
+++ b/centralledger/chart-handler-transfer-transfer/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v3.5.0-snapshot
+      tag: v3.5.1-snapshot
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--transfer"]'
     service:

--- a/centralledger/chart-service/Chart.yaml
+++ b/centralledger/chart-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Central-Ledger Service Helm chart for Kubernetes
 name: centralledger-service
-version: 3.5.0
+version: 3.5.1
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v3.5.0-snapshot
+      tag: v3.5.1-snapshot
       pullPolicy: Always
       command: '["node", "src/api/index.js"]'
     service:
@@ -49,7 +49,7 @@ containers:
   admin:
     image:
       repository: mojaloop/central-ledger
-      tag: v3.5.0-snapshot
+      tag: v3.5.1-snapshot
       pullPolicy: Always
       command: '["node", "src/admin/index.js"]'
     service:

--- a/centralledger/requirements.yaml
+++ b/centralledger/requirements.yaml
@@ -1,27 +1,27 @@
 # requirements.yaml
 dependencies:
 - name: centralledger-service
-  version: 3.5.0
+  version: 3.5.1
   repository: "file://./chart-service"
   condition: centralledger-service.enabled
 - name: centralledger-handler-transfer-prepare
-  version: 3.5.0
+  version: 3.5.1
   repository: "file://./chart-handler-transfer-prepare"
   condition: centralledger-handler-transfer-prepare.enabled
 - name: centralledger-handler-transfer-position
-  version: 3.5.0
+  version: 3.5.1
   repository: "file://./chart-handler-transfer-position"
   condition: centralledger-handler-transfer-position.enabled
 - name: centralledger-handler-transfer-transfer
-  version: 3.5.0
+  version: 3.5.1
   repository: "file://./chart-handler-transfer-transfer"
   condition: centralledger-handler-transfer-transfer.enabled
 - name: centralledger-handler-transfer-fulfil
-  version: 3.5.0
+  version: 3.5.1
   repository: "file://./chart-handler-transfer-fulfil"
   condition: centralledger-handler-transfer-fulfil.enabled
 - name: centralledger-handler-timeout
-  version: 3.5.0
+  version: 3.5.1
   repository: "file://./chart-handler-timeout"
   condition: centralledger-handler-timeout.enabled
 - name: forensicloggingsidecar

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -30,7 +30,7 @@ centralledger-service:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v3.3.0-snapshot
+        tag: v3.5.1-snapshot
         pullPolicy: Always
         command: '["node", "src/api/index.js"]'
       service:
@@ -55,7 +55,7 @@ centralledger-service:
     admin:
       image:
         repository: mojaloop/central-ledger
-        tag: v3.3.0-snapshot
+        tag: v3.5.1-snapshot
         pullPolicy: Always
         command: '["node", "src/admin/index.js"]'
       service:
@@ -679,7 +679,7 @@ centralledger-handler-transfer-prepare:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v3.3.0-snapshot
+        tag: v3.5.1-snapshot
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
       service:
@@ -1308,7 +1308,7 @@ centralledger-handler-transfer-position:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v3.3.0-snapshot
+        tag: v3.5.1-snapshot
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--position"]'
       service:
@@ -1936,7 +1936,7 @@ centralledger-handler-transfer-transfer:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v3.3.0-snapshot
+        tag: v3.5.1-snapshot
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--transfer"]'
       service:
@@ -2565,7 +2565,7 @@ centralledger-handler-transfer-fulfil:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v3.3.0-snapshot
+        tag: v3.5.1-snapshot
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
       service:
@@ -3193,7 +3193,7 @@ centralledger-handler-timeout:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v3.3.0-snapshot
+        tag: v3.5.1-snapshot
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
       service:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -120,7 +120,7 @@ central:
 #          api:
 #            image:
 #              repository: mojaloop/central-ledger
-#              tag: v3.5.0-snapshot
+#              tag: v3.5.1-snapshot
 #              pullPolicy: Always
 #              command: '["node", "src/api/index.js"]'
 #            service:
@@ -145,7 +145,7 @@ central:
 #          admin:
 #            image:
 #              repository: mojaloop/central-ledger
-#              tag: v3.5.0-snapshot
+#              tag: v3.5.1-snapshot
 #              pullPolicy: Always
 #              command: '["node", "src/admin/index.js"]'
 #            service:
@@ -769,7 +769,7 @@ central:
 #          api:
 #            image:
 #              repository: mojaloop/central-ledger
-#              tag: v3.5.0-snapshot
+#              tag: v3.5.1-snapshot
 #              pullPolicy: Always
 #              command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
 #            service:
@@ -1398,7 +1398,7 @@ central:
 #          api:
 #            image:
 #              repository: mojaloop/central-ledger
-#              tag: v3.5.0-snapshot
+#              tag: v3.5.1-snapshot
 #              pullPolicy: Always
 #              command: '["node", "src/handlers/index.js", "handler", "--position"]'
 #            service:
@@ -2026,7 +2026,7 @@ central:
 #          api:
 #            image:
 #              repository: mojaloop/central-ledger
-#              tag: v3.5.0-snapshot
+#              tag: v3.5.1-snapshot
 #              pullPolicy: Always
 #              command: '["node", "src/handlers/index.js", "handler", "--transfer"]'
 #            service:
@@ -2655,7 +2655,7 @@ central:
 #          api:
 #            image:
 #              repository: mojaloop/central-ledger
-#              tag: v3.5.0-snapshot
+#              tag: v3.5.1-snapshot
 #              pullPolicy: Always
 #              command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
 #            service:
@@ -3984,7 +3984,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v3.5.0-snapshot
+            tag: v3.5.1-snapshot
             pullPolicy: Always
             command: '["node", "src/api/index.js"]'
           service:
@@ -4009,7 +4009,7 @@ central:
         admin:
           image:
             repository: mojaloop/central-ledger
-            tag: v3.5.0-snapshot
+            tag: v3.5.1-snapshot
             pullPolicy: Always
             command: '["node", "src/admin/index.js"]'
           service:
@@ -4633,7 +4633,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v3.5.0-snapshot
+            tag: v3.5.1-snapshot
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
           service:
@@ -5262,7 +5262,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v3.5.0-snapshot
+            tag: v3.5.1-snapshot
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--position"]'
           service:
@@ -5890,7 +5890,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v3.5.0-snapshot
+            tag: v3.5.1-snapshot
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--transfer"]'
           service:
@@ -6519,7 +6519,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v3.5.0-snapshot
+            tag: v3.5.1-snapshot
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
           service:
@@ -7147,7 +7147,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v3.5.0-snapshot
+            tag: v3.5.1-snapshot
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
           service:


### PR DESCRIPTION
Added fix to align container version in public configs for Central-ledger 3.5.1.

This has been verified for deployments on the following charts:
- centralledger
- central
- mojaloop