### PR TITLE
Update ml-api-adapter helm chart to 7.1.1, add `ENDPOINT_HEALTH_URL` variable

### DIFF
--- a/ml-api-adapter/Chart.yaml
+++ b/ml-api-adapter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Helm chart for Kubernetes
 name: ml-api-adapter
-version: 7.0.0
-appVersion: "7.0.0"
+version: 7.1.0
+appVersion: "7.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/Chart.yaml
+++ b/ml-api-adapter/Chart.yaml
@@ -1,13 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Helm chart for Kubernetes
 name: ml-api-adapter
-<<<<<<< HEAD
 version: 7.1.1
 appVersion: "7.1.1"
-=======
-version: 7.1.0
-appVersion: "7.1.0"
->>>>>>> 5ee36891f3349d77ed4bb1accb0ea31de906eb5b
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/Chart.yaml
+++ b/ml-api-adapter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Helm chart for Kubernetes
 name: ml-api-adapter
-version: 7.1.0
-appVersion: "7.1.0"
+version: 7.1.1
+appVersion: "7.1.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/Chart.yaml
+++ b/ml-api-adapter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Helm chart for Kubernetes
 name: ml-api-adapter
-version: 6.2.1
-appVersion: "6.2.1"
+version: 7.0.0
+appVersion: "7.0.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-handler-notification/Chart.yaml
+++ b/ml-api-adapter/chart-handler-notification/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: ml-api-adapter-handler-notification
-version: 7.0.0
-appVersion: "7.0.0"
+version: 7.1.0
+appVersion: "7.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-handler-notification/Chart.yaml
+++ b/ml-api-adapter/chart-handler-notification/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: ml-api-adapter-handler-notification
-version: 7.1.0
-appVersion: "7.1.0"
+version: 7.1.1
+appVersion: "7.1.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-handler-notification/Chart.yaml
+++ b/ml-api-adapter/chart-handler-notification/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: ml-api-adapter-handler-notification
-version: 6.2.1
-appVersion: "6.2.1"
+version: 7.0.0
+appVersion: "7.0.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-handler-notification/configs/default.json
+++ b/ml-api-adapter/chart-handler-notification/configs/default.json
@@ -3,6 +3,7 @@
 {
     "PORT": {{ .Values.service.internalPort }},
     "ENDPOINT_SOURCE_URL": "http://{{ $centralServicesHost }}:{{ .Values.config.central_services_port }}/participants/{{"{{"}}fsp{{"}}"}}/endpoints",
+    "ENDPOINT_HEALTH_URL": "http://{{ $centralServicesHost }}:{{ .Values.config.central_services_port }}/health",
     "ENDPOINT_CACHE_CONFIG": {
         "expiresIn": 180000,
         "generateTimeout": 30000

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v7.1.0
+  tag: v7.1.1
   command: '["node", "src/handlers/index.js", "handler", "--notification"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v6.2.1
+  tag: v7.0.0
   command: '["node", "src/handlers/index.js", "handler", "--notification"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -4,11 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-<<<<<<< HEAD
   tag: v7.1.1
-=======
-  tag: v7.1.0
->>>>>>> 5ee36891f3349d77ed4bb1accb0ea31de906eb5b
   command: '["node", "src/handlers/index.js", "handler", "--notification"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v7.0.0
+  tag: v7.1.0
   command: '["node", "src/handlers/index.js", "handler", "--notification"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/chart-service/Chart.yaml
+++ b/ml-api-adapter/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter API component Helm chart for Kubernetes
 name: ml-api-adapter-service
-version: 6.2.1
-appVersion: "6.2.1"
+version: 7.0.0
+appVersion: "7.0.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-service/Chart.yaml
+++ b/ml-api-adapter/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter API component Helm chart for Kubernetes
 name: ml-api-adapter-service
-version: 7.0.0
-appVersion: "7.0.0"
+version: 7.1.0
+appVersion: "7.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-service/Chart.yaml
+++ b/ml-api-adapter/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter API component Helm chart for Kubernetes
 name: ml-api-adapter-service
-version: 7.1.0
-appVersion: "7.1.0"
+version: 7.1.1
+appVersion: "7.1.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-service/configs/default.json
+++ b/ml-api-adapter/chart-service/configs/default.json
@@ -3,6 +3,7 @@
 {
     "PORT": {{ .Values.service.internalPort }},
     "ENDPOINT_SOURCE_URL": "http://{{ $centralServicesHost }}:{{ .Values.config.central_services_port }}/participants/{{"{{"}}fsp{{"}}"}}/endpoints",
+    "ENDPOINT_HEALTH_URL": "http://{{ $centralServicesHost }}:{{ .Values.config.central_services_port }}/health",
     "ENDPOINT_CACHE_CONFIG": {
         "expiresIn": 180000,
         "generateTimeout": 30000

--- a/ml-api-adapter/chart-service/values.yaml
+++ b/ml-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v7.0.0
+  tag: v7.1.0
   command: '["node", "src/api/index.js"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/chart-service/values.yaml
+++ b/ml-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v7.1.0
+  tag: v7.1.1
   command: '["node", "src/api/index.js"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/chart-service/values.yaml
+++ b/ml-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v6.2.1
+  tag: v7.0.0
   command: '["node", "src/api/index.js"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/requirements.yaml
+++ b/ml-api-adapter/requirements.yaml
@@ -1,19 +1,11 @@
 # requirements.yaml
 dependencies:
 - name: ml-api-adapter-service
-<<<<<<< HEAD
   version: 7.1.1
   repository: "file://./chart-service"
   condition: ml-api-adapter-service.enabled
 - name: ml-api-adapter-handler-notification
   version: 7.1.1
-=======
-  version: 7.1.0
-  repository: "file://./chart-service"
-  condition: ml-api-adapter-service.enabled
-- name: ml-api-adapter-handler-notification
-  version: 7.1.0
->>>>>>> 5ee36891f3349d77ed4bb1accb0ea31de906eb5b
   repository: "file://./chart-handler-notification"
   condition: ml-api-adapter-handler-notification.enabled
 ## This is used for testing ml-api-adapter deployments

--- a/ml-api-adapter/requirements.yaml
+++ b/ml-api-adapter/requirements.yaml
@@ -1,11 +1,11 @@
 # requirements.yaml
 dependencies:
 - name: ml-api-adapter-service
-  version: 6.2.1
+  version: 7.0.0
   repository: "file://./chart-service"
   condition: ml-api-adapter-service.enabled
 - name: ml-api-adapter-handler-notification
-  version: 6.2.1
+  version: 7.0.0
   repository: "file://./chart-handler-notification"
   condition: ml-api-adapter-handler-notification.enabled
 ## This is used for testing ml-api-adapter deployments

--- a/ml-api-adapter/requirements.yaml
+++ b/ml-api-adapter/requirements.yaml
@@ -1,11 +1,11 @@
 # requirements.yaml
 dependencies:
 - name: ml-api-adapter-service
-  version: 7.0.0
+  version: 7.1.0
   repository: "file://./chart-service"
   condition: ml-api-adapter-service.enabled
 - name: ml-api-adapter-handler-notification
-  version: 7.0.0
+  version: 7.1.0
   repository: "file://./chart-handler-notification"
   condition: ml-api-adapter-handler-notification.enabled
 ## This is used for testing ml-api-adapter deployments

--- a/ml-api-adapter/requirements.yaml
+++ b/ml-api-adapter/requirements.yaml
@@ -1,11 +1,11 @@
 # requirements.yaml
 dependencies:
 - name: ml-api-adapter-service
-  version: 7.1.0
+  version: 7.1.1
   repository: "file://./chart-service"
   condition: ml-api-adapter-service.enabled
 - name: ml-api-adapter-handler-notification
-  version: 7.1.0
+  version: 7.1.1
   repository: "file://./chart-handler-notification"
   condition: ml-api-adapter-handler-notification.enabled
 ## This is used for testing ml-api-adapter deployments

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -26,7 +26,7 @@ ml-api-adapter-service:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v7.0.0
+    tag: v7.1.0
     command: '["node", "src/api/index.js"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -107,7 +107,7 @@ ml-api-adapter-handler-notification:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v7.0.0
+    tag: v7.1.0
     command: '["node", "src/handlers/index.js", "handler", "--notification"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -26,11 +26,7 @@ ml-api-adapter-service:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-<<<<<<< HEAD
     tag: v7.1.1
-=======
-    tag: v7.1.0
->>>>>>> 5ee36891f3349d77ed4bb1accb0ea31de906eb5b
     command: '["node", "src/api/index.js"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -111,11 +107,7 @@ ml-api-adapter-handler-notification:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-<<<<<<< HEAD
     tag: v7.1.1
-=======
-    tag: v7.1.0
->>>>>>> 5ee36891f3349d77ed4bb1accb0ea31de906eb5b
     command: '["node", "src/handlers/index.js", "handler", "--notification"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -26,7 +26,7 @@ ml-api-adapter-service:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v6.2.1
+    tag: v7.0.0
     command: '["node", "src/api/index.js"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -107,7 +107,7 @@ ml-api-adapter-handler-notification:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v6.2.1
+    tag: v7.0.0
     command: '["node", "src/handlers/index.js", "handler", "--notification"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -26,7 +26,7 @@ ml-api-adapter-service:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v7.1.0
+    tag: v7.1.1
     command: '["node", "src/api/index.js"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -107,7 +107,7 @@ ml-api-adapter-handler-notification:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v7.1.0
+    tag: v7.1.1
     command: '["node", "src/handlers/index.js", "handler", "--notification"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
 #  repository: "file://../interop-switch"
 #  condition: interop-switch.enabled
 - name: ml-api-adapter
-  version: 6.2.1
+  version: 7.0.0
   repository: "file://../ml-api-adapter"
   condition: ml-api-adapter.enabled
 - name: emailnotifier

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
 #  repository: "file://../interop-switch"
 #  condition: interop-switch.enabled
 - name: ml-api-adapter
-  version: 7.1.0
+  version: 7.1.1
   repository: "file://../ml-api-adapter"
   condition: ml-api-adapter.enabled
 - name: emailnotifier

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -10,11 +10,7 @@ dependencies:
 #  repository: "file://../interop-switch"
 #  condition: interop-switch.enabled
 - name: ml-api-adapter
-<<<<<<< HEAD
   version: 7.1.1
-=======
-  version: 7.1.0
->>>>>>> 5ee36891f3349d77ed4bb1accb0ea31de906eb5b
   repository: "file://../ml-api-adapter"
   condition: ml-api-adapter.enabled
 - name: emailnotifier

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
 #  repository: "file://../interop-switch"
 #  condition: interop-switch.enabled
 - name: ml-api-adapter
-  version: 7.0.0
+  version: 7.1.0
   repository: "file://../ml-api-adapter"
   condition: ml-api-adapter.enabled
 - name: emailnotifier

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2545,11 +2545,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-<<<<<<< HEAD
       tag: v7.1.1
-=======
-      tag: v7.1.0
->>>>>>> 5ee36891f3349d77ed4bb1accb0ea31de906eb5b
       command: '["node", "src/api/index.js"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2545,7 +2545,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v7.1.0
+      tag: v7.1.1
       command: '["node", "src/api/index.js"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -2611,7 +2611,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v7.1.0
+      tag: v7.1.1
       command: '["node", "src/handlers/index.js", "handler", "--notification"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2545,7 +2545,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v7.0.0
+      tag: v7.1.0
       command: '["node", "src/api/index.js"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -2611,7 +2611,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v7.0.0
+      tag: v7.1.0
       command: '["node", "src/handlers/index.js", "handler", "--notification"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2611,11 +2611,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-<<<<<<< HEAD
       tag: v7.1.1
-=======
-      tag: v7.1.0
->>>>>>> 5ee36891f3349d77ed4bb1accb0ea31de906eb5b
       command: '["node", "src/handlers/index.js", "handler", "--notification"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2545,7 +2545,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v6.2.1
+      tag: v7.0.0
       command: '["node", "src/api/index.js"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -2611,7 +2611,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v6.2.1
+      tag: v7.0.0
       command: '["node", "src/handlers/index.js", "handler", "--notification"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
__DON'T MERGE__ - wait for https://github.com/mojaloop/ml-api-adapter/pull/124

- Add a new ENDPOINT_HEALTH_URL variable to enable the new health checks in the ml-api-adapter
- increment the ml-api-adapter helm charts to 7.0.0
- use the upcoming `mojaloop/ml-api-adapter:7.0.0` docker image