### PR TITLE
fix: remove duplicate key definitions in values

### DIFF
--- a/interop-switch/values.yaml
+++ b/interop-switch/values.yaml
@@ -15,7 +15,6 @@ image:
 
 config:
   MAX_JVM_MEMORY: '256'
-  MAX_JVM_MEMORY: '256'
   SWITCH_SERVICE_HOST: '0.0.0.0'
   SWITCH_SERVICE_PORT: '8088'
   CENTRAL_DIR_HOST: 'centraldirectory'

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2030,7 +2030,7 @@ central:
       # requests:
       #  cpu: 100m
       #  memory: 128Mi
-  
+
   centraleventprocessor:
     replicaCount: 1
     image:
@@ -2067,8 +2067,8 @@ central:
 
       annotations: {}
 
-      # This allows one to point the service to an external backend. 
-      # This is useful for local development where one wishes to hijack 
+      # This allows one to point the service to an external backend.
+      # This is useful for local development where one wishes to hijack
       # the communication from the service to the node layer and point
       # to a specific endpoint (IP, Port, etc).
       external:
@@ -2076,7 +2076,7 @@ central:
         # 10.0.2.2 is the magic IP for the host on virtualbox's network
         ip: 10.0.2.2
         ports:
-          api: 
+          api:
             name: central-event-processor
             externalPort: 3080
 
@@ -2099,13 +2099,13 @@ central:
       # Used to create an Ingress record.
       hosts:
         api: central-event-processor.local
-      
+
       externalPath: /
-      
+
       annotations:
         # kubernetes.io/ingress.class: nginx
         # kubernetes.io/tls-acme: "true"
-      
+
       tls:
         # Secrets must be manually created in the namespace.
         # - secretName: chart-example-tls
@@ -2436,7 +2436,6 @@ interop-switch:
 
     config:
       MAX_JVM_MEMORY: '256'
-      MAX_JVM_MEMORY: '256'
       SWITCH_SERVICE_HOST: '0.0.0.0'
       SWITCH_SERVICE_PORT: '8088'
       CENTRAL_DIR_HOST: 'centraldirectory'
@@ -2666,9 +2665,6 @@ emailnotifier:
       ciphers: 'SSLv3'
     PORT: 3081
 
-  init:
-    enabled: true
-
   service:
     name: email-notifier
     type: ClusterIP
@@ -2677,8 +2673,8 @@ emailnotifier:
 
     annotations: {}
 
-    # This allows one to point the service to an external backend. 
-    # This is useful for local development where one wishes to hijack 
+    # This allows one to point the service to an external backend.
+    # This is useful for local development where one wishes to hijack
     # the communication from the service to the node layer and point
     # to a specific endpoint (IP, Port, etc).
     external:
@@ -2686,7 +2682,7 @@ emailnotifier:
       # 10.0.2.2 is the magic IP for the host on virtualbox's network
       ip: 10.0.2.2
       ports:
-        api: 
+        api:
           name: email-notifier
           externalPort: 3081
           internalPort: 3081
@@ -2710,13 +2706,13 @@ emailnotifier:
     # Used to create an Ingress record.
     hosts:
       api: email-notifier.local
-    
+
     externalPath: /
-    
+
     annotations:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
-    
+
     tls:
       # Secrets must be manually created in the namespace.
       # - secretName: chart-example-tls


### PR DESCRIPTION
Removing duplicate keys defined in `values.yaml` for:
* emailnotifier
* interop-switch