### PR TITLE
Updates to support message stream encoding/decoding & ALS issue fixes

### DIFF
--- a/account-lookup-service/Chart.yaml
+++ b/account-lookup-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 6.2.3
-appVersion: "6.2.3-snapshot"
+version: 6.2.4
+appVersion: "6.2.4-snapshot"
 description: Account Lookup Service Helm Chart for Mojaloop
 name: account-lookup-service

--- a/account-lookup-service/chart-admin/Chart.yaml
+++ b/account-lookup-service/chart-admin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 6.2.3
-appVersion: "6.2.3-snapshot"
+version: 6.2.4
+appVersion: "6.2.4-snapshot"
 description: A Helm chart for Kubernetes
 name: account-lookup-service-admin

--- a/account-lookup-service/chart-admin/values.yaml
+++ b/account-lookup-service/chart-admin/values.yaml
@@ -8,7 +8,7 @@ containers:
   api:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v6.2.3-snapshot
+      tag: v6.2.4-snapshot
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--api"]'
     service:
@@ -19,7 +19,7 @@ containers:
   admin:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v6.2.3-snapshot
+      tag: v6.2.4-snapshot
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--admin"]'
     service:

--- a/account-lookup-service/chart-admin/values.yaml
+++ b/account-lookup-service/chart-admin/values.yaml
@@ -45,7 +45,7 @@ metrics:
 config:
   ## Central-Ledger config
   central_services_host: '$release_name-centralledger-service'
-  central_services_port: 3001
+  central_services_port: 80
 
   end_point_cache:
     expiresIn: 180000

--- a/account-lookup-service/chart-service/Chart.yaml
+++ b/account-lookup-service/chart-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 6.2.3
-appVersion: "6.2.3-snapshot"
+version: 6.2.4
+appVersion: "6.2.4-snapshot"
 description: A Helm chart for Kubernetes
 name: account-lookup-service

--- a/account-lookup-service/chart-service/values.yaml
+++ b/account-lookup-service/chart-service/values.yaml
@@ -8,7 +8,7 @@ containers:
   api:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v6.2.3-snapshot
+      tag: v6.2.4-snapshot
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--api"]'
     service:
@@ -19,7 +19,7 @@ containers:
   admin:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v6.2.3-snapshot
+      tag: v6.2.4-snapshot
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--admin"]'
     service:

--- a/account-lookup-service/chart-service/values.yaml
+++ b/account-lookup-service/chart-service/values.yaml
@@ -45,7 +45,7 @@ metrics:
 config:
   ## Central-Ledger config
   central_services_host: '$release_name-centralledger-service'
-  central_services_port: 3001
+  central_services_port: 80
 
   end_point_cache:
     expiresIn: 180000

--- a/account-lookup-service/requirements.yaml
+++ b/account-lookup-service/requirements.yaml
@@ -1,11 +1,11 @@
 # requirements.yaml
 dependencies:
 - name: account-lookup-service
-  version: 6.2.3
+  version: 6.2.4
   repository: "file://./chart-service"
   condition: account-lookup-service.enabled
 - name: account-lookup-service-admin
-  version: 6.2.3
+  version: 6.2.4
   repository: "file://./chart-admin"
   condition: account-lookup-service-admin.enabled
 - name: percona-xtradb-cluster

--- a/account-lookup-service/values.yaml
+++ b/account-lookup-service/values.yaml
@@ -10,7 +10,7 @@ account-lookup-service:
     api:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v6.2.3-snapshot
+        tag: v6.2.4-snapshot
         pullPolicy: IfNotPresent
         command: '["node", "src/index.js", "server", "--api"]'
       service:
@@ -21,7 +21,7 @@ account-lookup-service:
     admin:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v6.2.3-snapshot
+        tag: v6.2.4-snapshot
         pullPolicy: IfNotPresent
         command: '["node", "src/index.js", "server", "--admin"]'
       service:
@@ -123,7 +123,7 @@ account-lookup-service-admin:
     api:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v6.2.3-snapshot
+        tag: v6.2.4-snapshot
         pullPolicy: IfNotPresent
         command: '["node", "src/index.js", "server", "--api"]'
       service:
@@ -134,7 +134,7 @@ account-lookup-service-admin:
     admin:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v6.2.3-snapshot
+        tag: v6.2.4-snapshot
         pullPolicy: IfNotPresent
         command: '["node", "src/index.js", "server", "--admin"]'
       service:

--- a/account-lookup-service/values.yaml
+++ b/account-lookup-service/values.yaml
@@ -47,7 +47,7 @@ account-lookup-service:
   config:
     ## Central-Ledger config
     central_services_host: '$release_name-centralledger-service'
-    central_services_port: 3001
+    central_services_port: 80
 
     end_point_cache:
       expiresIn: 180000
@@ -160,7 +160,7 @@ account-lookup-service-admin:
   config:
     ## Central-Ledger config
     central_services_host: '$release_name-centralledger-service'
-    central_services_port: 3001
+    central_services_port: 80
 
     end_point_cache:
       expiresIn: 180000

--- a/central/Chart.yaml
+++ b/central/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central Helm chart for Kubernetes
 name: central
-version: 6.2.4
-appVersion: "6.2.4"
+version: 6.2.5
+appVersion: "6.2.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/central/Chart.yaml
+++ b/central/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Central Helm chart for Kubernetes
 name: central
-version: 6.2.5
+version: 6.3.0
 appVersion: "6.2.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png

--- a/central/requirements.yaml
+++ b/central/requirements.yaml
@@ -10,10 +10,10 @@ dependencies:
 #  repository: "file://../centraldirectory"
 #  condition: centraldirectory.enabled
 - name: centralsettlement
-  version: 6.1.3
+  version: 6.3.0
   repository: "file://../centralsettlement"
   condition: centralsettlement.enabled
 - name: centraleventprocessor
-  version: 6.1.1
+  version: 6.3.0
   repository: "file://../centraleventprocessor"
   condition: centraleventprocessor.enabled

--- a/central/requirements.yaml
+++ b/central/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: centralledger
-  version: 6.2.4
+  version: 6.2.5
   repository: "file://../centralledger"
   condition: centralledger.enabled
 ## Deprecated - to be removed shortly

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -42,7 +42,7 @@ centralledger:
           ports:
             api:
               name: http-api
-              externalPort: 3001
+              externalPort: 80
               internalPort: 3001
         readinessProbe:
           enabled: true
@@ -171,7 +171,7 @@ centralledger:
           ports:
             api:
               name: http-api
-              externalPort: 3001
+              externalPort: 80
               internalPort: 3001
         readinessProbe:
           enabled: true
@@ -309,7 +309,7 @@ centralledger:
           ports:
             api:
               name: http-api
-              externalPort: 3001
+              externalPort: 80
               internalPort: 3001
         readinessProbe:
           enabled: true
@@ -446,7 +446,7 @@ centralledger:
           ports:
             api:
               name: http-api
-              externalPort: 3001
+              externalPort: 80
               internalPort: 3001
         readinessProbe:
           enabled: true
@@ -584,7 +584,7 @@ centralledger:
           ports:
             api:
               name: http-api
-              externalPort: 3001
+              externalPort: 80
               internalPort: 3001
         readinessProbe:
           enabled: true
@@ -721,7 +721,7 @@ centralledger:
           ports:
             api:
               name: http-api
-              externalPort: 3001
+              externalPort: 80
               internalPort: 3001
         readinessProbe:
           enabled: true
@@ -858,7 +858,7 @@ centralledger:
           ports:
             api:
               name: http-api
-              externalPort: 3001
+              externalPort: 80
               internalPort: 3001
         readinessProbe:
           enabled: true

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -2014,7 +2014,7 @@ centralsettlement:
     ports:
       api:
         name: http-api
-        externalPort: 3007
+        externalPort: 80
         internalPort: 3007
 
     annotations: {}
@@ -2091,7 +2091,7 @@ centraleventprocessor:
   service:
     name: central-event-processor
     type: ClusterIP
-    externalPort: 3080
+    externalPort: 80
     internalPort: 3080
 
     annotations: {}

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -35,7 +35,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v6.2.4
+          tag: v6.2.5
           pullPolicy: Always
           command: '["node", "src/api/index.js"]'
         service:
@@ -164,7 +164,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v6.2.4
+          tag: v6.2.5
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
         service:
@@ -302,7 +302,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v6.2.4
+          tag: v6.2.5
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--position"]'
         service:
@@ -439,7 +439,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v6.2.4
+          tag: v6.2.5
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--get"]'
         service:
@@ -577,7 +577,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v6.2.4
+          tag: v6.2.5
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
         service:
@@ -714,7 +714,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v6.2.4
+          tag: v6.2.5
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
         service:
@@ -851,7 +851,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v6.2.4
+          tag: v6.2.5
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--admin"]'
         service:

--- a/centraleventprocessor/Chart.yaml
+++ b/centraleventprocessor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Central Event Processor for Mojaloop
 name: centraleventprocessor
-version: 6.1.1
+version: 6.3.0
 appVersion: "5.5.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png

--- a/centraleventprocessor/values.yaml
+++ b/centraleventprocessor/values.yaml
@@ -50,7 +50,7 @@ init:
 service:
   name: central-event-processor
   type: ClusterIP
-  externalPort: 3080
+  externalPort: 80
   internalPort: 3080
 
   annotations: {}

--- a/centralledger/Chart.yaml
+++ b/centralledger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Helm chart for Kubernetes
 name: centralledger
-version: 6.2.4
-appVersion: "6.2.4"
+version: 6.2.5
+appVersion: "6.2.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-admin-transfer/Chart.yaml
+++ b/centralledger/chart-handler-admin-transfer/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-admin-transfer
-version: 6.2.4
-appVersion: "6.2.4"
+version: 6.2.5
+appVersion: "6.2.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-admin-transfer/values.yaml
+++ b/centralledger/chart-handler-admin-transfer/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v6.2.4
+      tag: v6.2.5
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--admin"]'
     service:

--- a/centralledger/chart-handler-admin-transfer/values.yaml
+++ b/centralledger/chart-handler-admin-transfer/values.yaml
@@ -31,7 +31,7 @@ containers:
       ports:
         api:
           name: http-api
-          externalPort: 3001
+          externalPort: 80
           internalPort: 3001
     readinessProbe:
       enabled: true

--- a/centralledger/chart-handler-timeout/Chart.yaml
+++ b/centralledger/chart-handler-timeout/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Timeout Handler Helm chart for Kubernetes
 name: centralledger-handler-timeout
-version: 6.2.4
-appVersion: "6.2.4"
+version: 6.2.5
+appVersion: "6.2.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-timeout/values.yaml
+++ b/centralledger/chart-handler-timeout/values.yaml
@@ -31,7 +31,7 @@ containers:
       ports:
         api:
           name: http-api
-          externalPort: 3001
+          externalPort: 80
           internalPort: 3001
     readinessProbe:
       enabled: true

--- a/centralledger/chart-handler-timeout/values.yaml
+++ b/centralledger/chart-handler-timeout/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v6.2.4
+      tag: v6.2.5
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
     service:

--- a/centralledger/chart-handler-transfer-fulfil/Chart.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Fulfil Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-fulfil
-version: 6.2.4
-appVersion: "6.2.4"
+version: 6.2.5
+appVersion: "6.2.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-fulfil/values.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v6.2.4
+      tag: v6.2.5
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
     service:

--- a/centralledger/chart-handler-transfer-fulfil/values.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/values.yaml
@@ -31,7 +31,7 @@ containers:
       ports:
         api:
           name: http-api
-          externalPort: 3001
+          externalPort: 80
           internalPort: 3001
     readinessProbe:
       enabled: true

--- a/centralledger/chart-handler-transfer-get/Chart.yaml
+++ b/centralledger/chart-handler-transfer-get/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Get Transfer Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-get
-version: 6.2.4
-appVersion: "6.2.4"
+version: 6.2.5
+appVersion: "6.2.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-get/values.yaml
+++ b/centralledger/chart-handler-transfer-get/values.yaml
@@ -31,7 +31,7 @@ containers:
       ports:
         api:
           name: http-api
-          externalPort: 3001
+          externalPort: 80
           internalPort: 3001
     readinessProbe:
       enabled: true

--- a/centralledger/chart-handler-transfer-get/values.yaml
+++ b/centralledger/chart-handler-transfer-get/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v6.2.4
+      tag: v6.2.5
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--get"]'
     service:

--- a/centralledger/chart-handler-transfer-position/Chart.yaml
+++ b/centralledger/chart-handler-transfer-position/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Position Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-position
-version: 6.2.4
-appVersion: "6.2.4"
+version: 6.2.5
+appVersion: "6.2.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-position/values.yaml
+++ b/centralledger/chart-handler-transfer-position/values.yaml
@@ -31,7 +31,7 @@ containers:
       ports:
         api:
           name: http-api
-          externalPort: 3001
+          externalPort: 80
           internalPort: 3001
     readinessProbe:
       enabled: true

--- a/centralledger/chart-handler-transfer-position/values.yaml
+++ b/centralledger/chart-handler-transfer-position/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v6.2.4
+      tag: v6.2.5
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--position"]'
     service:

--- a/centralledger/chart-handler-transfer-prepare/Chart.yaml
+++ b/centralledger/chart-handler-transfer-prepare/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-prepare
-version: 6.2.4
-appVersion: "6.2.4"
+version: 6.2.5
+appVersion: "6.2.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-prepare/values.yaml
+++ b/centralledger/chart-handler-transfer-prepare/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v6.2.4
+      tag: v6.2.5
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
     service:

--- a/centralledger/chart-handler-transfer-prepare/values.yaml
+++ b/centralledger/chart-handler-transfer-prepare/values.yaml
@@ -31,7 +31,7 @@ containers:
       ports:
         api:
           name: http-api
-          externalPort: 3001
+          externalPort: 80
           internalPort: 3001
     readinessProbe:
       enabled: true

--- a/centralledger/chart-service/Chart.yaml
+++ b/centralledger/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Service Helm chart for Kubernetes
 name: centralledger-service
-version: 6.2.4
-appVersion: "6.2.4"
+version: 6.2.5
+appVersion: "6.2.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -31,7 +31,7 @@ containers:
       ports:
         api:
           name: http-api
-          externalPort: 3001
+          externalPort: 80
           internalPort: 3001
     readinessProbe:
       enabled: true

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v6.2.4
+      tag: v6.2.5
       pullPolicy: Always
       command: '["node", "src/api/index.js"]'
     service:

--- a/centralledger/requirements.yaml
+++ b/centralledger/requirements.yaml
@@ -1,31 +1,31 @@
 # requirements.yaml
 dependencies:
 - name: centralledger-service
-  version: 6.2.4
+  version: 6.2.5
   repository: "file://./chart-service"
   condition: centralledger-service.enabled
 - name: centralledger-handler-transfer-prepare
-  version: 6.2.4
+  version: 6.2.5
   repository: "file://./chart-handler-transfer-prepare"
   condition: centralledger-handler-transfer-prepare.enabled
 - name: centralledger-handler-transfer-position
-  version: 6.2.4
+  version: 6.2.5
   repository: "file://./chart-handler-transfer-position"
   condition: centralledger-handler-transfer-position.enabled
 - name: centralledger-handler-transfer-get
-  version: 6.2.4
+  version: 6.2.5
   repository: "file://./chart-handler-transfer-get"
   condition: centralledger-handler-transfer-get.enabled
 - name: centralledger-handler-transfer-fulfil
-  version: 6.2.4
+  version: 6.2.5
   repository: "file://./chart-handler-transfer-fulfil"
   condition: centralledger-handler-transfer-fulfil.enabled
 - name: centralledger-handler-timeout
-  version: 6.2.4
+  version: 6.2.5
   repository: "file://./chart-handler-timeout"
   condition: centralledger-handler-timeout.enabled
 - name: centralledger-handler-admin-transfer
-  version: 6.2.4
+  version: 6.2.5
   repository: "file://./chart-handler-admin-transfer"
   condition: centralledger-handler-transfer-get.enabled
 - name: forensicloggingsidecar

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -30,7 +30,7 @@ centralledger-service:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v6.2.4
+        tag: v6.2.5
         pullPolicy: Always
         command: '["node", "src/api/index.js"]'
       service:
@@ -159,7 +159,7 @@ centralledger-handler-transfer-prepare:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v6.2.4
+        tag: v6.2.5
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
       service:
@@ -297,7 +297,7 @@ centralledger-handler-transfer-position:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v6.2.4
+        tag: v6.2.5
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--position"]'
       service:
@@ -434,7 +434,7 @@ centralledger-handler-transfer-get:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v6.2.4
+        tag: v6.2.5
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--get"]'
       service:
@@ -572,7 +572,7 @@ centralledger-handler-transfer-fulfil:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v6.2.4
+        tag: v6.2.5
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
       service:
@@ -709,7 +709,7 @@ centralledger-handler-timeout:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v6.2.4
+        tag: v6.2.5
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
       service:
@@ -846,7 +846,7 @@ centralledger-handler-admin-transfer:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v6.2.4
+        tag: v6.2.5
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--admin"]'
       service:

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -37,7 +37,7 @@ centralledger-service:
         ports:
           api:
             name: http-api
-            externalPort: 3001
+            externalPort: 80
             internalPort: 3001
       readinessProbe:
         enabled: true
@@ -166,7 +166,7 @@ centralledger-handler-transfer-prepare:
         ports:
           api:
             name: http-api
-            externalPort: 3001
+            externalPort: 80
             internalPort: 3001
       readinessProbe:
         enabled: true
@@ -304,7 +304,7 @@ centralledger-handler-transfer-position:
         ports:
           api:
             name: http-api
-            externalPort: 3001
+            externalPort: 80
             internalPort: 3001
       readinessProbe:
         enabled: true
@@ -441,7 +441,7 @@ centralledger-handler-transfer-get:
         ports:
           api:
             name: http-api
-            externalPort: 3001
+            externalPort: 80
             internalPort: 3001
       readinessProbe:
         enabled: true
@@ -579,7 +579,7 @@ centralledger-handler-transfer-fulfil:
         ports:
           api:
             name: http-api
-            externalPort: 3001
+            externalPort: 80
             internalPort: 3001
       readinessProbe:
         enabled: true
@@ -716,7 +716,7 @@ centralledger-handler-timeout:
         ports:
           api:
             name: http-api
-            externalPort: 3001
+            externalPort: 80
             internalPort: 3001
       readinessProbe:
         enabled: true
@@ -853,7 +853,7 @@ centralledger-handler-admin-transfer:
         ports:
           api:
             name: http-api
-            externalPort: 3001
+            externalPort: 80
             internalPort: 3001
       readinessProbe:
         enabled: true

--- a/centralsettlement/Chart.yaml
+++ b/centralsettlement/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Central-Settlement Helm chart for Kubernetes
 name: centralsettlement
-version: 6.1.3
+version: 6.3.0
 appVersion: "6.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png

--- a/centralsettlement/values.yaml
+++ b/centralsettlement/values.yaml
@@ -72,7 +72,7 @@ service:
   ports:
     api:
       name: http-api
-      externalPort: 3007
+      externalPort: 80
       internalPort: 3007
 
   annotations: {}

--- a/emailnotifier/Chart.yaml
+++ b/emailnotifier/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Email Notifier For Mojaloop
 name: emailnotifier
-version: 6.1.1
+version: 6.3.0
 appVersion: "5.5.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png

--- a/emailnotifier/values.yaml
+++ b/emailnotifier/values.yaml
@@ -43,7 +43,7 @@ init:
 service:
   name: email-notifier
   type: ClusterIP
-  externalPort: 3081
+  externalPort: 80
   internalPort: 3081
 
   annotations: {}

--- a/ml-api-adapter/Chart.yaml
+++ b/ml-api-adapter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Helm chart for Kubernetes
 name: ml-api-adapter
-version: 6.2.0
-appVersion: "6.2.0"
+version: 6.2.1
+appVersion: "6.2.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-handler-notification/Chart.yaml
+++ b/ml-api-adapter/chart-handler-notification/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: ml-api-adapter-handler-notification
-version: 6.2.0
-appVersion: "6.2.0"
+version: 6.2.1
+appVersion: "6.2.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-handler-notification/configs/default.json
+++ b/ml-api-adapter/chart-handler-notification/configs/default.json
@@ -1,7 +1,7 @@
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
 {{- $centralServicesHost := printf "%s-%s" .Release.Name .Values.config.central_services_host -}}
 {
-    "PORT": {{ .Values.service.externalPort }},
+    "PORT": {{ .Values.service.internalPort }},
     "ENDPOINT_SOURCE_URL": "http://{{ $centralServicesHost }}:{{ .Values.config.central_services_port }}/participants/{{"{{"}}fsp{{"}}"}}/endpoints",
     "ENDPOINT_CACHE_CONFIG": {
         "expiresIn": 180000,

--- a/ml-api-adapter/chart-handler-notification/configs/default.json
+++ b/ml-api-adapter/chart-handler-notification/configs/default.json
@@ -1,5 +1,5 @@
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
-{{- $centralServicesHost := printf "%s-%s" .Release.Name .Values.config.central_services_host -}}
+{{- $centralServicesHost := ( .Values.config.central_services_host | replace "$release_name" .Release.Name ) -}}
 {
     "PORT": {{ .Values.service.internalPort }},
     "ENDPOINT_SOURCE_URL": "http://{{ $centralServicesHost }}:{{ .Values.config.central_services_port }}/participants/{{"{{"}}fsp{{"}}"}}/endpoints",

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v6.2.0
+  tag: v6.2.1
   command: '["node", "src/handlers/index.js", "handler", "--notification"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -57,8 +57,8 @@ config:
   # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
   kafka_host: '$release_name-kafka'
   kafka_port: 9092
-  central_services_host: centralledger-service
-  central_services_port: 3001
+  central_services_host: '$release_name-centralledger-service'
+  central_services_port: 80
   security:
     callback:
       rejectUnauthorized: true

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -65,9 +65,8 @@ config:
   log_level: 'info'
 
 service:
-  name: ml-api-adapter
   type: ClusterIP
-  externalPort: 8088
+  externalPort: 80
   internalPort: 8088
 
 ingress:

--- a/ml-api-adapter/chart-service/Chart.yaml
+++ b/ml-api-adapter/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter API component Helm chart for Kubernetes
 name: ml-api-adapter-service
-version: 6.2.0
-appVersion: "6.2.0"
+version: 6.2.1
+appVersion: "6.2.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-service/configs/default.json
+++ b/ml-api-adapter/chart-service/configs/default.json
@@ -1,7 +1,7 @@
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
 {{- $centralServicesHost := printf "%s-%s" .Release.Name .Values.config.central_services_host -}}
 {
-    "PORT": {{ .Values.service.externalPort }},
+    "PORT": {{ .Values.service.internalPort }},
     "ENDPOINT_SOURCE_URL": "http://{{ $centralServicesHost }}:{{ .Values.config.central_services_port }}/participants/{{"{{"}}fsp{{"}}"}}/endpoints",
     "ENDPOINT_CACHE_CONFIG": {
         "expiresIn": 180000,

--- a/ml-api-adapter/chart-service/configs/default.json
+++ b/ml-api-adapter/chart-service/configs/default.json
@@ -1,5 +1,5 @@
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
-{{- $centralServicesHost := printf "%s-%s" .Release.Name .Values.config.central_services_host -}}
+{{- $centralServicesHost := ( .Values.config.central_services_host | replace "$release_name" .Release.Name ) -}}
 {
     "PORT": {{ .Values.service.internalPort }},
     "ENDPOINT_SOURCE_URL": "http://{{ $centralServicesHost }}:{{ .Values.config.central_services_port }}/participants/{{"{{"}}fsp{{"}}"}}/endpoints",

--- a/ml-api-adapter/chart-service/values.yaml
+++ b/ml-api-adapter/chart-service/values.yaml
@@ -49,9 +49,8 @@ config:
   log_level: 'info'
 
 service:
-  name: ml-api-adapter
   type: ClusterIP
-  externalPort: 8088
+  externalPort: 80
   internalPort: 8088
 
 ingress:

--- a/ml-api-adapter/chart-service/values.yaml
+++ b/ml-api-adapter/chart-service/values.yaml
@@ -41,8 +41,8 @@ config:
   # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
   kafka_host: '$release_name-kafka'
   kafka_port: 9092
-  central_services_host: centralledger-service
-  central_services_port: 3001
+  central_services_host: '$release_name-centralledger-service'
+  central_services_port: 80
   security:
     callback:
       rejectUnauthorized: true

--- a/ml-api-adapter/chart-service/values.yaml
+++ b/ml-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v6.2.0
+  tag: v6.2.1
   command: '["node", "src/api/index.js"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/requirements.yaml
+++ b/ml-api-adapter/requirements.yaml
@@ -1,11 +1,11 @@
 # requirements.yaml
 dependencies:
 - name: ml-api-adapter-service
-  version: 6.2.0
+  version: 6.2.1
   repository: "file://./chart-service"
   condition: ml-api-adapter-service.enabled
 - name: ml-api-adapter-handler-notification
-  version: 6.2.0
+  version: 6.2.1
   repository: "file://./chart-handler-notification"
   condition: ml-api-adapter-handler-notification.enabled
 ## This is used for testing ml-api-adapter deployments

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -58,8 +58,8 @@ ml-api-adapter-service:
     # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
     kafka_host: '$release_name-kafka'
     kafka_port: 9092
-    central_services_host: centralledger-service
-    central_services_port: 3001
+    central_services_host: '$release_name-centralledger-service'
+    central_services_port: 80
     security:
       callback:
         rejectUnauthorized: true
@@ -142,8 +142,8 @@ ml-api-adapter-handler-notification:
     # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
     kafka_host: '$release_name-kafka'
     kafka_port: 9092
-    central_services_host: centralledger-service
-    central_services_port: 3001
+    central_services_host: '$release_name-centralledger-service'
+    central_services_port: 80
     security:
       callback:
         rejectUnauthorized: true

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -66,9 +66,8 @@ ml-api-adapter-service:
     log_level: 'info'
 
   service:
-    name: ml-api-adapter
     type: ClusterIP
-    externalPort: 8088
+    externalPort: 80
     internalPort: 8088
 
   ingress:
@@ -151,9 +150,8 @@ ml-api-adapter-handler-notification:
     log_level: 'info'
 
   service:
-    name: ml-api-adapter
     type: ClusterIP
-    externalPort: 8088
+    externalPort: 80
     internalPort: 8088
 
   ingress:

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -26,7 +26,7 @@ ml-api-adapter-service:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v6.2.0
+    tag: v6.2.1
     command: '["node", "src/api/index.js"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -108,7 +108,7 @@ ml-api-adapter-handler-notification:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v6.2.0
+    tag: v6.2.1
     command: '["node", "src/handlers/index.js", "handler", "--notification"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
-version: 6.2.11
+version: 6.3.0
 appVersion: "6.2.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
-version: 6.2.10
-appVersion: "6.2.4"
+version: 6.2.11
+appVersion: "6.2.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -26,6 +26,6 @@ dependencies:
   repository: "file://../quoting-service"
   condition: quoting-service.enabled
 - name: simulator
-  version: 6.3.0
+  version: 6.3.1
   repository: "file://../simulator"
   condition: simulator.enabled

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: central
-  version: 6.2.5
+  version: 6.3.0
   repository: "file://../central"
   condition: central.enabled
 ## Deprecated - to be removed shortly
@@ -14,7 +14,7 @@ dependencies:
   repository: "file://../ml-api-adapter"
   condition: ml-api-adapter.enabled
 - name: emailnotifier
-  version: 6.1.1
+  version: 6.3.0
   repository: "file://../emailnotifier"
   condition: emailnotifier.enabled
 - name: account-lookup-service

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: central
-  version: 6.2.4
+  version: 6.2.5
   repository: "file://../central"
   condition: central.enabled
 ## Deprecated - to be removed shortly

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -18,11 +18,11 @@ dependencies:
   repository: "file://../emailnotifier"
   condition: emailnotifier.enabled
 - name: account-lookup-service
-  version: 6.2.3
+  version: 6.2.4
   repository: "file://../account-lookup-service"
   condition: account-lookup-service.enabled
 - name: quoting-service
-  version: 6.2.0
+  version: 6.2.1
   repository: "file://../quoting-service"
   condition: quoting-service.enabled
 - name: simulator

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -26,6 +26,6 @@ dependencies:
   repository: "file://../quoting-service"
   condition: quoting-service.enabled
 - name: simulator
-  version: 6.2.6
+  version: 6.3.0
   repository: "file://../simulator"
   condition: simulator.enabled

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
 #  repository: "file://../interop-switch"
 #  condition: interop-switch.enabled
 - name: ml-api-adapter
-  version: 6.2.0
+  version: 6.2.1
   repository: "file://../ml-api-adapter"
   condition: ml-api-adapter.enabled
 - name: emailnotifier

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2012,7 +2012,7 @@ central:
       ports:
         api:
           name: http-api
-          externalPort: 3007
+          externalPort: 80
           internalPort: 3007
 
       annotations: {}
@@ -2088,7 +2088,7 @@ central:
     service:
       name: central-event-processor
       type: ClusterIP
-      externalPort: 3080
+      externalPort: 80
       internalPort: 3080
 
       annotations: {}
@@ -2730,7 +2730,7 @@ emailnotifier:
       ports:
         api:
           name: email-notifier
-          externalPort: 3081
+          externalPort: 80
           internalPort: 3081
 
   readinessProbe:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3169,7 +3169,7 @@ quoting-service:
     ports:
       api:
         name: http-api
-        externalPort: 3002
+        externalPort: 80
         internalPort: 3002
 
     annotations: {}

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2537,141 +2537,140 @@ central:
 #      #  memory: 128Mi
 
 ml-api-adapter:
-    ml-api-adapter-service:
+  ml-api-adapter-service:
+    enabled: true
+    # Default values for ml-api-adapter.
+    # This is a YAML-formatted file.
+    # Declare variables to be passed into your templates.
+    replicaCount: 1
+    image:
+      repository: mojaloop/ml-api-adapter
+      tag: v6.2.1
+      command: '["node", "src/api/index.js"]'
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    ##
+    #  imagePullSecrets:
+    #    - name: myregistrykey
+      pullPolicy: Always
+
+    ## metric configuration for prometheus instrumentation
+    metrics:
+      ## flag to enable/disable the metrics end-points
       enabled: true
-      # Default values for ml-api-adapter.
-      # This is a YAML-formatted file.
-      # Declare variables to be passed into your templates.
-      replicaCount: 1
-      image:
-        repository: mojaloop/ml-api-adapter
-        tag: v6.2.1
-        command: '["node", "src/api/index.js"]'
-      ## Optionally specify an array of imagePullSecrets.
-      ## Secrets must be manually created in the namespace.
-      ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
-      ##
-      #  imagePullSecrets:
-      #    - name: myregistrykey
-        pullPolicy: Always
 
-      ## metric configuration for prometheus instrumentation
-      metrics:
-        ## flag to enable/disable the metrics end-points
-        enabled: true
+    config:
+      # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+      kafka_host: '$release_name-kafka'
+      kafka_port: 9092
+      central_services_host: '$release_name-centralledger-service'
+      central_services_port: 80
+      security:
+        callback:
+          rejectUnauthorized: true
 
-      config:
-        # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
-        kafka_host: '$release_name-kafka'
-        kafka_port: 9092
-        central_services_host: centralledger-service
-        central_services_port: 3001
-        security:
-          callback:
-            rejectUnauthorized: true
+    service:
+      type: ClusterIP
+      externalPort: 80
+      internalPort: 8088
 
-      service:
-        type: ClusterIP
-        externalPort: 80
-        internalPort: 8088
-
-      ingress:
-        enabled: true
-        externalPath: /
-        # Used to create an Ingress record.
-        hosts:
-          api: ml-api-adapter.local
-
-        annotations:
-          nginx.ingress.kubernetes.io/rewrite-target: '/'
-          # kubernetes.io/ingress.class: nginx
-          # kubernetes.io/tls-acme: "true"
-        tls:
-          # Secrets must be manually created in the namespace.
-          # - secretName: chart-example-tls
-          #   hosts:
-          #     - chart-example.local
-      resources: {}
-        # We usually recommend not to specify default resources and to leave this as a conscious
-        # choice for the user. This also increases chances charts run on environments with little
-        # resources, such as Minikube. If you do want to specify resources, uncomment the following
-        # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-        # limits:
-        #  cpu: 100m
-        #  memory: 128Mi
-        # requests:
-        #  cpu: 100m
-        #  memory: 128Mi
-
-
-    ml-api-adapter-handler-notification:
+    ingress:
       enabled: true
-      # Default values for ml-api-adapter.
-      # This is a YAML-formatted file.
-      # Declare variables to be passed into your templates.
-      replicaCount: 1
-      image:
-        repository: mojaloop/ml-api-adapter
-        tag: v6.2.1
-        command: '["node", "src/handlers/index.js", "handler", "--notification"]'
-      ## Optionally specify an array of imagePullSecrets.
-      ## Secrets must be manually created in the namespace.
-      ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
-      ##
-      #  imagePullSecrets:
-      #    - name: myregistrykey
-        pullPolicy: Always
+      externalPath: /
+      # Used to create an Ingress record.
+      hosts:
+        api: ml-api-adapter.local
 
-      init:
-        enabled: true
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: '/'
+        # kubernetes.io/ingress.class: nginx
+        # kubernetes.io/tls-acme: "true"
+      tls:
+        # Secrets must be manually created in the namespace.
+        # - secretName: chart-example-tls
+        #   hosts:
+        #     - chart-example.local
+    resources: {}
+      # We usually recommend not to specify default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      # limits:
+      #  cpu: 100m
+      #  memory: 128Mi
+      # requests:
+      #  cpu: 100m
+      #  memory: 128Mi
 
-      ## metric configuration for prometheus instrumentation
-      metrics:
-        ## flag to enable/disable the metrics end-points
-        enabled: true
+  ml-api-adapter-handler-notification:
+    enabled: true
+    # Default values for ml-api-adapter.
+    # This is a YAML-formatted file.
+    # Declare variables to be passed into your templates.
+    replicaCount: 1
+    image:
+      repository: mojaloop/ml-api-adapter
+      tag: v6.2.1
+      command: '["node", "src/handlers/index.js", "handler", "--notification"]'
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    ##
+    #  imagePullSecrets:
+    #    - name: myregistrykey
+      pullPolicy: Always
 
-      config:
-        # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
-        kafka_host: '$release_name-kafka'
-        kafka_port: 9092
-        central_services_host: centralledger-service
-        central_services_port: 3001
-        security:
-          callback:
-            rejectUnauthorized: true
+    init:
+      enabled: true
 
-      service:
-        type: ClusterIP
-        externalPort: 80
-        internalPort: 8088
+    ## metric configuration for prometheus instrumentation
+    metrics:
+      ## flag to enable/disable the metrics end-points
+      enabled: true
 
-      ingress:
-        enabled: true
-        externalPath: /
-        # Used to create an Ingress record.
-        hosts:
-          api: ml-api-adapter-notification.local
+    config:
+      # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+      kafka_host: '$release_name-kafka'
+      kafka_port: 9092
+      central_services_host: '$release_name-centralledger-service'
+      central_services_port: 80
+      security:
+        callback:
+          rejectUnauthorized: true
 
-        annotations:
-          nginx.ingress.kubernetes.io/rewrite-target: '/'
-          # kubernetes.io/ingress.class: nginx
-          # kubernetes.io/tls-acme: "true"
-        tls:
-          # Secrets must be manually created in the namespace.
-          # - secretName: chart-example-tls
-          #   hosts:
-          #     - chart-example.local
-      resources: {}
-        # We usually recommend not to specify default resources and to leave this as a conscious
-        # choice for the user. This also increases chances charts run on environments with little
-        # resources, such as Minikube. If you do want to specify resources, uncomment the following
-        # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-        # limits:
-        #  cpu: 100m
-        #  memory: 128Mi
-        # requests:
-        #  cpu: 100m
-        #  memory: 128Mi
+    service:
+      type: ClusterIP
+      externalPort: 80
+      internalPort: 8088
+
+    ingress:
+      enabled: true
+      externalPath: /
+      # Used to create an Ingress record.
+      hosts:
+        api: ml-api-adapter-notification.local
+
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: '/'
+        # kubernetes.io/ingress.class: nginx
+        # kubernetes.io/tls-acme: "true"
+      tls:
+        # Secrets must be manually created in the namespace.
+        # - secretName: chart-example-tls
+        #   hosts:
+        #     - chart-example.local
+    resources: {}
+      # We usually recommend not to specify default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      # limits:
+      #  cpu: 100m
+      #  memory: 128Mi
+      # requests:
+      #  cpu: 100m
+      #  memory: 128Mi
 
 emailnotifier:
   replicaCount: 1

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3223,7 +3223,7 @@ simulator:
 
   image:
     repository: mojaloop/simulator
-    tag: v6.2.6
+    tag: v6.3.0
     pullPolicy: Always
 
   imagePullSecrets: []

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2828,7 +2828,7 @@ account-lookup-service:
     config:
       ## Central-Ledger config
       central_services_host: '$release_name-centralledger-service'
-      central_services_port: 3001
+      central_services_port: 80
 
       end_point_cache:
         expiresIn: 180000
@@ -2939,7 +2939,7 @@ account-lookup-service:
     config:
       ## Central-Ledger config
       central_services_host: '$release_name-centralledger-service'
-      central_services_port: 3001
+      central_services_port: 80
 
       end_point_cache:
         expiresIn: 180000

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -37,7 +37,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v6.2.4
+            tag: v6.2.5
             pullPolicy: Always
             command: '["node", "src/api/index.js"]'
           service:
@@ -166,7 +166,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v6.2.4
+            tag: v6.2.5
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
           service:
@@ -303,7 +303,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v6.2.4
+            tag: v6.2.5
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--admin"]'
           service:
@@ -440,7 +440,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v6.2.4
+            tag: v6.2.5
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--position"]'
           service:
@@ -577,7 +577,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v6.2.4
+            tag: v6.2.5
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--get"]'
           service:
@@ -714,7 +714,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v6.2.4
+            tag: v6.2.5
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
           service:
@@ -851,7 +851,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v6.2.4
+            tag: v6.2.5
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
           service:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3220,7 +3220,7 @@ simulator:
 
   image:
     repository: mojaloop/simulator
-    tag: v6.3.0
+    tag: v6.3.1
     pullPolicy: Always
 
   imagePullSecrets: []

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2545,7 +2545,7 @@ ml-api-adapter:
       replicaCount: 1
       image:
         repository: mojaloop/ml-api-adapter
-        tag: v6.2.0
+        tag: v6.2.1
         command: '["node", "src/api/index.js"]'
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
@@ -2613,7 +2613,7 @@ ml-api-adapter:
       replicaCount: 1
       image:
         repository: mojaloop/ml-api-adapter
-        tag: v6.2.0
+        tag: v6.2.1
         command: '["node", "src/handlers/index.js", "handler", "--notification"]'
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -44,7 +44,7 @@ central:
             ports:
               api:
                 name: http-api
-                externalPort: 3001
+                externalPort: 80
                 internalPort: 3001
           readinessProbe:
             enabled: true
@@ -173,7 +173,7 @@ central:
             ports:
               api:
                 name: http-api
-                externalPort: 3001
+                externalPort: 80
                 internalPort: 3001
           readinessProbe:
             enabled: true
@@ -310,7 +310,7 @@ central:
             ports:
               api:
                 name: http-api
-                externalPort: 3001
+                externalPort: 80
                 internalPort: 3001
           readinessProbe:
             enabled: true
@@ -447,7 +447,7 @@ central:
             ports:
               api:
                 name: http-api
-                externalPort: 3001
+                externalPort: 80
                 internalPort: 3001
           readinessProbe:
             enabled: true
@@ -584,7 +584,7 @@ central:
             ports:
               api:
                 name: http-api
-                externalPort: 3001
+                externalPort: 80
                 internalPort: 3001
           readinessProbe:
             enabled: true
@@ -721,7 +721,7 @@ central:
             ports:
               api:
                 name: http-api
-                externalPort: 3001
+                externalPort: 80
                 internalPort: 3001
           readinessProbe:
             enabled: true
@@ -858,7 +858,7 @@ central:
             ports:
               api:
                 name: http-api
-                externalPort: 3001
+                externalPort: 80
                 internalPort: 3001
           readinessProbe:
             enabled: true
@@ -2571,9 +2571,8 @@ ml-api-adapter:
             rejectUnauthorized: true
 
       service:
-        name: ml-api-adapter
         type: ClusterIP
-        externalPort: 8088
+        externalPort: 80
         internalPort: 8088
 
       ingress:
@@ -2642,9 +2641,8 @@ ml-api-adapter:
             rejectUnauthorized: true
 
       service:
-        name: ml-api-adapter
         type: ClusterIP
-        externalPort: 8088
+        externalPort: 80
         internalPort: 8088
 
       ingress:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2793,7 +2793,7 @@ account-lookup-service:
       api:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v6.2.3-snapshot
+          tag: v6.2.4-snapshot
           pullPolicy: IfNotPresent
           command: '["node", "src/index.js", "server", "--api"]'
         service:
@@ -2804,7 +2804,7 @@ account-lookup-service:
       admin:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v6.2.3-snapshot
+          tag: v6.2.4-snapshot
           pullPolicy: IfNotPresent
           command: '["node", "src/index.js", "server", "--admin"]'
         service:
@@ -2904,7 +2904,7 @@ account-lookup-service:
       api:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v6.2.3-snapshot
+          tag: v6.2.4-snapshot
           pullPolicy: IfNotPresent
           command: '["node", "src/index.js", "server", "--api"]'
         service:
@@ -2915,7 +2915,7 @@ account-lookup-service:
       admin:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v6.2.3-snapshot
+          tag: v6.2.4-snapshot
           pullPolicy: IfNotPresent
           command: '["node", "src/index.js", "server", "--admin"]'
         service:
@@ -3123,7 +3123,7 @@ quoting-service:
   replicaCount: 1
   image:
     repository: mojaloop/quoting-service
-    tag: v6.2.0-snapshot
+    tag: v6.2.1-snapshot
     pullPolicy: Always
 
   readinessProbe:

--- a/quoting-service/Chart.yaml
+++ b/quoting-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Quoting-Service Helm chart for Kubernetes
 name: quoting-service
-version: 6.2.0
-appVersion: "6.2.0"
+version: 6.2.1
+appVersion: "6.2.1-snapshot"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/quoting-service/values.yaml
+++ b/quoting-service/values.yaml
@@ -21,7 +21,7 @@ global:
 replicaCount: 1
 image:
   repository: mojaloop/quoting-service
-  tag: v6.2.0-snapshot
+  tag: v6.2.1-snapshot
   pullPolicy: Always
 
 readinessProbe:

--- a/quoting-service/values.yaml
+++ b/quoting-service/values.yaml
@@ -67,7 +67,7 @@ service:
   ports:
     api:
       name: http-api
-      externalPort: 3002
+      externalPort: 80
       internalPort: 3002
 
   annotations: {}

--- a/simulator/Chart.yaml
+++ b/simulator/Chart.yaml
@@ -1,4 +1,4 @@
 description: Simulators Helm Chart for Simultors
 name: simulator
-version: 6.2.6
-appVersion: "6.2.6"
+version: 6.3.0
+appVersion: "6.3.0"

--- a/simulator/Chart.yaml
+++ b/simulator/Chart.yaml
@@ -1,4 +1,4 @@
 description: Simulators Helm Chart for Simultors
 name: simulator
-version: 6.3.0
-appVersion: "6.3.0"
+version: 6.3.1
+appVersion: "6.3.1"

--- a/simulator/values.yaml
+++ b/simulator/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: mojaloop/simulator
-  tag: v6.3.0
+  tag: v6.3.1
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/simulator/values.yaml
+++ b/simulator/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: mojaloop/simulator
-  tag: v6.2.6
+  tag: v6.3.0
   pullPolicy: Always
 
 imagePullSecrets: []


### PR DESCRIPTION
Updates for the following releases:
- ml-api-adapter to v6.2.1 release
- central-ledger to v6.2.5 release 
- quoting-service to v6.2.1-snapshot
- account-lookup-service to v6.2.4-snapshot
- simulator to v6.3.0