### PR TITLE
Update kafka requirement from 0.7.2 to 0.13.11

### DIFF
--- a/centralledger/requirements.yaml
+++ b/centralledger/requirements.yaml
@@ -42,7 +42,7 @@ dependencies:
   alias: mysql
   condition: mysql.enabled
 - name: kafka
-  version: 0.7.2
+  version: 0.13.11
   repository: http://storage.googleapis.com/kubernetes-charts-incubator
   alias: kafka
   condition: kafka.enabled


### PR DESCRIPTION
Updates the kafka requirement to the latest version

- Fixes bugs of values not being pulled through correctly

@mdebarros Can you try get this run against some nightly integration test to ensure it still passes? I did some manual testing my side and it looks to work correctly. This upgrade means zookeeper doesn't start a 3 node cluster when deploying mojaloop or centralledger. Which brings down the dev environment requirements quite considerably

**Before**
![Screenshot 2019-03-15 at 13 28 25](https://user-images.githubusercontent.com/12172996/54433581-e9ecea00-4734-11e9-9e5a-de40a64cbe2a.png)

**After**
![Screenshot 2019-03-15 at 13 10 08](https://user-images.githubusercontent.com/12172996/54433580-e9ecea00-4734-11e9-9718-2ef481b8ea17.png)


