### PR TITLE
v7.1.0 Release

### DIFF
--- a/bulk-api-adapter/Chart.yaml
+++ b/bulk-api-adapter/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+description: bulk-api-adapter Helm chart for Kubernetes
+name: bulk-api-adapter
+version: 7.1.0
+appVersion: "7.1.1-snapshot"
+home: http://mojaloop.io
+icon: http://mojaloop.io/images/logo.png
+sources:
+  - https://github.com/mojaloop/mojaloop
+  - https://github.com/mojaloop/helm
+  - https://github.com/mojaloop/bulk-api-adapter
+maintainers:
+  - name: Miguel de Barros
+    email: miguel.debarros@modusbox.com
+

--- a/bulk-api-adapter/chart-handler-notification/Chart.yaml
+++ b/bulk-api-adapter/chart-handler-notification/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+description: bulk-api-adapter Handler for Notifications component Helm chart for Kubernetes
+name: bulk-api-adapter-handler-notification
+version: 7.1.0
+appVersion: "7.1.1-snapshot"
+home: http://mojaloop.io
+icon: http://mojaloop.io/images/logo.png
+sources:
+  - https://github.com/mojaloop/mojaloop
+  - https://github.com/mojaloop/helm
+  - https://github.com/mojaloop/bulk-api-adapter
+maintainers:
+  - name: Miguel de Barros
+    email: miguel.debarros@modusbox.com

--- a/bulk-api-adapter/chart-handler-notification/configs/default.json
+++ b/bulk-api-adapter/chart-handler-notification/configs/default.json
@@ -44,7 +44,7 @@
   "KAFKA": {
     "TOPIC_TEMPLATES": {
       "GENERAL_TOPIC_TEMPLATE": {
-        "TEMPLATE": "topic-{{functionality}}-{{action}}",
+        "TEMPLATE": "topic-{{"{{"}}functionality{{"}}"}}-{{"{{"}}action{{"}}"}}",
         "REGEX": "topic-(.*)-(.*)"
       },
       "NOTIFICATION_TOPIC_TEMPLATE": {

--- a/bulk-api-adapter/chart-handler-notification/configs/default.json
+++ b/bulk-api-adapter/chart-handler-notification/configs/default.json
@@ -1,0 +1,123 @@
+{{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+{{- $centralServicesHost := ( .Values.config.central_services_host | replace "$release_name" .Release.Name ) -}}
+{{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
+{
+  "PORT": {{ .Values.service.internalPort }},
+  "ENDPOINT_SOURCE_URL": "http://{{ $centralServicesHost }}:{{ .Values.config.central_services_port }}/participants/{{"{{"}}fsp{{"}}"}}/endpoints",
+  "ENDPOINT_CACHE_CONFIG": {
+    "expiresIn": 180000,
+    "generateTimeout": 30000
+  },
+  "MONGODB": {
+    "URI": {{ (default .Values.config.objstore_uri $objStoreUri) | quote }}
+  },
+  "ENDPOINT_SECURITY": {
+    "TLS": {
+      "rejectUnauthorized": {{ .Values.config.security.callback.rejectUnauthorized }}
+    }
+  },
+  "MAX_FULFIL_TIMEOUT_DURATION_SECONDS": 300,
+  "AMOUNT": {
+    "PRECISION": 10,
+    "SCALE": 2
+  },
+  "HANDLERS": {
+    "DISABLED": false,
+    "API": {
+      "DISABLED": false
+    }
+  },
+  "INSTRUMENTATION": {
+    "METRICS": {
+      "DISABLED": {{ not .Values.metrics.enabled }},
+      "config": {
+        "timeout": {{ .Values.metrics.config.timeout }},
+        "prefix": {{ .Values.metrics.config.prefix | quote }},
+        "defaultLabels": {
+          {{- range $key, $value := .Values.metrics.config.defaultLabels }}
+          {{ $key | quote }}: {{ $value | quote }}
+          {{- end }}
+        }
+      }
+    }
+  },
+  "KAFKA": {
+    "TOPIC_TEMPLATES": {
+      "GENERAL_TOPIC_TEMPLATE": {
+        "TEMPLATE": "topic-{{functionality}}-{{action}}",
+        "REGEX": "topic-(.*)-(.*)"
+      },
+      "NOTIFICATION_TOPIC_TEMPLATE": {
+        "TEMPLATE": "topic-notification-event",
+        "REGEX": "topic-notification-event"
+      }
+    },
+    "CONSUMER": {
+      "NOTIFICATION": {
+        "EVENT": {
+          "config": {
+            "options": {
+              "mode": 2,
+              "batchSize": 1,
+              "pollFrequency": 10,
+              "recursiveTimeout": 100,
+              "messageCharset": "utf8",
+              "messageAsJSON": true,
+              "sync": true,
+              "consumeTimeout": 1000
+            },
+            "rdkafkaConf": {
+              "client.id": "bulk-con-notification-event",
+              "group.id": "bulk-group-notification-event",
+              "metadata.broker.list": "{{ $kafkaHost }}:{{ .Values.config.kafka_port }}",
+              "socket.keepalive.enable": true
+            },
+            "topicConf": {
+              "auto.offset.reset": "earliest"
+            }
+          }
+        }
+      }
+    },
+    "PRODUCER": {
+      "BULK": {
+        "PREPARE": {
+          "config": {
+            "options": {
+              "messageCharset": "utf8"
+            },
+            "rdkafkaConf": {
+              "metadata.broker.list": "{{ $kafkaHost }}:{{ .Values.config.kafka_port }}",
+              "client.id": "bulk-prod-bulk-prepare",
+              "event_cb": true,
+              "dr_cb": true,
+              "socket.keepalive.enable": true,
+              "queue.buffering.max.messages": 10000000
+            },
+            "topicConf": {  
+              "request.required.acks": "all"
+            }
+          }
+        },
+        "FULFIL": {
+          "config": {
+            "options": {
+              "messageCharset": "utf8"
+            },
+            "rdkafkaConf": {
+              "metadata.broker.list": "{{ $kafkaHost }}:{{ .Values.config.kafka_port }}",
+              "client.id": "bulk-prod-bulk-fulfil",
+              "event_cb": true,
+              "dr_cb": true,
+              "socket.keepalive.enable": true,
+              "queue.buffering.max.messages": 10000000
+            },
+            "topicConf": {  
+              "request.required.acks": "all"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/bulk-api-adapter/chart-handler-notification/configs/default.json
+++ b/bulk-api-adapter/chart-handler-notification/configs/default.json
@@ -3,6 +3,7 @@
 {{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
 {
   "PORT": {{ .Values.service.internalPort }},
+  "HOSTNAME": "{{ .Values.ingress.hosts.api }}",
   "ENDPOINT_SOURCE_URL": "http://{{ $centralServicesHost }}:{{ .Values.config.central_services_port }}/participants/{{"{{"}}fsp{{"}}"}}/endpoints",
   "ENDPOINT_CACHE_CONFIG": {
     "expiresIn": 180000,

--- a/bulk-api-adapter/chart-handler-notification/templates/NOTES.txt
+++ b/bulk-api-adapter/chart-handler-notification/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http://{{ . }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "bulk-api-adapter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "bulk-api-adapter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "bulk-api-adapter.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "bulk-api-adapter.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.internalPort }}
+{{- end }}

--- a/bulk-api-adapter/chart-handler-notification/templates/_helpers.tpl
+++ b/bulk-api-adapter/chart-handler-notification/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bulk-api-adapter-handler-notification.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "bulk-api-adapter-handler-notification.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/bulk-api-adapter/chart-handler-notification/templates/config.yaml
+++ b/bulk-api-adapter/chart-handler-notification/templates/config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "bulk-api-adapter-handler-notification.fullname" . }}
+  labels:
+      app: {{ template "bulk-api-adapter-handler-notification.fullname" . }}
+      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+data:
+  default.json: {{ (tpl (.Files.Get "configs/default.json") . ) | quote }}

--- a/bulk-api-adapter/chart-handler-notification/templates/deployment.yaml
+++ b/bulk-api-adapter/chart-handler-notification/templates/deployment.yaml
@@ -1,0 +1,81 @@
+{{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "bulk-api-adapter-handler-notification.fullname" . }}
+  labels:
+    app: {{ template "bulk-api-adapter-handler-notification.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "bulk-api-adapter-handler-notification.fullname" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+      {{- if .Values.metrics.enabled }}
+      annotations:
+        prometheus.io/port: "{{ .Values.service.internalPort }}"
+        prometheus.io/scrape: "true"
+      {{- end }}
+    spec:
+      {{- if .Values.init.enabled }}
+      initContainers:
+        - name: {{ .Values.init.image.name }}
+          image: {{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}
+          imagePullPolicy: {{ .Values.init.image.pullPolicy }}
+          command:
+            - sh
+            - "-c"
+            - {{ (.Values.init.image.command | replace "$kafka_host" $kafkaHost | replace "$kafka_port" (printf "%.0f" .Values.config.kafka_port) ) | quote }}
+          env:
+          {{- range $envItem := .Values.init.image.env }}
+            - name: {{ $envItem.name }}
+              value: {{ $envItem.value }}
+          {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.image.imagePullSecrets }}
+          imagePullSecrets:
+          {{ toYaml .Values.image.imagePullSecrets | indent 10 }}
+          {{- end }}
+          command: {{ .Values.image.command }}
+          ports:
+            - containerPort: {{ .Values.service.internalPort }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.httpGet.path }}
+              port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.httpGet.path }}
+              port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          {{- end }}
+          volumeMounts:
+            - name: {{ template "bulk-api-adapter-handler-notification.fullname" . }}-config-volume
+              mountPath: /opt/bulk-api-adapter/config
+          env:
+            - name: LOG_LEVEL
+              value: {{ .Values.config.log_level }}
+      volumes:
+        - name: {{ template "bulk-api-adapter-handler-notification.fullname" . }}-config-volume
+          configMap:
+            name: {{ template "bulk-api-adapter-handler-notification.fullname" . }}
+            items:
+            - key: default.json
+              path: default.json

--- a/bulk-api-adapter/chart-handler-notification/templates/deployment.yaml
+++ b/bulk-api-adapter/chart-handler-notification/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+{{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -26,6 +27,13 @@ spec:
     spec:
       {{- if .Values.init.enabled }}
       initContainers:
+        - name: {{ .Values.init.mongodb.name }}
+          image: {{ .Values.init.mongodb.repository }}:{{ .Values.init.mongodb.tag }}
+          imagePullPolicy: {{ .Values.init.mongodb.pullPolicy }}
+          command:
+            - sh
+            - "-c"
+            - {{ (.Values.init.mongodb.command | replace "$mongouri" $objStoreUri | quote }}
         - name: {{ .Values.init.image.name }}
           image: {{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}
           imagePullPolicy: {{ .Values.init.image.pullPolicy }}

--- a/bulk-api-adapter/chart-handler-notification/templates/deployment.yaml
+++ b/bulk-api-adapter/chart-handler-notification/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           command:
             - sh
             - "-c"
-            - {{ (.Values.init.mongodb.command | replace "$mongouri" $objStoreUri | quote }}
+            - {{ (.Values.init.mongodb.command | replace "$mongouri" $objStoreUri) | quote }}
         - name: {{ .Values.init.image.name }}
           image: {{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}
           imagePullPolicy: {{ .Values.init.image.pullPolicy }}

--- a/bulk-api-adapter/chart-handler-notification/templates/ingress.yaml
+++ b/bulk-api-adapter/chart-handler-notification/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "bulk-api-adapter-handler-notification.fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+{{- $servicePath := .Values.ingress.externalPath -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "bulk-api-adapter-handler-notification.fullname" . }}
+  labels:
+    app: {{ template "bulk-api-adapter-handler-notification.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: {{ $servicePath }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/bulk-api-adapter/chart-handler-notification/templates/service.yaml
+++ b/bulk-api-adapter/chart-handler-notification/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "bulk-api-adapter-handler-notification.fullname" . }}
+  labels:
+    app: {{ template "bulk-api-adapter-handler-notification.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      targetPort: {{ .Values.service.internalPort }}
+      protocol: TCP
+      name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "bulk-api-adapter-handler-notification.fullname" . }}
+    release: {{ .Release.Name }}

--- a/bulk-api-adapter/chart-handler-notification/values.yaml
+++ b/bulk-api-adapter/chart-handler-notification/values.yaml
@@ -1,0 +1,101 @@
+# Default values for bulk-api-adapter-handler-notification.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+image:
+  repository: mojaloop/bulk-api-adapter
+  tag: v7.1.1-snapshot
+  command: '["node", "src/handlers/index.js", "handler", "--notification"]'
+## Optionally specify an array of imagePullSecrets.
+## Secrets must be manually created in the namespace.
+## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+##
+#  imagePullSecrets:
+#    - name: myregistrykey
+  pullPolicy: Always
+
+init:
+  enabled: true
+  image:
+    name: wait-for-kafka
+    repository: solsson/kafka
+    tag: latest
+    pullPolicy: Always
+    command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
+    env: {}
+    ## Env example
+    # env:
+    #   envItem1:
+    #     name: hello
+    #     value: world
+    #
+
+readinessProbe:
+  enabled: true
+  httpGet:
+    path: /health
+  initialDelaySeconds: 120
+  periodSeconds: 15
+livenessProbe:
+  enabled: true
+  httpGet:
+    path: /health
+  initialDelaySeconds: 90
+  periodSeconds: 15
+
+## metric configuration for prometheus instrumentation
+metrics:
+  ## flag to enable/disable the metrics end-points
+  enabled: true
+  config:
+    timeout: 5000
+    prefix: moja_
+    defaultLabels:
+      serviceName: bulk-handler-notification
+
+config:
+  # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+  kafka_host: '$release_name-kafka'
+  kafka_port: 9092
+  central_services_host: '$release_name-centralledger-service'
+  central_services_port: 80
+  security:
+    callback:
+      rejectUnauthorized: true
+  log_level: 'info'
+
+  ## MongoDB Configuration for Object Store
+  objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
+
+service:
+  type: ClusterIP
+  externalPort: 80
+  internalPort: 8088
+
+ingress:
+  enabled: true
+  externalPath: /
+  # Used to create an Ingress record.
+  hosts:
+    api: bulk-api-adapter-notification.local
+
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: '/'
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi

--- a/bulk-api-adapter/chart-handler-notification/values.yaml
+++ b/bulk-api-adapter/chart-handler-notification/values.yaml
@@ -29,6 +29,12 @@ init:
     #     name: hello
     #     value: world
     #
+  mongodb:
+    name: wait-for-mongodb
+    repository: bitnami/mongodb
+    tag: latest
+    pullPolicy: Always
+    command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
 
 readinessProbe:
   enabled: true

--- a/bulk-api-adapter/chart-service/Chart.yaml
+++ b/bulk-api-adapter/chart-service/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+description: bulk-api-adapter API component Helm chart for Kubernetes
+name: bulk-api-adapter-service
+version: 7.1.0
+appVersion: "7.1.1-snapshot"
+home: http://mojaloop.io
+icon: http://mojaloop.io/images/logo.png
+sources:
+  - https://github.com/mojaloop/mojaloop
+  - https://github.com/mojaloop/helm
+  - https://github.com/mojaloop/bulk-api-adapter
+maintainers:
+  - name: Miguel de Barros
+    email: miguel.debarros@modusbox.com

--- a/bulk-api-adapter/chart-service/configs/default.json
+++ b/bulk-api-adapter/chart-service/configs/default.json
@@ -44,7 +44,7 @@
   "KAFKA": {
     "TOPIC_TEMPLATES": {
       "GENERAL_TOPIC_TEMPLATE": {
-        "TEMPLATE": "topic-{{functionality}}-{{action}}",
+        "TEMPLATE": "topic-{{"{{"}}functionality{{"}}"}}-{{"{{"}}action{{"}}"}}",
         "REGEX": "topic-(.*)-(.*)"
       },
       "NOTIFICATION_TOPIC_TEMPLATE": {

--- a/bulk-api-adapter/chart-service/configs/default.json
+++ b/bulk-api-adapter/chart-service/configs/default.json
@@ -1,0 +1,123 @@
+{{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+{{- $centralServicesHost := ( .Values.config.central_services_host | replace "$release_name" .Release.Name ) -}}
+{{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
+{
+  "PORT": {{ .Values.service.internalPort }},
+  "ENDPOINT_SOURCE_URL": "http://{{ $centralServicesHost }}:{{ .Values.config.central_services_port }}/participants/{{"{{"}}fsp{{"}}"}}/endpoints",
+  "ENDPOINT_CACHE_CONFIG": {
+    "expiresIn": 180000,
+    "generateTimeout": 30000
+  },
+  "MONGODB": {
+    "URI": {{ (default .Values.config.objstore_uri $objStoreUri) | quote }}
+  },
+  "ENDPOINT_SECURITY": {
+    "TLS": {
+      "rejectUnauthorized": {{ .Values.config.security.callback.rejectUnauthorized }}
+    }
+  },
+  "MAX_FULFIL_TIMEOUT_DURATION_SECONDS": 300,
+  "AMOUNT": {
+    "PRECISION": 10,
+    "SCALE": 2
+  },
+  "HANDLERS": {
+    "DISABLED": true,
+    "API": {
+      "DISABLED": false
+    }
+  },
+  "INSTRUMENTATION": {
+    "METRICS": {
+      "DISABLED": {{ not .Values.metrics.enabled }},
+      "config": {
+        "timeout": {{ .Values.metrics.config.timeout }},
+        "prefix": {{ .Values.metrics.config.prefix | quote }},
+        "defaultLabels": {
+          {{- range $key, $value := .Values.metrics.config.defaultLabels }}
+          {{ $key | quote }}: {{ $value | quote }}
+          {{- end }}
+        }
+      }
+    }
+  },
+  "KAFKA": {
+    "TOPIC_TEMPLATES": {
+      "GENERAL_TOPIC_TEMPLATE": {
+        "TEMPLATE": "topic-{{functionality}}-{{action}}",
+        "REGEX": "topic-(.*)-(.*)"
+      },
+      "NOTIFICATION_TOPIC_TEMPLATE": {
+        "TEMPLATE": "topic-notification-event",
+        "REGEX": "topic-notification-event"
+      }
+    },
+    "CONSUMER": {
+      "NOTIFICATION": {
+        "EVENT": {
+          "config": {
+            "options": {
+              "mode": 2,
+              "batchSize": 1,
+              "pollFrequency": 10,
+              "recursiveTimeout": 100,
+              "messageCharset": "utf8",
+              "messageAsJSON": true,
+              "sync": true,
+              "consumeTimeout": 1000
+            },
+            "rdkafkaConf": {
+              "client.id": "bulk-con-notification-event",
+              "group.id": "bulk-group-notification-event",
+              "metadata.broker.list": "{{ $kafkaHost }}:{{ .Values.config.kafka_port }}",
+              "socket.keepalive.enable": true
+            },
+            "topicConf": {
+              "auto.offset.reset": "earliest"
+            }
+          }
+        }
+      }
+    },
+    "PRODUCER": {
+      "BULK": {
+        "PREPARE": {
+          "config": {
+            "options": {
+              "messageCharset": "utf8"
+            },
+            "rdkafkaConf": {
+              "metadata.broker.list": "{{ $kafkaHost }}:{{ .Values.config.kafka_port }}",
+              "client.id": "bulk-prod-bulk-prepare",
+              "event_cb": true,
+              "dr_cb": true,
+              "socket.keepalive.enable": true,
+              "queue.buffering.max.messages": 10000000
+            },
+            "topicConf": {  
+              "request.required.acks": "all"
+            }
+          }
+        },
+        "FULFIL": {
+          "config": {
+            "options": {
+              "messageCharset": "utf8"
+            },
+            "rdkafkaConf": {
+              "metadata.broker.list": "{{ $kafkaHost }}:{{ .Values.config.kafka_port }}",
+              "client.id": "bulk-prod-bulk-fulfil",
+              "event_cb": true,
+              "dr_cb": true,
+              "socket.keepalive.enable": true,
+              "queue.buffering.max.messages": 10000000
+            },
+            "topicConf": {  
+              "request.required.acks": "all"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/bulk-api-adapter/chart-service/configs/default.json
+++ b/bulk-api-adapter/chart-service/configs/default.json
@@ -3,6 +3,7 @@
 {{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
 {
   "PORT": {{ .Values.service.internalPort }},
+  "HOSTNAME": "{{ .Values.ingress.hosts.api }}",
   "ENDPOINT_SOURCE_URL": "http://{{ $centralServicesHost }}:{{ .Values.config.central_services_port }}/participants/{{"{{"}}fsp{{"}}"}}/endpoints",
   "ENDPOINT_CACHE_CONFIG": {
     "expiresIn": 180000,

--- a/bulk-api-adapter/chart-service/templates/NOTES.txt
+++ b/bulk-api-adapter/chart-service/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http://{{ . }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "ml-api-adapter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "ml-api-adapter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "ml-api-adapter.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "ml-api-adapter.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.internalPort }}
+{{- end }}

--- a/bulk-api-adapter/chart-service/templates/_helpers.tpl
+++ b/bulk-api-adapter/chart-service/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bulk-api-adapter-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "bulk-api-adapter-service.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/bulk-api-adapter/chart-service/templates/config.yaml
+++ b/bulk-api-adapter/chart-service/templates/config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "bulk-api-adapter-service.fullname" . }}
+  labels:
+      app: {{ template "bulk-api-adapter-service.fullname" . }}
+      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+data:
+  default.json: {{ (tpl (.Files.Get "configs/default.json") . ) | quote }}

--- a/bulk-api-adapter/chart-service/templates/deployment.yaml
+++ b/bulk-api-adapter/chart-service/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "bulk-api-adapter-service.fullname" . }}
+  labels:
+    app: {{ template "bulk-api-adapter-service.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "bulk-api-adapter-service.fullname" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+      {{- if .Values.metrics.enabled }}
+      annotations:
+        prometheus.io/port: "{{ .Values.service.internalPort }}"
+        prometheus.io/scrape: "true"
+      {{- end }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.image.imagePullSecrets }}
+          imagePullSecrets:
+          {{ toYaml .Values.image.imagePullSecrets | indent 10 }}
+          {{- end }}
+          command: {{ .Values.image.command }}
+          ports:
+            - containerPort: {{ .Values.service.internalPort }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.httpGet.path }}
+              port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.httpGet.path }}
+              port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          {{- end }}
+          volumeMounts:
+            - name: {{ template "bulk-api-adapter-service.fullname" . }}-config-volume
+              mountPath: /opt/bulk-api-adapter/config
+          env:
+            - name: LOG_LEVEL
+              value: {{ .Values.config.log_level }}
+      volumes:
+        - name: {{ template "bulk-api-adapter-service.fullname" . }}-config-volume
+          configMap:
+            name: {{ template "bulk-api-adapter-service.fullname" . }}
+            items:
+            - key: default.json
+              path: default.json

--- a/bulk-api-adapter/chart-service/templates/deployment.yaml
+++ b/bulk-api-adapter/chart-service/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+{{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -22,6 +24,28 @@ spec:
         prometheus.io/scrape: "true"
       {{- end }}
     spec:
+      {{- if .Values.init.enabled }}
+      initContainers:
+        - name: {{ .Values.init.mongodb.name }}
+          image: {{ .Values.init.mongodb.repository }}:{{ .Values.init.mongodb.tag }}
+          imagePullPolicy: {{ .Values.init.mongodb.pullPolicy }}
+          command:
+            - sh
+            - "-c"
+            - {{ (.Values.init.mongodb.command | replace "$mongouri" $objStoreUri | quote }}
+        - name: {{ .Values.init.image.name }}
+          image: {{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}
+          imagePullPolicy: {{ .Values.init.image.pullPolicy }}
+          command:
+            - sh
+            - "-c"
+            - {{ (.Values.init.image.command | replace "$kafka_host" $kafkaHost | replace "$kafka_port" (printf "%.0f" .Values.config.kafka_port) ) | quote }}
+          env:
+          {{- range $envItem := .Values.init.image.env }}
+          - name: {{ $envItem.name }}
+            value: {{ $envItem.value }}
+          {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/bulk-api-adapter/chart-service/templates/deployment.yaml
+++ b/bulk-api-adapter/chart-service/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           command:
             - sh
             - "-c"
-            - {{ (.Values.init.mongodb.command | replace "$mongouri" $objStoreUri | quote }}
+            - {{ (.Values.init.mongodb.command | replace "$mongouri" $objStoreUri) | quote }}
         - name: {{ .Values.init.image.name }}
           image: {{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}
           imagePullPolicy: {{ .Values.init.image.pullPolicy }}

--- a/bulk-api-adapter/chart-service/templates/ingress.yaml
+++ b/bulk-api-adapter/chart-service/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "bulk-api-adapter-service.fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+{{- $servicePath := .Values.ingress.externalPath -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "bulk-api-adapter-service.fullname" . }}
+  labels:
+    app: {{ template "bulk-api-adapter-service.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: {{ $servicePath }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/bulk-api-adapter/chart-service/templates/service.yaml
+++ b/bulk-api-adapter/chart-service/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "bulk-api-adapter-service.fullname" . }}
+  labels:
+    app: {{ template "bulk-api-adapter-service.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      targetPort: {{ .Values.service.internalPort }}
+      protocol: TCP
+      name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "bulk-api-adapter-service.fullname" . }}
+    release: {{ .Release.Name }}

--- a/bulk-api-adapter/chart-service/values.yaml
+++ b/bulk-api-adapter/chart-service/values.yaml
@@ -14,6 +14,28 @@ image:
 #    - name: myregistrykey
   pullPolicy: Always
 
+init:
+  enabled: true
+  image:
+    name: wait-for-kafka
+    repository: solsson/kafka
+    tag: latest
+    pullPolicy: Always
+    command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
+    env: {}
+    ## Env example
+    # env:
+    #   envItem1:
+    #     name: hello
+    #     value: world
+    #
+  mongodb:
+    name: wait-for-mongodb
+    repository: bitnami/mongodb
+    tag: latest
+    pullPolicy: Always
+    command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+
 readinessProbe:
   enabled: true
   httpGet:

--- a/bulk-api-adapter/chart-service/values.yaml
+++ b/bulk-api-adapter/chart-service/values.yaml
@@ -1,0 +1,85 @@
+# Default values for bulk-api-adapter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+image:
+  repository: mojaloop/bulk-api-adapter
+  tag: v7.1.1-snapshot
+  command: '["node", "src/api/index.js"]'
+## Optionally specify an array of imagePullSecrets.
+## Secrets must be manually created in the namespace.
+## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+##
+#  imagePullSecrets:
+#    - name: myregistrykey
+  pullPolicy: Always
+
+readinessProbe:
+  enabled: true
+  httpGet:
+    path: /health
+  initialDelaySeconds: 120
+  periodSeconds: 15
+livenessProbe:
+  enabled: true
+  httpGet:
+    path: /health
+  initialDelaySeconds: 90
+  periodSeconds: 15
+
+## metric configuration for prometheus instrumentation
+metrics:
+  ## flag to enable/disable the metrics end-points
+  enabled: true
+  config:
+    timeout: 5000
+    prefix: moja_
+    defaultLabels:
+      serviceName: bulk-service
+
+config:
+  # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+  kafka_host: '$release_name-kafka'
+  kafka_port: 9092
+  central_services_host: '$release_name-centralledger-service'
+  central_services_port: 80
+  security:
+    callback:
+      rejectUnauthorized: true
+  log_level: 'info'
+
+  ## MongoDB Configuration for Object Store
+  objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
+
+service:
+  type: ClusterIP
+  externalPort: 80
+  internalPort: 8088
+
+ingress:
+  enabled: true
+  externalPath: /
+  # Used to create an Ingress record.
+  hosts:
+    api: bulk-api-adapter.local
+
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: '/'
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi

--- a/bulk-api-adapter/requirements.yaml
+++ b/bulk-api-adapter/requirements.yaml
@@ -1,0 +1,10 @@
+# requirements.yaml
+dependencies:
+- name: bulk-api-adapter
+  version: 7.1.0
+  repository: "file://./chart-service"
+  condition: bulk-api-adapter.enabled
+- name: bulk-api-adapter-handler-notification
+  version: 7.1.0
+  repository: "file://./chart-handler-notification"
+  condition: bulk-api-adapter-handler-notification.enabled

--- a/bulk-api-adapter/values.yaml
+++ b/bulk-api-adapter/values.yaml
@@ -35,6 +35,28 @@ bulk-api-adapter-service:
     #    - name: myregistrykey
     pullPolicy: Always
 
+  init:
+    enabled: true
+    image:
+      name: wait-for-kafka
+      repository: solsson/kafka
+      tag: latest
+      pullPolicy: Always
+      command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
+      env: {}
+      ## Env example
+      # env:
+      #   envItem1:
+      #     name: hello
+      #     value: world
+      #
+    mongodb:
+      name: wait-for-mongodb
+      repository: bitnami/mongodb
+      tag: latest
+      pullPolicy: Always
+      command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+
   readinessProbe:
     enabled: true
     httpGet:
@@ -138,6 +160,12 @@ bulk-api-adapter-handler-notification:
       #     name: hello
       #     value: world
       #
+    mongodb:
+      name: wait-for-mongodb
+      repository: bitnami/mongodb
+      tag: latest
+      pullPolicy: Always
+      command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
 
   readinessProbe:
     enabled: true

--- a/bulk-api-adapter/values.yaml
+++ b/bulk-api-adapter/values.yaml
@@ -1,0 +1,210 @@
+# Default values for central.
+# This is a YAML-formatted file.
+# Declare global configurations
+global:
+  config:
+    ## Pod scheduling preferences.
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ##
+    affinity: {}
+
+    ## Node labels for pod assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+    nodeSelector: {}
+
+    ## Set toleration for schedular
+    ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    tolerations: []
+
+# Declare variables to be passed into your templates.
+bulk-api-adapter-service:
+  enabled: true
+  # Default values for bulk-api-adapter.
+  # This is a YAML-formatted file.
+  # Declare variables to be passed into your templates.
+  replicaCount: 1
+  image:
+    repository: mojaloop/bulk-api-adapter
+    tag: v7.1.1-snapshot
+    command: '["node", "src/api/index.js"]'
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    ##
+    #  imagePullSecrets:
+    #    - name: myregistrykey
+    pullPolicy: Always
+
+  readinessProbe:
+    enabled: true
+    httpGet:
+      path: /health
+    initialDelaySeconds: 120
+    periodSeconds: 15
+  livenessProbe:
+    enabled: true
+    httpGet:
+      path: /health
+    initialDelaySeconds: 90
+    periodSeconds: 15
+
+  ## metric configuration for prometheus instrumentation
+  metrics:
+    ## flag to enable/disable the metrics end-points
+    enabled: true
+    config:
+      timeout: 5000
+      prefix: moja_
+      defaultLabels:
+        serviceName: bulk-service
+
+  config:
+    # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+    kafka_host: '$release_name-kafka'
+    kafka_port: 9092
+    central_services_host: '$release_name-centralledger-service'
+    central_services_port: 80
+    security:
+      callback:
+        rejectUnauthorized: true
+    log_level: 'info'
+
+    ## MongoDB Configuration for Object Store
+    objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
+
+  service:
+    type: ClusterIP
+    externalPort: 80
+    internalPort: 8088
+
+  ingress:
+    enabled: true
+    externalPath: /
+    # Used to create an Ingress record.
+    hosts:
+      api: bulk-api-adapter.local
+
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: '/'
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+  #  memory: 128Mi
+
+bulk-api-adapter-handler-notification:
+  enabled: true
+  # Default values for bulk-api-adapter-handler-notification.
+  # This is a YAML-formatted file.
+  # Declare variables to be passed into your templates.
+  replicaCount: 1
+  image:
+    repository: mojaloop/bulk-api-adapter
+    tag: v7.1.1-snapshot
+    command: '["node", "src/handlers/index.js", "handler", "--notification"]'
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    ##
+    #  imagePullSecrets:
+    #    - name: myregistrykey
+    pullPolicy: Always
+
+  init:
+    enabled: true
+    image:
+      name: wait-for-kafka
+      repository: solsson/kafka
+      tag: latest
+      pullPolicy: Always
+      command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
+      env: {}
+      ## Env example
+      # env:
+      #   envItem1:
+      #     name: hello
+      #     value: world
+      #
+
+  readinessProbe:
+    enabled: true
+    httpGet:
+      path: /health
+    initialDelaySeconds: 120
+    periodSeconds: 15
+  livenessProbe:
+    enabled: true
+    httpGet:
+      path: /health
+    initialDelaySeconds: 90
+    periodSeconds: 15
+
+  ## metric configuration for prometheus instrumentation
+  metrics:
+    ## flag to enable/disable the metrics end-points
+    enabled: true
+    config:
+      timeout: 5000
+      prefix: moja_
+      defaultLabels:
+        serviceName: bulk-handler-notification
+
+  config:
+    # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+    kafka_host: '$release_name-kafka'
+    kafka_port: 9092
+    central_services_host: '$release_name-centralledger-service'
+    central_services_port: 80
+    security:
+      callback:
+        rejectUnauthorized: true
+    log_level: 'info'
+
+    ## MongoDB Configuration for Object Store
+    objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
+
+  service:
+    type: ClusterIP
+    externalPort: 80
+    internalPort: 8088
+
+  ingress:
+    enabled: true
+    externalPath: /
+    # Used to create an Ingress record.
+    hosts:
+      api: bulk-api-adapter-notification.local
+
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: '/'
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+  #  memory: 128Mi

--- a/bulk-centralledger/Chart.yaml
+++ b/bulk-centralledger/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+description: Central-Ledger Bulk Services Helm chart for Kubernetes
+name: bulk-centralledger
+version: 7.1.0
+appVersion: "7.1.2"
+home: http://mojaloop.io
+icon: http://mojaloop.io/images/logo.png
+sources:
+  - https://github.com/mojaloop/mojaloop
+  - https://github.com/mojaloop/helm
+  - https://github.com/mojaloop/central-ledger
+maintainers:
+  - name: Miguel de Barros
+    email: miguel.debarros@modusbox.com

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+description: Central-Ledger Bulk Transfer Fulfil Handler Helm chart for Kubernetes
+name: centralledger-handler-bulk-transfer-fulfil
+version: 7.1.0
+appVersion: "7.1.2"
+home: http://mojaloop.io
+icon: http://mojaloop.io/images/logo.png
+sources:
+  - https://github.com/mojaloop/mojaloop
+  - https://github.com/mojaloop/helm
+  - https://github.com/mojaloop/central-ledger
+maintainers:
+  - name: Miguel de Barros
+    email: miguel.debarros@modusbox.com

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Central-Ledger Bulk Transfer Fulfil Handler Helm chart for Kubernetes
-name: centralledger-handler-bulk-transfer-fulfil
+name: cl-handler-bulk-transfer-fulfil
 version: 7.1.0
 appVersion: "7.1.2"
 home: http://mojaloop.io

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/configs/default.json
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/configs/default.json
@@ -1,0 +1,404 @@
+{{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+{{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
+{
+    "PORT": {{ .Values.containers.api.service.ports.api.internalPort }},
+    "HOSTNAME": "{{ .Values.ingress.hosts.api }}",
+    "RUN_MIGRATIONS": false,
+    "AMOUNT": {
+        "PRECISION": 10,
+        "SCALE": 2
+    },
+    "SIDECAR": {
+        "DISABLED": {{ .Values.config.forensicloggingsidecar_disabled }},
+        "HOST": "{{ printf "%s-%s" .Release.Name .Values.config.forensicloggingsidecar_host }}",
+        "PORT": {{ .Values.config.forensicloggingsidecar_port }},
+        "CONNECT_TIMEOUT": 45000,
+        "RECONNECT_INTERVAL": 5000
+    },
+    "DB_CONNECTION": {
+        "POOL_MIN": {{ .Values.config.db_connection_pool_min }},
+        "POOL_MAX": {{ .Values.config.db_connection_pool_max }}
+    },
+    "MONGODB": {
+        "DISABLED": {{ .Values.config.objstore_disabled }},
+        "URI": {{ (default .Values.config.objstore_uri $objStoreUri) | quote }}
+    },
+    "HANDLERS": {
+        "DISABLED": false,
+        "API": {
+            "DISABLED": false
+        },
+        "CRON": {
+            "DISABLED": true,
+            "TIMEXP": "*/10 * * * * *",
+            "TIMEZONE": "UTC"
+        },
+        "TIMEOUT": {
+            "DISABLED": true,
+            "TIMEXP": "*/15 * * * * *",
+            "TIMEZONE": "UTC"
+        }
+    },
+    "INSTRUMENTATION": {
+        "METRICS": {
+            "DISABLED": {{ not .Values.metrics.enabled }},
+            "labels": {
+                "fspId": "*"
+            },
+            "config": {
+                "timeout": {{ .Values.metrics.config.timeout }},
+                "prefix": {{ .Values.metrics.config.prefix | quote }},
+                "defaultLabels": {
+                {{- range $key, $value := .Values.metrics.config.defaultLabels }}
+                    {{ $key  | quote }}: {{ $value | quote }}
+                {{- end }}
+                }
+            }
+        }
+    },
+    "EMAIL_USER": "user",
+    "EMAIL_PASSWORD": "password",
+    "EMAIL_SMTP": "smtp.local",
+    "PARTICIPANT_INITIAL_POSITION": 0,
+    "HUB_PARTICIPANT": {
+        "ID": 1,
+        "NAME": "Hub",
+        "ACCOUNTS": [
+            "HUB_RECONCILIATION",
+            "HUB_MULTILATERAL_SETTLEMENT",
+            "HUB_FEE"
+        ]
+    },
+    "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+    "KAFKA": {
+        "TOPIC_TEMPLATES": {
+            "PARTICIPANT_TOPIC_TEMPLATE": {
+                "TEMPLATE": "topic-{{"{{"}}participantName{{"}}"}}-{{"{{"}}functionality{{"}}"}}-{{"{{"}}action{{"}}"}}",
+                "REGEX": "topic-(.*)-(.*)-(.*)"
+            },
+            "GENERAL_TOPIC_TEMPLATE": {
+                "TEMPLATE": "topic-{{"{{"}}functionality{{"}}"}}-{{"{{"}}action{{"}}"}}",
+                "REGEX": "topic-(.*)-(.*)"
+            }
+        },
+        "CONSUMER": {
+            "BULK": {
+                "PREPARE": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-bulk-prepare",
+                            "group.id": "cl-group-bulk-prepare",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
+                "PROCESSING": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-bulk-processing",
+                            "group.id": "cl-group-bulk-processing",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
+                "FULFIL": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-bulk-fulfil",
+                            "group.id": "cl-group-bulk-fulfil",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                }
+            },
+            "TRANSFER": {
+                "PREPARE": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-prepare",
+                            "group.id": "cl-group-transfer-prepare",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
+                "POSITION": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-position",
+                            "group.id": "cl-group-transfer-position",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
+                "FULFIL": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-fulfil",
+                            "group.id": "cl-group-transfer-fulfil",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
+                "GET": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-get",
+                            "group.id": "cl-group-transfer-get",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                }
+            },
+            "ADMIN": {
+                "TRANSFER": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-admin",
+                            "group.id": "cl-group-transfer-admin",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                }
+            }
+        },
+        "PRODUCER": {
+            "BULK": {
+                "PROCESSING": {
+                    "config": {
+                        "options": {
+                        "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "cl-prod-bulk-processing",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        },
+                        "topicConf": {
+                            "request.required.acks": "all"
+                        }
+                    }
+                }
+            },
+            "TRANSFER": {
+                "PREPARE": {
+                    "config": {
+                        "options": {
+                            "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "cl-prod-transfer-prepare",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        }
+                    }
+                },
+                "POSITION": {
+                    "config": {
+                        "options": {
+                            "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "cl-prod-transfer-position",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        }
+                    }
+                },
+                "FULFIL": {
+                    "config": {
+                        "options": {
+                            "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "cl-prod-transfer-fulfil",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        }
+                    }
+                },
+                "GET": {
+                    "config": {
+                        "options": {
+                            "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "cl-prod-transfer-get",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        },
+                        "topicConf": {
+                            "request.required.acks": "all"
+                        }
+                    }
+                }
+            },
+            "NOTIFICATION": {
+                "EVENT": {
+                    "config": {
+                        "options": {
+                            "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "cl-prod-notification-event",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        },
+                        "topicConf": {
+                            "request.required.acks": "all"
+                        }
+                    }
+                }
+            },
+            "ADMIN": {
+                "TRANSFER": {
+                    "config": {
+                        "options": {
+                            "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "admin-transfer-produce",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        },
+                        "topicConf": {
+                            "request.required.acks": "all"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/configs/knexfile.js
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/configs/knexfile.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const migrationsDirectory = '/opt/central-ledger/migrations'
+const seedsDirectory = '/opt/central-ledger/seeds'
+
+const Config = require('/opt/central-ledger/src/lib/config')
+
+module.exports = {
+  client: 'mysql',
+  connection: Config.DATABASE_URI,
+  min: Config.DB_CONNECTION_POOL_MIN,
+  max: Config.DB_CONNECTION_POOL_MAX,
+  migrations: {
+    directory: migrationsDirectory,
+    tableName: 'migration',
+    stub: `${migrationsDirectory}/migration.template`
+  },
+  seeds: {
+    directory: seedsDirectory,
+    loadExtensions: ['.js']
+  }
+}

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/NOTES.txt
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http://{{ . }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "centralledger-handler-bulk-transfer-fulfil.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.internalPort }}
+{{- end }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/_helpers.tpl
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "centralledger-handler-bulk-transfer-fulfil.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "centralledger-handler-bulk-transfer-fulfil.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/config.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}
+  labels:
+      app: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}
+      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+data:
+  default.json: {{ (tpl (.Files.Get "configs/default.json") . ) | quote }}
+  knexfile.js: {{ (tpl (.Files.Get "configs/knexfile.js") . ) | quote }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/deployment.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/deployment.yaml
@@ -1,0 +1,113 @@
+{{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
+{{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}
+  labels:
+    app: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+      {{- if .Values.metrics.enabled }}
+      annotations:
+        prometheus.io/port: "{{ .Values.containers.api.service.ports.api.internalPort }}"
+        prometheus.io/scrape: "true"
+      {{- end }}
+    spec:
+{{- if .Values.global.config.affinity }}
+      affinity:
+{{ toYaml .Values.global.config.affinity | indent 8 }}
+{{- end }}
+{{- if .Values.global.config.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.config.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.global.config.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.config.tolerations | indent 8 }}
+{{- end }}
+      {{- if .Values.init.enabled }}
+      initContainers:
+        {{- if eq .Values.config.db_type "postgres"}}
+        - name: {{ .Values.init.psql.name }}
+          image: {{ .Values.init.psql.repository }}:{{ .Values.init.psql.tag }}
+          imagePullPolicy: {{ .Values.init.psql.pullPolicy }}
+          env:
+          - name: "POSTGRES_URL"
+            value: "postgresql://{{ .Values.config.db_user }}:{{ .Values.config.db_password }}@{{ $dbHost }}:{{ .Values.config.db_port }}/{{ .Values.config.db_database }}?sslmode=disable"
+        {{- end }}
+        {{- if eq .Values.config.db_type "mysql"}}
+        - name: {{ .Values.init.mysql.name }}
+          image: {{ .Values.init.mysql.repository }}:{{ .Values.init.mysql.tag }}
+          imagePullPolicy: {{ .Values.init.mysql.pullPolicy }}
+          command:
+            - sh
+            - "-c"
+            - {{ (.Values.init.mysql.command | replace "$db_user" (print .Values.config.db_user) | replace "$db_password" (print .Values.config.db_password) | replace "$db_host" $dbHost | replace "$db_database" (print .Values.config.db_database) | replace "$db_port" (print .Values.config.db_port) )| quote }}
+        {{- end }}
+        - name: {{ .Values.init.kafka.name }}
+          image: {{ .Values.init.kafka.repository }}:{{ .Values.init.kafka.tag }}
+          imagePullPolicy: {{ .Values.init.kafka.pullPolicy }}
+          command:
+            - sh
+            - "-c"
+            - {{ (.Values.init.kafka.command | replace "$kafka_host" $kafkaHost | replace "$kafka_port" (printf "%.0f" .Values.config.kafka_port) ) | quote }}
+          env:
+          {{- range $envItem := .Values.init.kafka.env }}
+            - name: {{ $envItem.name }}
+              value: {{ $envItem.value }}
+          {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ template "centralledger-handler-bulk-transfer-fulfil.name" . }}
+          image: "{{ .Values.containers.api.image.repository }}:{{ .Values.containers.api.image.tag }}"
+          imagePullPolicy: {{ .Values.containers.api.image.pullPolicy }}
+          command: {{ .Values.containers.api.image.command }}
+          ports:
+          {{- range $port := .Values.containers.api.service.ports }}
+            - name: {{ $port.name }}
+              containerPort: {{ $port.internalPort }}
+          {{- end }}
+          {{- if .Values.containers.api.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.containers.api.readinessProbe.httpGet.path }}
+              port: {{ .Values.containers.api.service.ports.api.internalPort }}
+            initialDelaySeconds: {{ .Values.containers.api.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.containers.api.readinessProbe.periodSeconds }}
+          {{- end }}
+          {{- if .Values.containers.api.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.containers.api.livenessProbe.httpGet.path }}
+              port: {{ .Values.containers.api.service.ports.api.internalPort }}
+            initialDelaySeconds: {{ .Values.containers.api.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.containers.api.livenessProbe.periodSeconds }}
+          {{- end }}
+          env:
+            - name: CLEDG_DATABASE_URI
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}
+                  key: db.uri
+            - name: LOG_LEVEL
+              value: {{ .Values.config.log_level }}
+          volumeMounts:
+          - name: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}-config-volume
+            mountPath: /opt/central-ledger/config
+      volumes:
+        - name: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}-config-volume
+          configMap:
+            name: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}
+            items:
+            - key: default.json
+              path: default.json
+            - key: knexfile.js
+              path: knexfile.js

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/deployment.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/deployment.yaml
@@ -1,5 +1,6 @@
 {{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+{{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -35,6 +36,13 @@ spec:
 {{- end }}
       {{- if .Values.init.enabled }}
       initContainers:
+        - name: {{ .Values.init.mongodb.name }}
+          image: {{ .Values.init.mongodb.repository }}:{{ .Values.init.mongodb.tag }}
+          imagePullPolicy: {{ .Values.init.mongodb.pullPolicy }}
+          command:
+            - sh
+            - "-c"
+            - {{ (.Values.init.mongodb.command | replace "$mongouri" $objStoreUri | quote }}
         {{- if eq .Values.config.db_type "postgres"}}
         - name: {{ .Values.init.psql.name }}
           image: {{ .Values.init.psql.repository }}:{{ .Values.init.psql.tag }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/deployment.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           command:
             - sh
             - "-c"
-            - {{ (.Values.init.mongodb.command | replace "$mongouri" $objStoreUri | quote }}
+            - {{ (.Values.init.mongodb.command | replace "$mongouri" $objStoreUri) | quote }}
         {{- if eq .Values.config.db_type "postgres"}}
         - name: {{ .Values.init.psql.name }}
           image: {{ .Values.init.psql.repository }}:{{ .Values.init.psql.tag }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/endpoint.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/endpoint.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.service.external.enabled -}}
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}
+  labels:
+    app: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subsets: 
+  -
+    addresses:
+      -
+        ip: {{ .Values.service.external.ip }}
+    ports:
+      -
+        port: {{ .Values.service.external.ports.api.externalPort }}
+        name: {{ .Values.service.external.ports.api.name }}
+{{- end -}}

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/ingress.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/ingress.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "centralledger-handler-bulk-transfer-fulfil.fullname" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}
+  labels:
+    app: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    - host: {{ .Values.ingress.hosts.api }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.externalPath.api }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ .Values.containers.api.service.ports.api.externalPort }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/secret.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- $dbHost := (.Values.config.db_host | replace "$release_name" .Release.Name) }}
+{{- $dbURL := printf "%s://%s:%s@%s:%.0f/%s" .Values.config.db_type .Values.config.db_user .Values.config.db_password $dbHost .Values.config.db_port .Values.config.db_database -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}
+  labels:
+      app: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}
+      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  # base64 encoded string
+  db.uri: {{ $dbURL | b64enc }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/service.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}
+  labels:
+    app: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.service.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    {{- range $port := .Values.containers.api.service.ports }}
+    - port: {{ $port.externalPort }}
+      targetPort: {{ $port.internalPort }}
+      protocol: TCP
+      name: {{ $port.name }}
+    {{- end }}
+{{- if not .Values.service.external.enabled }}
+  selector:
+    app: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}
+    release: {{ .Release.Name }}
+{{- end -}}

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
@@ -114,6 +114,12 @@ init:
     tag: latest
     pullPolicy: Always
     command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
+  mongodb:
+    name: wait-for-mongodb
+    repository: bitnami/mongodb
+    tag: latest
+    pullPolicy: Always
+    command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
 
 service:
   type: ClusterIP

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
@@ -1,0 +1,163 @@
+# Default values for centralledger-handler-bulk-transfer-fulfil.
+# This is a YAML-formatted file.
+
+# Declare global configurations
+global:
+  config:
+    ## Pod scheduling preferences.
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ##
+    affinity: {}
+
+    ## Node labels for pod assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+    nodeSelector: {}
+
+    ## Set toleration for schedular
+    ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    tolerations: []
+
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+containers:
+  api:
+    image:
+      repository: mojaloop/central-ledger
+      tag: v7.1.2
+      pullPolicy: Always
+      command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
+    service:
+      ports:
+        api:
+          name: http-api
+          externalPort: 80
+          internalPort: 3001
+    readinessProbe:
+      enabled: true
+      httpGet:
+        path: /health
+      initialDelaySeconds: 60
+      periodSeconds: 15
+    livenessProbe:
+      enabled: true
+      httpGet:
+        path: /health
+      initialDelaySeconds: 60
+      periodSeconds: 15
+
+## metric configuration for prometheus instrumentation
+metrics:
+  ## flag to enable/disable the metrics end-points
+  enabled: true
+  config:
+    timeout: 5000
+    prefix: moja_
+    defaultLabels:
+      serviceName: central-handler-bulkfulfil
+
+config:
+  ## Forensic Logging sidecar
+  # this is for Forensic Logging Sidecar
+  forensicloggingsidecar_disabled: false
+  forensicloggingsidecar_host: forensicloggingsidecar-ledger
+  forensicloggingsidecar_port: 5678
+
+  ## DB Configuration
+  # db_type can either be 'postgres' or 'mysql'. Ensure the correct DB is enabled and configured below: postgresql.enabled or mysql.enabled
+  db_type: 'mysql'
+  # db_driver can either be 'pg' or 'mysql'. Ensure the correct corresponding db_type above has been set.
+  db_driver: 'mysql'
+  db_host: '$release_name-centralledger-mysql'
+  db_port: 3306
+  db_user: central_ledger
+  db_password: oyMxgZChuu
+  db_database: central_ledger
+  db_connection_pool_min: 10
+  db_connection_pool_max: 30
+
+  ## MongoDB Configuration for Object Store
+  objstore_disabled: false
+  objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
+
+  ## Kafka Configuration
+  # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+  kafka_host: '$release_name-kafka'
+  kafka_port: 9092
+
+  ## Node Configuration
+  log_level: 'info'
+
+init:
+  enabled: true
+  kafka:
+    name: wait-for-kafka
+    repository: solsson/kafka
+    tag: latest
+    pullPolicy: Always
+    command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
+    env: {}
+    ## Env example
+    # env:
+    #   envItem1:
+    #     name: hello
+    #     value: world
+    #
+  psql:
+    name: wait-for-postgres
+    repository: bowerswilkins/awaitpostgres
+    tag: latest
+    pullPolicy: Always
+  mysql:
+    name: wait-for-mysql
+    repository: mysql
+    tag: latest
+    pullPolicy: Always
+    command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
+
+service:
+  type: ClusterIP
+
+  annotations: {}
+
+  # This allows one to point the service to an external backend.
+  # This is useful for local development where one wishes to hijack
+  # the communication from the service to the node layer and point
+  # to a specific endpoint (IP, Port, etc).
+  external:
+    enabled: false
+    # 10.0.2.2 is the magic IP for the host on virtualbox's network
+    ip: 10.0.2.2
+    ports:
+      api:
+        name: http-api
+        externalPort: 3001
+
+ingress:
+  enabled: true
+  type: http
+  externalPath:
+    api: /
+  # Used to create an Ingress record.
+  hosts:
+    api: central-ledger-transfer-bulkfulfil.local
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: '/'
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Central-Ledger Bulk Transfer Prepare Handler Helm chart for Kubernetes
-name: centralledger-handler-bulk-transfer-prepare
+name: cl-handler-bulk-transfer-prepare
 version: 7.1.0
 appVersion: "7.1.2"
 home: http://mojaloop.io

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+description: Central-Ledger Bulk Transfer Prepare Handler Helm chart for Kubernetes
+name: centralledger-handler-bulk-transfer-prepare
+version: 7.1.0
+appVersion: "7.1.2"
+home: http://mojaloop.io
+icon: http://mojaloop.io/images/logo.png
+sources:
+  - https://github.com/mojaloop/mojaloop
+  - https://github.com/mojaloop/helm
+  - https://github.com/mojaloop/central-ledger
+maintainers:
+  - name: Miguel de Barros
+    email: miguel.debarros@modusbox.com

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/configs/default.json
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/configs/default.json
@@ -1,0 +1,404 @@
+{{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+{{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
+{
+    "PORT": {{ .Values.containers.api.service.ports.api.internalPort }},
+    "HOSTNAME": "{{ .Values.ingress.hosts.api }}",
+    "RUN_MIGRATIONS": false,
+    "AMOUNT": {
+        "PRECISION": 10,
+        "SCALE": 2
+    },
+    "SIDECAR": {
+        "DISABLED": {{ .Values.config.forensicloggingsidecar_disabled }},
+        "HOST": "{{ printf "%s-%s" .Release.Name .Values.config.forensicloggingsidecar_host }}",
+        "PORT": {{ .Values.config.forensicloggingsidecar_port }},
+        "CONNECT_TIMEOUT": 45000,
+        "RECONNECT_INTERVAL": 5000
+    },
+    "DB_CONNECTION": {
+        "POOL_MIN": {{ .Values.config.db_connection_pool_min }},
+        "POOL_MAX": {{ .Values.config.db_connection_pool_max }}
+    },
+    "MONGODB": {
+        "DISABLED": {{ .Values.config.objstore_disabled }},
+        "URI": {{ (default .Values.config.objstore_uri $objStoreUri) | quote }}
+    },
+    "HANDLERS": {
+        "DISABLED": false,
+        "API": {
+            "DISABLED": false
+        },
+        "CRON": {
+            "DISABLED": true,
+            "TIMEXP": "*/10 * * * * *",
+            "TIMEZONE": "UTC"
+        },
+        "TIMEOUT": {
+            "DISABLED": true,
+            "TIMEXP": "*/15 * * * * *",
+            "TIMEZONE": "UTC"
+        }
+    },
+    "INSTRUMENTATION": {
+        "METRICS": {
+            "DISABLED": {{ not .Values.metrics.enabled }},
+            "labels": {
+                "fspId": "*"
+            },
+            "config": {
+                "timeout": {{ .Values.metrics.config.timeout }},
+                "prefix": {{ .Values.metrics.config.prefix | quote }},
+                "defaultLabels": {
+                {{- range $key, $value := .Values.metrics.config.defaultLabels }}
+                    {{ $key  | quote }}: {{ $value | quote }}
+                {{- end }}
+                }
+            }
+        }
+    },
+    "EMAIL_USER": "user",
+    "EMAIL_PASSWORD": "password",
+    "EMAIL_SMTP": "smtp.local",
+    "PARTICIPANT_INITIAL_POSITION": 0,
+    "HUB_PARTICIPANT": {
+        "ID": 1,
+        "NAME": "Hub",
+        "ACCOUNTS": [
+            "HUB_RECONCILIATION",
+            "HUB_MULTILATERAL_SETTLEMENT",
+            "HUB_FEE"
+        ]
+    },
+    "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+    "KAFKA": {
+        "TOPIC_TEMPLATES": {
+            "PARTICIPANT_TOPIC_TEMPLATE": {
+                "TEMPLATE": "topic-{{"{{"}}participantName{{"}}"}}-{{"{{"}}functionality{{"}}"}}-{{"{{"}}action{{"}}"}}",
+                "REGEX": "topic-(.*)-(.*)-(.*)"
+            },
+            "GENERAL_TOPIC_TEMPLATE": {
+                "TEMPLATE": "topic-{{"{{"}}functionality{{"}}"}}-{{"{{"}}action{{"}}"}}",
+                "REGEX": "topic-(.*)-(.*)"
+            }
+        },
+        "CONSUMER": {
+            "BULK": {
+                "PREPARE": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-bulk-prepare",
+                            "group.id": "cl-group-bulk-prepare",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
+                "PROCESSING": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-bulk-processing",
+                            "group.id": "cl-group-bulk-processing",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
+                "FULFIL": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-bulk-fulfil",
+                            "group.id": "cl-group-bulk-fulfil",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                }
+            },
+            "TRANSFER": {
+                "PREPARE": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-prepare",
+                            "group.id": "cl-group-transfer-prepare",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
+                "POSITION": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-position",
+                            "group.id": "cl-group-transfer-position",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
+                "FULFIL": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-fulfil",
+                            "group.id": "cl-group-transfer-fulfil",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
+                "GET": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-get",
+                            "group.id": "cl-group-transfer-get",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                }
+            },
+            "ADMIN": {
+                "TRANSFER": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-admin",
+                            "group.id": "cl-group-transfer-admin",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                }
+            }
+        },
+        "PRODUCER": {
+            "BULK": {
+                "PROCESSING": {
+                    "config": {
+                        "options": {
+                        "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "cl-prod-bulk-processing",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        },
+                        "topicConf": {
+                            "request.required.acks": "all"
+                        }
+                    }
+                }
+            },
+            "TRANSFER": {
+                "PREPARE": {
+                    "config": {
+                        "options": {
+                            "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "cl-prod-transfer-prepare",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        }
+                    }
+                },
+                "POSITION": {
+                    "config": {
+                        "options": {
+                            "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "cl-prod-transfer-position",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        }
+                    }
+                },
+                "FULFIL": {
+                    "config": {
+                        "options": {
+                            "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "cl-prod-transfer-fulfil",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        }
+                    }
+                },
+                "GET": {
+                    "config": {
+                        "options": {
+                            "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "cl-prod-transfer-get",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        },
+                        "topicConf": {
+                            "request.required.acks": "all"
+                        }
+                    }
+                }
+            },
+            "NOTIFICATION": {
+                "EVENT": {
+                    "config": {
+                        "options": {
+                            "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "cl-prod-notification-event",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        },
+                        "topicConf": {
+                            "request.required.acks": "all"
+                        }
+                    }
+                }
+            },
+            "ADMIN": {
+                "TRANSFER": {
+                    "config": {
+                        "options": {
+                            "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "admin-transfer-produce",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        },
+                        "topicConf": {
+                            "request.required.acks": "all"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/configs/knexfile.js
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/configs/knexfile.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const migrationsDirectory = '/opt/central-ledger/migrations'
+const seedsDirectory = '/opt/central-ledger/seeds'
+
+const Config = require('/opt/central-ledger/src/lib/config')
+
+module.exports = {
+    client: 'mysql',
+    connection: Config.DATABASE_URI,
+    min: Config.DB_CONNECTION_POOL_MIN,
+    max: Config.DB_CONNECTION_POOL_MAX,
+    migrations: {
+        directory: migrationsDirectory,
+        tableName: 'migration',
+        stub: `${migrationsDirectory}/migration.template`
+    },
+    seeds: {
+        directory: seedsDirectory,
+        loadExtensions: ['.js']
+    }
+}

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/NOTES.txt
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http://{{ . }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "centralledger-handler-bulk-transfer-prepare.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.internalPort }}
+{{- end }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/_helpers.tpl
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "centralledger-handler-bulk-transfer-prepare.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "centralledger-handler-bulk-transfer-prepare.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/config.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/config.yaml
@@ -1,0 +1,13 @@
+{{- $forensicLoggingSidecarHost := printf "%s-%s" .Release.Name .Values.config.forensicloggingsidecar_host -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}
+  labels:
+      app: {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}
+      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+data:
+  default.json: {{ (tpl (.Files.Get "configs/default.json") . ) | quote }}
+  knexfile.js: {{ (tpl (.Files.Get "configs/knexfile.js") . ) | quote }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/deployment.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/deployment.yaml
@@ -1,5 +1,6 @@
 {{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+{{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -35,6 +36,13 @@ spec:
 {{- end }}
       {{- if .Values.init.enabled }}
       initContainers:
+        - name: {{ .Values.init.mongodb.name }}
+          image: {{ .Values.init.mongodb.repository }}:{{ .Values.init.mongodb.tag }}
+          imagePullPolicy: {{ .Values.init.mongodb.pullPolicy }}
+          command:
+            - sh
+            - "-c"
+            - {{ (.Values.init.mongodb.command | replace "$mongouri" $objStoreUri | quote }}
         {{- if eq .Values.config.db_type "postgres"}}
         - name: {{ .Values.init.psql.name }}
           image: {{ .Values.init.psql.repository }}:{{ .Values.init.psql.tag }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/deployment.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           command:
             - sh
             - "-c"
-            - {{ (.Values.init.mongodb.command | replace "$mongouri" $objStoreUri | quote }}
+            - {{ (.Values.init.mongodb.command | replace "$mongouri" $objStoreUri) | quote }}
         {{- if eq .Values.config.db_type "postgres"}}
         - name: {{ .Values.init.psql.name }}
           image: {{ .Values.init.psql.repository }}:{{ .Values.init.psql.tag }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/deployment.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/deployment.yaml
@@ -1,0 +1,113 @@
+{{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
+{{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}
+  labels:
+    app: {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+      {{- if .Values.metrics.enabled }}
+      annotations:
+        prometheus.io/port: "{{ .Values.containers.api.service.ports.api.internalPort }}"
+        prometheus.io/scrape: "true"
+      {{- end }}
+    spec:
+{{- if .Values.global.config.affinity }}
+      affinity:
+{{ toYaml .Values.global.config.affinity | indent 8 }}
+{{- end }}
+{{- if .Values.global.config.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.config.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.global.config.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.config.tolerations | indent 8 }}
+{{- end }}
+      {{- if .Values.init.enabled }}
+      initContainers:
+        {{- if eq .Values.config.db_type "postgres"}}
+        - name: {{ .Values.init.psql.name }}
+          image: {{ .Values.init.psql.repository }}:{{ .Values.init.psql.tag }}
+          imagePullPolicy: {{ .Values.init.psql.pullPolicy }}
+          env:
+          - name: "POSTGRES_URL"
+            value: "postgresql://{{ .Values.config.db_user }}:{{ .Values.config.db_password }}@{{ $dbHost }}:{{ .Values.config.db_port }}/{{ .Values.config.db_database }}?sslmode=disable"
+        {{- end }}
+        {{- if eq .Values.config.db_type "mysql"}}
+        - name: {{ .Values.init.mysql.name }}
+          image: {{ .Values.init.mysql.repository }}:{{ .Values.init.mysql.tag }}
+          imagePullPolicy: {{ .Values.init.mysql.pullPolicy }}
+          command:
+            - sh
+            - "-c"
+            - {{ (.Values.init.mysql.command | replace "$db_user" (print .Values.config.db_user) | replace "$db_password" (print .Values.config.db_password) | replace "$db_host" $dbHost | replace "$db_database" (print .Values.config.db_database) | replace "$db_port" (print .Values.config.db_port) )| quote }}
+        {{- end }}
+        - name: {{ .Values.init.kafka.name }}
+          image: {{ .Values.init.kafka.repository }}:{{ .Values.init.kafka.tag }}
+          imagePullPolicy: {{ .Values.init.kafka.pullPolicy }}
+          command:
+            - sh
+            - "-c"
+            - {{ (.Values.init.kafka.command | replace "$kafka_host" $kafkaHost | replace "$kafka_port" (printf "%.0f" .Values.config.kafka_port) ) | quote }}
+          env:
+          {{- range $envItem := .Values.init.kafka.env }}
+            - name: {{ $envItem.name }}
+              value: {{ $envItem.value }}
+          {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ template "centralledger-handler-bulk-transfer-prepare.name" . }}
+          image: "{{ .Values.containers.api.image.repository }}:{{ .Values.containers.api.image.tag }}"
+          imagePullPolicy: {{ .Values.containers.api.image.pullPolicy }}
+          command: {{ .Values.containers.api.image.command }}
+          ports:
+          {{- range $port := .Values.containers.api.service.ports }}
+            - name: {{ $port.name }}
+              containerPort: {{ $port.internalPort }}
+          {{- end }}
+          {{- if .Values.containers.api.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.containers.api.readinessProbe.httpGet.path }}
+              port: {{ .Values.containers.api.service.ports.api.internalPort }}
+            initialDelaySeconds: {{ .Values.containers.api.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.containers.api.readinessProbe.periodSeconds }}
+          {{- end }}
+          {{- if .Values.containers.api.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.containers.api.livenessProbe.httpGet.path }}
+              port: {{ .Values.containers.api.service.ports.api.internalPort }}
+            initialDelaySeconds: {{ .Values.containers.api.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.containers.api.livenessProbe.periodSeconds }}
+          {{- end }}
+          env:
+            - name: CLEDG_DATABASE_URI
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}
+                  key: db.uri
+            - name: LOG_LEVEL
+              value: {{ .Values.config.log_level }}
+          volumeMounts:
+          - name: {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}-config-volume
+            mountPath: /opt/central-ledger/config
+      volumes:
+        - name: {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}-config-volume
+          configMap:
+            name: {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}
+            items:
+            - key: default.json
+              path: default.json
+            - key: knexfile.js
+              path: knexfile.js

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/endpoint.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/endpoint.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.service.external.enabled -}}
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}
+  labels:
+    app: {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subsets: 
+  -
+    addresses:
+      -
+        ip: {{ .Values.service.external.ip }}
+    ports:
+      -
+        port: {{ .Values.service.external.ports.api.externalPort }}
+        name: {{ .Values.service.external.ports.api.name }}
+{{- end -}}

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/ingress.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/ingress.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "centralledger-handler-bulk-transfer-prepare.fullname" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}
+  labels:
+    app: {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    - host: {{ .Values.ingress.hosts.api }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.externalPath.api }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ .Values.containers.api.service.ports.api.externalPort }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/secret.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- $dbHost := (.Values.config.db_host | replace "$release_name" .Release.Name) }}
+{{- $dbURL := printf "%s://%s:%s@%s:%.0f/%s" .Values.config.db_type .Values.config.db_user .Values.config.db_password $dbHost .Values.config.db_port .Values.config.db_database -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}
+  labels:
+      app: {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}
+      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  # base64 encoded string
+  db.uri: {{ $dbURL | b64enc }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/service.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}
+  labels:
+    app: {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.service.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    {{- range $port := .Values.containers.api.service.ports }}
+    - port: {{ $port.externalPort }}
+      targetPort: {{ $port.internalPort }}
+      protocol: TCP
+      name: {{ $port.name }}
+    {{- end }}
+{{- if not .Values.service.external.enabled }}
+  selector:
+    app: {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}
+    release: {{ .Release.Name }}
+{{- end -}}

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
@@ -114,6 +114,12 @@ init:
     tag: latest
     pullPolicy: Always
     command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
+  mongodb:
+    name: wait-for-mongodb
+    repository: bitnami/mongodb
+    tag: latest
+    pullPolicy: Always
+    command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
 
 service:
   type: ClusterIP

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
@@ -1,0 +1,163 @@
+# Default values for centralledger-handler-bulk-transfer-prepare.
+# This is a YAML-formatted file.
+
+# Declare global configurations
+global:
+  config:
+    ## Pod scheduling preferences.
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ##
+    affinity: {}
+
+    ## Node labels for pod assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+    nodeSelector: {}
+
+    ## Set toleration for schedular
+    ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    tolerations: []
+
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+containers:
+  api:
+    image:
+      repository: mojaloop/central-ledger
+      tag: v7.1.2
+      pullPolicy: Always
+      command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
+    service:
+      ports:
+        api:
+          name: http-api
+          externalPort: 80
+          internalPort: 3001
+    readinessProbe:
+      enabled: true
+      httpGet:
+        path: /health
+      initialDelaySeconds: 60
+      periodSeconds: 15
+    livenessProbe:
+      enabled: true
+      httpGet:
+        path: /health
+      initialDelaySeconds: 60
+      periodSeconds: 15
+
+## metric configuration for prometheus instrumentation
+metrics:
+  ## flag to enable/disable the metrics end-points
+  enabled: true
+  config:
+    timeout: 5000
+    prefix: moja_
+    defaultLabels:
+      serviceName: central-handler-bulkprepare
+
+config:
+  ## Forensic Logging sidecar
+  # this is for Forensic Logging Sidecar
+  forensicloggingsidecar_disabled: false
+  forensicloggingsidecar_host: forensicloggingsidecar-ledger
+  forensicloggingsidecar_port: 5678
+
+  ## DB Configuration
+  # db_type can either be 'postgres' or 'mysql'. Ensure the correct DB is enabled and configured below: postgresql.enabled or mysql.enabled
+  db_type: 'mysql'
+  # db_driver can either be 'pg' or 'mysql'. Ensure the correct corresponding db_type above has been set.
+  db_driver: 'mysql'
+  db_host: '$release_name-centralledger-mysql'
+  db_port: 3306
+  db_user: central_ledger
+  db_password: oyMxgZChuu
+  db_database: central_ledger
+  db_connection_pool_min: 10
+  db_connection_pool_max: 30
+
+  ## MongoDB Configuration for Object Store
+  objstore_disabled: false
+  objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
+
+  ## Kafka Configuration
+  # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+  kafka_host: '$release_name-kafka'
+  kafka_port: 9092
+
+  ## Node Configuration
+  log_level: 'info'
+
+init:
+  enabled: true
+  kafka:
+    name: wait-for-kafka
+    repository: solsson/kafka
+    tag: latest
+    pullPolicy: Always
+    command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
+    env: {}
+    ## Env example
+    # env:
+    #   envItem1:
+    #     name: hello
+    #     value: world
+    #
+  psql:
+    name: wait-for-postgres
+    repository: bowerswilkins/awaitpostgres
+    tag: latest
+    pullPolicy: Always
+  mysql:
+    name: wait-for-mysql
+    repository: mysql
+    tag: latest
+    pullPolicy: Always
+    command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
+
+service:
+  type: ClusterIP
+
+  annotations: {}
+
+  # This allows one to point the service to an external backend.
+  # This is useful for local development where one wishes to hijack
+  # the communication from the service to the node layer and point
+  # to a specific endpoint (IP, Port, etc).
+  external:
+    enabled: false
+    # 10.0.2.2 is the magic IP for the host on virtualbox's network
+    ip: 10.0.2.2
+    ports:
+      api:
+        name: http-api
+        externalPort: 3001
+
+ingress:
+  enabled: true
+  type: http
+  externalPath:
+    api: /
+  # Used to create an Ingress record.
+  hosts:
+    api: central-ledger-transfer-bulkprepare.local
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: '/'
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+description: Central-Ledger Bulk Transfer Processing Handler Helm chart for Kubernetes
+name: centralledger-handler-bulk-transfer-processing
+version: 7.1.0
+appVersion: "7.1.2"
+home: http://mojaloop.io
+icon: http://mojaloop.io/images/logo.png
+sources:
+  - https://github.com/mojaloop/mojaloop
+  - https://github.com/mojaloop/helm
+  - https://github.com/mojaloop/central-ledger
+maintainers:
+  - name: Miguel de Barros
+    email: miguel.debarros@modusbox.com

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Central-Ledger Bulk Transfer Processing Handler Helm chart for Kubernetes
-name: centralledger-handler-bulk-transfer-processing
+name: cl-handler-bulk-transfer-processing
 version: 7.1.0
 appVersion: "7.1.2"
 home: http://mojaloop.io

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/configs/default.json
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/configs/default.json
@@ -1,0 +1,404 @@
+{{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+{{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
+{
+    "PORT": {{ .Values.containers.api.service.ports.api.internalPort }},
+    "HOSTNAME": "{{ .Values.ingress.hosts.api }}",
+    "RUN_MIGRATIONS": false,
+    "AMOUNT": {
+        "PRECISION": 10,
+        "SCALE": 2
+    },
+    "SIDECAR": {
+        "DISABLED": {{ .Values.config.forensicloggingsidecar_disabled }},
+        "HOST": "{{ printf "%s-%s" .Release.Name .Values.config.forensicloggingsidecar_host }}",
+        "PORT": {{ .Values.config.forensicloggingsidecar_port }},
+        "CONNECT_TIMEOUT": 45000,
+        "RECONNECT_INTERVAL": 5000
+    },
+    "DB_CONNECTION": {
+        "POOL_MIN": {{ .Values.config.db_connection_pool_min }},
+        "POOL_MAX": {{ .Values.config.db_connection_pool_max }}
+    },
+    "MONGODB": {
+        "DISABLED": {{ .Values.config.objstore_disabled }},
+        "URI": {{ (default .Values.config.objstore_uri $objStoreUri) | quote }}
+    },
+    "HANDLERS": {
+        "DISABLED": false,
+        "API": {
+            "DISABLED": false
+        },
+        "CRON": {
+            "DISABLED": true,
+            "TIMEXP": "*/10 * * * * *",
+            "TIMEZONE": "UTC"
+        },
+        "TIMEOUT": {
+            "DISABLED": true,
+            "TIMEXP": "*/15 * * * * *",
+            "TIMEZONE": "UTC"
+        }
+    },
+    "INSTRUMENTATION": {
+        "METRICS": {
+            "DISABLED": {{ not .Values.metrics.enabled }},
+            "labels": {
+                "fspId": "*"
+            },
+            "config": {
+                "timeout": {{ .Values.metrics.config.timeout }},
+                "prefix": {{ .Values.metrics.config.prefix | quote }},
+                "defaultLabels": {
+                {{- range $key, $value := .Values.metrics.config.defaultLabels }}
+                    {{ $key  | quote }}: {{ $value | quote }}
+                {{- end }}
+                }
+            }
+        }
+    },
+    "EMAIL_USER": "user",
+    "EMAIL_PASSWORD": "password",
+    "EMAIL_SMTP": "smtp.local",
+    "PARTICIPANT_INITIAL_POSITION": 0,
+    "HUB_PARTICIPANT": {
+        "ID": 1,
+        "NAME": "Hub",
+        "ACCOUNTS": [
+            "HUB_RECONCILIATION",
+            "HUB_MULTILATERAL_SETTLEMENT",
+            "HUB_FEE"
+        ]
+    },
+    "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+    "KAFKA": {
+        "TOPIC_TEMPLATES": {
+            "PARTICIPANT_TOPIC_TEMPLATE": {
+                "TEMPLATE": "topic-{{"{{"}}participantName{{"}}"}}-{{"{{"}}functionality{{"}}"}}-{{"{{"}}action{{"}}"}}",
+                "REGEX": "topic-(.*)-(.*)-(.*)"
+            },
+            "GENERAL_TOPIC_TEMPLATE": {
+                "TEMPLATE": "topic-{{"{{"}}functionality{{"}}"}}-{{"{{"}}action{{"}}"}}",
+                "REGEX": "topic-(.*)-(.*)"
+            }
+        },
+        "CONSUMER": {
+            "BULK": {
+                "PREPARE": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-bulk-prepare",
+                            "group.id": "cl-group-bulk-prepare",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
+                "PROCESSING": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-bulk-processing",
+                            "group.id": "cl-group-bulk-processing",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
+                "FULFIL": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-bulk-fulfil",
+                            "group.id": "cl-group-bulk-fulfil",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                }
+            },
+            "TRANSFER": {
+                "PREPARE": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-prepare",
+                            "group.id": "cl-group-transfer-prepare",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
+                "POSITION": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-position",
+                            "group.id": "cl-group-transfer-position",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
+                "FULFIL": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-fulfil",
+                            "group.id": "cl-group-transfer-fulfil",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
+                "GET": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-get",
+                            "group.id": "cl-group-transfer-get",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                }
+            },
+            "ADMIN": {
+                "TRANSFER": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-admin",
+                            "group.id": "cl-group-transfer-admin",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                }
+            }
+        },
+        "PRODUCER": {
+            "BULK": {
+                "PROCESSING": {
+                    "config": {
+                        "options": {
+                        "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "cl-prod-bulk-processing",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        },
+                        "topicConf": {
+                            "request.required.acks": "all"
+                        }
+                    }
+                }
+            },
+            "TRANSFER": {
+                "PREPARE": {
+                    "config": {
+                        "options": {
+                            "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "cl-prod-transfer-prepare",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        }
+                    }
+                },
+                "POSITION": {
+                    "config": {
+                        "options": {
+                            "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "cl-prod-transfer-position",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        }
+                    }
+                },
+                "FULFIL": {
+                    "config": {
+                        "options": {
+                            "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "cl-prod-transfer-fulfil",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        }
+                    }
+                },
+                "GET": {
+                    "config": {
+                        "options": {
+                            "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "cl-prod-transfer-get",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        },
+                        "topicConf": {
+                            "request.required.acks": "all"
+                        }
+                    }
+                }
+            },
+            "NOTIFICATION": {
+                "EVENT": {
+                    "config": {
+                        "options": {
+                            "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "cl-prod-notification-event",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        },
+                        "topicConf": {
+                            "request.required.acks": "all"
+                        }
+                    }
+                }
+            },
+            "ADMIN": {
+                "TRANSFER": {
+                    "config": {
+                        "options": {
+                            "messageCharset": "utf8"
+                        },
+                        "rdkafkaConf": {
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "client.id": "admin-transfer-produce",
+                            "event_cb": true,
+                            "dr_cb": false,
+                            "socket.keepalive.enable": true,
+                            "queue.buffering.max.messages": 10000000
+                        },
+                        "topicConf": {
+                            "request.required.acks": "all"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/configs/knexfile.js
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/configs/knexfile.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const migrationsDirectory = '/opt/central-ledger/migrations'
+const seedsDirectory = '/opt/central-ledger/seeds'
+
+const Config = require('/opt/central-ledger/src/lib/config')
+
+module.exports = {
+    client: 'mysql',
+    connection: Config.DATABASE_URI,
+    min: Config.DB_CONNECTION_POOL_MIN,
+    max: Config.DB_CONNECTION_POOL_MAX,
+    migrations: {
+        directory: migrationsDirectory,
+        tableName: 'migration',
+        stub: `${migrationsDirectory}/migration.template`
+    },
+    seeds: {
+        directory: seedsDirectory,
+        loadExtensions: ['.js']
+    }
+}

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/NOTES.txt
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http://{{ . }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "centralledger-handler-bulk-transfer-processing.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.internalPort }}
+{{- end }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/_helpers.tpl
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "centralledger-handler-bulk-transfer-processing.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "centralledger-handler-bulk-transfer-processing.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/config.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}
+  labels:
+      app: {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}
+      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+data:
+  default.json: {{ (tpl (.Files.Get "configs/default.json") . ) | quote }}
+  knexfile.js: {{ (tpl (.Files.Get "configs/knexfile.js") . ) | quote }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/deployment.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/deployment.yaml
@@ -1,5 +1,6 @@
 {{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+{{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -35,6 +36,13 @@ spec:
 {{- end }}
       {{- if .Values.init.enabled }}
       initContainers:
+        - name: {{ .Values.init.mongodb.name }}
+          image: {{ .Values.init.mongodb.repository }}:{{ .Values.init.mongodb.tag }}
+          imagePullPolicy: {{ .Values.init.mongodb.pullPolicy }}
+          command:
+            - sh
+            - "-c"
+            - {{ (.Values.init.mongodb.command | replace "$mongouri" $objStoreUri | quote }}
         {{- if eq .Values.config.db_type "postgres"}}
         - name: {{ .Values.init.psql.name }}
           image: {{ .Values.init.psql.repository }}:{{ .Values.init.psql.tag }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/deployment.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           command:
             - sh
             - "-c"
-            - {{ (.Values.init.mongodb.command | replace "$mongouri" $objStoreUri | quote }}
+            - {{ (.Values.init.mongodb.command | replace "$mongouri" $objStoreUri) | quote }}
         {{- if eq .Values.config.db_type "postgres"}}
         - name: {{ .Values.init.psql.name }}
           image: {{ .Values.init.psql.repository }}:{{ .Values.init.psql.tag }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/deployment.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/deployment.yaml
@@ -1,0 +1,113 @@
+{{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
+{{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}
+  labels:
+    app: {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+      {{- if .Values.metrics.enabled }}
+      annotations:
+        prometheus.io/port: "{{ .Values.containers.api.service.ports.api.internalPort }}"
+        prometheus.io/scrape: "true"
+      {{- end }}
+    spec:
+{{- if .Values.global.config.affinity }}
+      affinity:
+{{ toYaml .Values.global.config.affinity | indent 8 }}
+{{- end }}
+{{- if .Values.global.config.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.config.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.global.config.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.config.tolerations | indent 8 }}
+{{- end }}
+      {{- if .Values.init.enabled }}
+      initContainers:
+        {{- if eq .Values.config.db_type "postgres"}}
+        - name: {{ .Values.init.psql.name }}
+          image: {{ .Values.init.psql.repository }}:{{ .Values.init.psql.tag }}
+          imagePullPolicy: {{ .Values.init.psql.pullPolicy }}
+          env:
+          - name: "POSTGRES_URL"
+            value: "postgresql://{{ .Values.config.db_user }}:{{ .Values.config.db_password }}@{{ $dbHost }}:{{ .Values.config.db_port }}/{{ .Values.config.db_database }}?sslmode=disable"
+        {{- end }}
+        {{- if eq .Values.config.db_type "mysql"}}
+        - name: {{ .Values.init.mysql.name }}
+          image: {{ .Values.init.mysql.repository }}:{{ .Values.init.mysql.tag }}
+          imagePullPolicy: {{ .Values.init.mysql.pullPolicy }}
+          command:
+            - sh
+            - "-c"
+            - {{ (.Values.init.mysql.command | replace "$db_user" (print .Values.config.db_user) | replace "$db_password" (print .Values.config.db_password) | replace "$db_host" $dbHost | replace "$db_database" (print .Values.config.db_database) | replace "$db_port" (print .Values.config.db_port) )| quote }}
+        {{- end }}
+        - name: {{ .Values.init.kafka.name }}
+          image: {{ .Values.init.kafka.repository }}:{{ .Values.init.kafka.tag }}
+          imagePullPolicy: {{ .Values.init.kafka.pullPolicy }}
+          command:
+            - sh
+            - "-c"
+            - {{ (.Values.init.kafka.command | replace "$kafka_host" $kafkaHost | replace "$kafka_port" (printf "%.0f" .Values.config.kafka_port) ) | quote }}
+          env:
+          {{- range $envItem := .Values.init.kafka.env }}
+            - name: {{ $envItem.name }}
+              value: {{ $envItem.value }}
+          {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ template "centralledger-handler-bulk-transfer-processing.name" . }}
+          image: "{{ .Values.containers.api.image.repository }}:{{ .Values.containers.api.image.tag }}"
+          imagePullPolicy: {{ .Values.containers.api.image.pullPolicy }}
+          command: {{ .Values.containers.api.image.command }}
+          ports:
+          {{- range $port := .Values.containers.api.service.ports }}
+            - name: {{ $port.name }}
+              containerPort: {{ $port.internalPort }}
+          {{- end }}
+          {{- if .Values.containers.api.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.containers.api.readinessProbe.httpGet.path }}
+              port: {{ .Values.containers.api.service.ports.api.internalPort }}
+            initialDelaySeconds: {{ .Values.containers.api.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.containers.api.readinessProbe.periodSeconds }}
+          {{- end }}
+          {{- if .Values.containers.api.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.containers.api.livenessProbe.httpGet.path }}
+              port: {{ .Values.containers.api.service.ports.api.internalPort }}
+            initialDelaySeconds: {{ .Values.containers.api.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.containers.api.livenessProbe.periodSeconds }}
+          {{- end }}
+          env:
+            - name: CLEDG_DATABASE_URI
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}
+                  key: db.uri
+            - name: LOG_LEVEL
+              value: {{ .Values.config.log_level }}
+          volumeMounts:
+          - name: {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}-config-volume
+            mountPath: /opt/central-ledger/config
+      volumes:
+        - name: {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}-config-volume
+          configMap:
+            name: {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}
+            items:
+            - key: default.json
+              path: default.json
+            - key: knexfile.js
+              path: knexfile.js

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/endpoint.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/endpoint.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.service.external.enabled -}}
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}
+  labels:
+    app: {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subsets: 
+  -
+    addresses:
+      -
+        ip: {{ .Values.service.external.ip }}
+    ports:
+      -
+        port: {{ .Values.service.external.ports.api.externalPort }}
+        name: {{ .Values.service.external.ports.api.name }}
+{{- end -}}

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/ingress.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/ingress.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "centralledger-handler-bulk-transfer-processing.fullname" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}
+  labels:
+    app: {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    - host: {{ .Values.ingress.hosts.api }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.externalPath.api }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ .Values.containers.api.service.ports.api.externalPort }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/secret.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- $dbHost := (.Values.config.db_host | replace "$release_name" .Release.Name) }}
+{{- $dbURL := printf "%s://%s:%s@%s:%.0f/%s" .Values.config.db_type .Values.config.db_user .Values.config.db_password $dbHost .Values.config.db_port .Values.config.db_database -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}
+  labels:
+      app: {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}
+      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  # base64 encoded string
+  db.uri: {{ $dbURL | b64enc }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/service.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}
+  labels:
+    app: {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.service.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    {{- range $port := .Values.containers.api.service.ports }}
+    - port: {{ $port.externalPort }}
+      targetPort: {{ $port.internalPort }}
+      protocol: TCP
+      name: {{ $port.name }}
+    {{- end }}
+{{- if not .Values.service.external.enabled }}
+  selector:
+    app: {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}
+    release: {{ .Release.Name }}
+{{- end -}}

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
@@ -114,6 +114,12 @@ init:
     tag: latest
     pullPolicy: Always
     command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
+  mongodb:
+    name: wait-for-mongodb
+    repository: bitnami/mongodb
+    tag: latest
+    pullPolicy: Always
+    command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
 
 service:
   type: ClusterIP

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
@@ -1,0 +1,163 @@
+# Default values for centralledger-handler-bulk-transfer-processing.
+# This is a YAML-formatted file.
+
+# Declare global configurations
+global:
+  config:
+    ## Pod scheduling preferences.
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ##
+    affinity: {}
+
+    ## Node labels for pod assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+    nodeSelector: {}
+
+    ## Set toleration for schedular
+    ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    tolerations: []
+
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+containers:
+  api:
+    image:
+      repository: mojaloop/central-ledger
+      tag: v7.1.0
+      pullPolicy: Always
+      command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
+    service:
+      ports:
+        api:
+          name: http-api
+          externalPort: 80
+          internalPort: 3001
+    readinessProbe:
+      enabled: true
+      httpGet:
+        path: /health
+      initialDelaySeconds: 60
+      periodSeconds: 15
+    livenessProbe:
+      enabled: true
+      httpGet:
+        path: /health
+      initialDelaySeconds: 60
+      periodSeconds: 15
+
+## metric configuration for prometheus instrumentation
+metrics:
+  ## flag to enable/disable the metrics end-points
+  enabled: true
+  config:
+    timeout: 5000
+    prefix: moja_
+    defaultLabels:
+      serviceName: central-handler-bulkprocessing
+
+config:
+  ## Forensic Logging sidecar
+  # this is for Forensic Logging Sidecar
+  forensicloggingsidecar_disabled: false
+  forensicloggingsidecar_host: forensicloggingsidecar-ledger
+  forensicloggingsidecar_port: 5678
+
+  ## DB Configuration
+  # db_type can either be 'postgres' or 'mysql'. Ensure the correct DB is enabled and configured below: postgresql.enabled or mysql.enabled
+  db_type: 'mysql'
+  # db_driver can either be 'pg' or 'mysql'. Ensure the correct corresponding db_type above has been set.
+  db_driver: 'mysql'
+  db_host: '$release_name-centralledger-mysql'
+  db_port: 3306
+  db_user: central_ledger
+  db_password: oyMxgZChuu
+  db_database: central_ledger
+  db_connection_pool_min: 10
+  db_connection_pool_max: 30
+
+  ## MongoDB Configuration for Object Store
+  objstore_disabled: false
+  objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
+
+  ## Kafka Configuration
+  # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+  kafka_host: '$release_name-kafka'
+  kafka_port: 9092
+
+  ## Node Configuration
+  log_level: 'info'
+
+init:
+  enabled: true
+  kafka:
+    name: wait-for-kafka
+    repository: solsson/kafka
+    tag: latest
+    pullPolicy: Always
+    command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
+    env: {}
+    ## Env example
+    # env:
+    #   envItem1:
+    #     name: hello
+    #     value: world
+    #
+  psql:
+    name: wait-for-postgres
+    repository: bowerswilkins/awaitpostgres
+    tag: latest
+    pullPolicy: Always
+  mysql:
+    name: wait-for-mysql
+    repository: mysql
+    tag: latest
+    pullPolicy: Always
+    command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
+
+service:
+  type: ClusterIP
+
+  annotations: {}
+
+  # This allows one to point the service to an external backend.
+  # This is useful for local development where one wishes to hijack
+  # the communication from the service to the node layer and point
+  # to a specific endpoint (IP, Port, etc).
+  external:
+    enabled: false
+    # 10.0.2.2 is the magic IP for the host on virtualbox's network
+    ip: 10.0.2.2
+    ports:
+      api:
+        name: http-api
+        externalPort: 3001
+
+ingress:
+  enabled: true
+  type: http
+  externalPath:
+    api: /
+  # Used to create an Ingress record.
+  hosts:
+    api: central-ledger-transfer-bulkprocessing.local
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: '/'
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v7.1.0
+      tag: v7.1.2
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
     service:

--- a/bulk-centralledger/requirements.yaml
+++ b/bulk-centralledger/requirements.yaml
@@ -1,9 +1,9 @@
 # requirements.yaml
 dependencies:
-  - name: centralledger-handler-bulk-transfer-prepare
-    version: 7.1.0
-    repository: "file://./chart-handler-bulk-transfer-prepare"
-    condition: centralledger-handler-bulk-transfer-prepare.enabled
+- name: centralledger-handler-bulk-transfer-prepare
+  version: 7.1.0
+  repository: "file://./chart-handler-bulk-transfer-prepare"
+  condition: centralledger-handler-bulk-transfer-prepare.enabled
 - name: centralledger-handler-bulk-transfer-fulfil
   version: 7.1.0
   repository: "file://./chart-handler-bulk-transfer-fulfil"

--- a/bulk-centralledger/requirements.yaml
+++ b/bulk-centralledger/requirements.yaml
@@ -1,0 +1,14 @@
+# requirements.yaml
+dependencies:
+  - name: centralledger-handler-bulk-transfer-prepare
+    version: 7.1.0
+    repository: "file://./chart-handler-bulk-transfer-prepare"
+    condition: centralledger-handler-bulk-transfer-prepare.enabled
+- name: centralledger-handler-bulk-transfer-fulfil
+  version: 7.1.0
+  repository: "file://./chart-handler-bulk-transfer-fulfil"
+  condition: centralledger-handler-bulk-transfer-fulfil.enabled
+- name: centralledger-handler-bulk-transfer-processing
+  version: 7.1.0
+  repository: "file://./chart-handler-bulk-transfer-processing"
+  condition: centralledger-handler-bulk-transfer-processing.enabled

--- a/bulk-centralledger/requirements.yaml
+++ b/bulk-centralledger/requirements.yaml
@@ -1,14 +1,14 @@
 # requirements.yaml
 dependencies:
-- name: centralledger-handler-bulk-transfer-prepare
+- name: cl-handler-bulk-transfer-prepare
   version: 7.1.0
   repository: "file://./chart-handler-bulk-transfer-prepare"
-  condition: centralledger-handler-bulk-transfer-prepare.enabled
-- name: centralledger-handler-bulk-transfer-fulfil
+  condition: cl-handler-bulk-transfer-prepare.enabled
+- name: cl-handler-bulk-transfer-fulfil
   version: 7.1.0
   repository: "file://./chart-handler-bulk-transfer-fulfil"
-  condition: centralledger-handler-bulk-transfer-fulfil.enabled
-- name: centralledger-handler-bulk-transfer-processing
+  condition: cl-handler-bulk-transfer-fulfil.enabled
+- name: cl-handler-bulk-transfer-processing
   version: 7.1.0
   repository: "file://./chart-handler-bulk-transfer-processing"
-  condition: centralledger-handler-bulk-transfer-processing.enabled
+  condition: cl-handler-bulk-transfer-processing.enabled

--- a/bulk-centralledger/values.yaml
+++ b/bulk-centralledger/values.yaml
@@ -17,7 +17,7 @@ global:
     tolerations: []
 
 # Declare variables to be passed into your templates.
-centralledger-handler-bulk-transfer-prepare:
+cl-handler-bulk-transfer-prepare:
   enabled: true
   # Default values for centralledger-handler-bulk-transfer-prepare.
   # This is a YAML-formatted file.
@@ -171,7 +171,7 @@ centralledger-handler-bulk-transfer-prepare:
     #  cpu: 100m
   #  memory: 128Mi
 
-centralledger-handler-bulk-transfer-fulfil:
+cl-handler-bulk-transfer-fulfil:
   enabled: true
   # Default values for centralledger-handler-bulk-transfer-fulfil.
   # This is a YAML-formatted file.
@@ -325,7 +325,7 @@ centralledger-handler-bulk-transfer-fulfil:
     #  cpu: 100m
   #  memory: 128Mi
 
-centralledger-handler-bulk-transfer-processing:
+cl-handler-bulk-transfer-processing:
   enabled: true
   # Default values for centralledger-handler-bulk-transfer-processing.
   # This is a YAML-formatted file.
@@ -335,7 +335,7 @@ centralledger-handler-bulk-transfer-processing:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v7.1.0
+        tag: v7.1.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
       service:

--- a/bulk-centralledger/values.yaml
+++ b/bulk-centralledger/values.yaml
@@ -1,0 +1,463 @@
+# Default values for bulk-centralledger.
+# This is a YAML-formatted file.
+# Declare global configurations
+global:
+  config:
+    ## Pod scheduling preferences.
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ##
+    affinity: {}
+
+    ## Node labels for pod assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+    nodeSelector: {}
+
+    ## Set toleration for schedular
+    ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    tolerations: []
+
+# Declare variables to be passed into your templates.
+centralledger-handler-bulk-transfer-prepare:
+  enabled: true
+  # Default values for centralledger-handler-bulk-transfer-prepare.
+  # This is a YAML-formatted file.
+  # Declare variables to be passed into your templates.
+  replicaCount: 1
+  containers:
+    api:
+      image:
+        repository: mojaloop/central-ledger
+        tag: v7.1.2
+        pullPolicy: Always
+        command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
+      service:
+        ports:
+          api:
+            name: http-api
+            externalPort: 80
+            internalPort: 3001
+      readinessProbe:
+        enabled: true
+        httpGet:
+          path: /health
+        initialDelaySeconds: 60
+        periodSeconds: 15
+      livenessProbe:
+        enabled: true
+        httpGet:
+          path: /health
+        initialDelaySeconds: 60
+        periodSeconds: 15
+
+  ## metric configuration for prometheus instrumentation
+  metrics:
+    ## flag to enable/disable the metrics end-points
+    enabled: true
+    config:
+      timeout: 5000
+      prefix: moja_
+      defaultLabels:
+        serviceName: central-handler-bulkprepare
+
+  config:
+    ## Forensic Logging sidecar
+    # this is for Forensic Logging Sidecar
+    forensicloggingsidecar_disabled: false
+    forensicloggingsidecar_host: forensicloggingsidecar-ledger
+    forensicloggingsidecar_port: 5678
+
+    ## DB Configuration
+    # db_type can either be 'postgres' or 'mysql'. Ensure the correct DB is enabled and configured below: postgresql.enabled or mysql.enabled
+    db_type: 'mysql'
+    # db_driver can either be 'pg' or 'mysql'. Ensure the correct corresponding db_type above has been set.
+    db_driver: 'mysql'
+    db_host: '$release_name-centralledger-mysql'
+    db_port: 3306
+    db_user: central_ledger
+    db_password: oyMxgZChuu
+    db_database: central_ledger
+    db_connection_pool_min: 10
+    db_connection_pool_max: 30
+
+    ## MongoDB Configuration for Object Store
+    objstore_disabled: false
+    objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
+
+    ## Kafka Configuration
+    # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+    kafka_host: '$release_name-kafka'
+    kafka_port: 9092
+
+    ## Node Configuration
+    log_level: 'info'
+
+  init:
+    enabled: true
+    kafka:
+      name: wait-for-kafka
+      repository: solsson/kafka
+      tag: latest
+      pullPolicy: Always
+      command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
+      env: {}
+      ## Env example
+      # env:
+      #   envItem1:
+      #     name: hello
+      #     value: world
+      #
+    psql:
+      name: wait-for-postgres
+      repository: bowerswilkins/awaitpostgres
+      tag: latest
+      pullPolicy: Always
+    mysql:
+      name: wait-for-mysql
+      repository: mysql
+      tag: latest
+      pullPolicy: Always
+      command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
+
+  service:
+    type: ClusterIP
+
+    annotations: {}
+
+    # This allows one to point the service to an external backend.
+    # This is useful for local development where one wishes to hijack
+    # the communication from the service to the node layer and point
+    # to a specific endpoint (IP, Port, etc).
+    external:
+      enabled: false
+      # 10.0.2.2 is the magic IP for the host on virtualbox's network
+      ip: 10.0.2.2
+      ports:
+        api:
+          name: http-api
+          externalPort: 3001
+
+  ingress:
+    enabled: true
+    type: http
+    externalPath:
+      api: /
+    # Used to create an Ingress record.
+    hosts:
+      api: central-ledger-transfer-bulkprepare.local
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: '/'
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+  #  memory: 128Mi
+
+centralledger-handler-bulk-transfer-fulfil:
+  enabled: true
+  # Default values for centralledger-handler-bulk-transfer-fulfil.
+  # This is a YAML-formatted file.
+  # Declare variables to be passed into your templates.
+  replicaCount: 1
+  containers:
+    api:
+      image:
+        repository: mojaloop/central-ledger
+        tag: v7.1.2
+        pullPolicy: Always
+        command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
+      service:
+        ports:
+          api:
+            name: http-api
+            externalPort: 80
+            internalPort: 3001
+      readinessProbe:
+        enabled: true
+        httpGet:
+          path: /health
+        initialDelaySeconds: 60
+        periodSeconds: 15
+      livenessProbe:
+        enabled: true
+        httpGet:
+          path: /health
+        initialDelaySeconds: 60
+        periodSeconds: 15
+
+  ## metric configuration for prometheus instrumentation
+  metrics:
+    ## flag to enable/disable the metrics end-points
+    enabled: true
+    config:
+      timeout: 5000
+      prefix: moja_
+      defaultLabels:
+        serviceName: central-handler-bulkfulfil
+
+  config:
+    ## Forensic Logging sidecar
+    # this is for Forensic Logging Sidecar
+    forensicloggingsidecar_disabled: false
+    forensicloggingsidecar_host: forensicloggingsidecar-ledger
+    forensicloggingsidecar_port: 5678
+
+    ## DB Configuration
+    # db_type can either be 'postgres' or 'mysql'. Ensure the correct DB is enabled and configured below: postgresql.enabled or mysql.enabled
+    db_type: 'mysql'
+    # db_driver can either be 'pg' or 'mysql'. Ensure the correct corresponding db_type above has been set.
+    db_driver: 'mysql'
+    db_host: '$release_name-centralledger-mysql'
+    db_port: 3306
+    db_user: central_ledger
+    db_password: oyMxgZChuu
+    db_database: central_ledger
+    db_connection_pool_min: 10
+    db_connection_pool_max: 30
+
+    ## MongoDB Configuration for Object Store
+    objstore_disabled: false
+    objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
+
+    ## Kafka Configuration
+    # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+    kafka_host: '$release_name-kafka'
+    kafka_port: 9092
+
+    ## Node Configuration
+    log_level: 'info'
+
+  init:
+    enabled: true
+    kafka:
+      name: wait-for-kafka
+      repository: solsson/kafka
+      tag: latest
+      pullPolicy: Always
+      command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
+      env: {}
+      ## Env example
+      # env:
+      #   envItem1:
+      #     name: hello
+      #     value: world
+      #
+    psql:
+      name: wait-for-postgres
+      repository: bowerswilkins/awaitpostgres
+      tag: latest
+      pullPolicy: Always
+    mysql:
+      name: wait-for-mysql
+      repository: mysql
+      tag: latest
+      pullPolicy: Always
+      command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
+
+  service:
+    type: ClusterIP
+
+    annotations: {}
+
+    # This allows one to point the service to an external backend.
+    # This is useful for local development where one wishes to hijack
+    # the communication from the service to the node layer and point
+    # to a specific endpoint (IP, Port, etc).
+    external:
+      enabled: false
+      # 10.0.2.2 is the magic IP for the host on virtualbox's network
+      ip: 10.0.2.2
+      ports:
+        api:
+          name: http-api
+          externalPort: 3001
+
+  ingress:
+    enabled: true
+    type: http
+    externalPath:
+      api: /
+    # Used to create an Ingress record.
+    hosts:
+      api: central-ledger-transfer-bulkfulfil.local
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: '/'
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+  #  memory: 128Mi
+
+centralledger-handler-bulk-transfer-processing:
+  enabled: true
+  # Default values for centralledger-handler-bulk-transfer-processing.
+  # This is a YAML-formatted file.
+  # Declare variables to be passed into your templates.
+  replicaCount: 1
+  containers:
+    api:
+      image:
+        repository: mojaloop/central-ledger
+        tag: v7.1.0
+        pullPolicy: Always
+        command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
+      service:
+        ports:
+          api:
+            name: http-api
+            externalPort: 80
+            internalPort: 3001
+      readinessProbe:
+        enabled: true
+        httpGet:
+          path: /health
+        initialDelaySeconds: 60
+        periodSeconds: 15
+      livenessProbe:
+        enabled: true
+        httpGet:
+          path: /health
+        initialDelaySeconds: 60
+        periodSeconds: 15
+
+  ## metric configuration for prometheus instrumentation
+  metrics:
+    ## flag to enable/disable the metrics end-points
+    enabled: true
+    config:
+      timeout: 5000
+      prefix: moja_
+      defaultLabels:
+        serviceName: central-handler-bulkprocessing
+
+  config:
+    ## Forensic Logging sidecar
+    # this is for Forensic Logging Sidecar
+    forensicloggingsidecar_disabled: false
+    forensicloggingsidecar_host: forensicloggingsidecar-ledger
+    forensicloggingsidecar_port: 5678
+
+    ## DB Configuration
+    # db_type can either be 'postgres' or 'mysql'. Ensure the correct DB is enabled and configured below: postgresql.enabled or mysql.enabled
+    db_type: 'mysql'
+    # db_driver can either be 'pg' or 'mysql'. Ensure the correct corresponding db_type above has been set.
+    db_driver: 'mysql'
+    db_host: '$release_name-centralledger-mysql'
+    db_port: 3306
+    db_user: central_ledger
+    db_password: oyMxgZChuu
+    db_database: central_ledger
+    db_connection_pool_min: 10
+    db_connection_pool_max: 30
+
+    ## MongoDB Configuration for Object Store
+    objstore_disabled: false
+    objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
+
+    ## Kafka Configuration
+    # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+    kafka_host: '$release_name-kafka'
+    kafka_port: 9092
+
+    ## Node Configuration
+    log_level: 'info'
+
+  init:
+    enabled: true
+    kafka:
+      name: wait-for-kafka
+      repository: solsson/kafka
+      tag: latest
+      pullPolicy: Always
+      command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
+      env: {}
+      ## Env example
+      # env:
+      #   envItem1:
+      #     name: hello
+      #     value: world
+      #
+    psql:
+      name: wait-for-postgres
+      repository: bowerswilkins/awaitpostgres
+      tag: latest
+      pullPolicy: Always
+    mysql:
+      name: wait-for-mysql
+      repository: mysql
+      tag: latest
+      pullPolicy: Always
+      command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
+
+  service:
+    type: ClusterIP
+
+    annotations: {}
+
+    # This allows one to point the service to an external backend.
+    # This is useful for local development where one wishes to hijack
+    # the communication from the service to the node layer and point
+    # to a specific endpoint (IP, Port, etc).
+    external:
+      enabled: false
+      # 10.0.2.2 is the magic IP for the host on virtualbox's network
+      ip: 10.0.2.2
+      ports:
+        api:
+          name: http-api
+          externalPort: 3001
+
+  ingress:
+    enabled: true
+    type: http
+    externalPath:
+      api: /
+    # Used to create an Ingress record.
+    hosts:
+      api: central-ledger-transfer-bulkprocessing.local
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: '/'
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+  #  memory: 128Mi
+

--- a/bulk-centralledger/values.yaml
+++ b/bulk-centralledger/values.yaml
@@ -117,6 +117,12 @@ centralledger-handler-bulk-transfer-prepare:
       tag: latest
       pullPolicy: Always
       command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
+    mongodb:
+      name: wait-for-mongodb
+      repository: bitnami/mongodb
+      tag: latest
+      pullPolicy: Always
+      command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
 
   service:
     type: ClusterIP
@@ -265,6 +271,12 @@ centralledger-handler-bulk-transfer-fulfil:
       tag: latest
       pullPolicy: Always
       command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
+    mongodb:
+      name: wait-for-mongodb
+      repository: bitnami/mongodb
+      tag: latest
+      pullPolicy: Always
+      command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
 
   service:
     type: ClusterIP
@@ -413,6 +425,12 @@ centralledger-handler-bulk-transfer-processing:
       tag: latest
       pullPolicy: Always
       command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
+    mongodb:
+      name: wait-for-mongodb
+      repository: bitnami/mongodb
+      tag: latest
+      pullPolicy: Always
+      command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
 
   service:
     type: ClusterIP
@@ -460,4 +478,3 @@ centralledger-handler-bulk-transfer-processing:
     # requests:
     #  cpu: 100m
   #  memory: 128Mi
-

--- a/central/Chart.yaml
+++ b/central/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central Helm chart for Kubernetes
 name: central
-version: 6.3.0
-appVersion: "6.2.5"
+version: 7.1.0
+appVersion: "7.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/central/Chart.yaml
+++ b/central/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central Helm chart for Kubernetes
 name: central
-version: 7.1.0
-appVersion: "7.1.0"
+version: 7.1.2
+appVersion: "7.1.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/central/requirements.yaml
+++ b/central/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: centralledger
-  version: 7.1.0
+  version: 7.1.2
   repository: "file://../centralledger"
   condition: centralledger.enabled
 ## Deprecated - to be removed shortly

--- a/central/requirements.yaml
+++ b/central/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: centralledger
-  version: 6.2.5
+  version: 7.1.0
   repository: "file://../centralledger"
   condition: centralledger.enabled
 ## Deprecated - to be removed shortly

--- a/central/requirements.yaml
+++ b/central/requirements.yaml
@@ -14,6 +14,6 @@ dependencies:
   repository: "file://../centralsettlement"
   condition: centralsettlement.enabled
 - name: centraleventprocessor
-  version: 6.3.0
+  version: 7.1.0
   repository: "file://../centraleventprocessor"
   condition: centraleventprocessor.enabled

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -35,7 +35,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v7.1.0
+          tag: v7.1.2
           pullPolicy: Always
           command: '["node", "src/api/index.js"]'
         service:
@@ -152,7 +152,6 @@ centralledger:
       #  cpu: 100m
       #  memory: 128Mi
 
-
   centralledger-handler-transfer-prepare:
     # Default values for central-ledger.
     # This is a YAML-formatted file.
@@ -164,7 +163,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v7.1.0
+          tag: v7.1.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
         service:
@@ -290,7 +289,6 @@ centralledger:
       #  cpu: 100m
       #  memory: 128Mi
 
-
   centralledger-handler-transfer-position:
     # Default values for central-ledger.
     # This is a YAML-formatted file.
@@ -302,7 +300,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v7.1.0
+          tag: v7.1.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--position"]'
         service:
@@ -439,7 +437,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v7.1.0
+          tag: v7.1.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--get"]'
         service:
@@ -565,7 +563,6 @@ centralledger:
       #  cpu: 100m
       #  memory: 128Mi
 
-
   centralledger-handler-transfer-fulfil:
     # Default values for central-ledger.
     # This is a YAML-formatted file.
@@ -577,7 +574,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v7.1.0
+          tag: v7.1.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
         service:
@@ -714,7 +711,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v7.1.0
+          tag: v7.1.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
         service:
@@ -851,7 +848,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v7.1.0
+          tag: v7.1.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--admin"]'
         service:

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -2060,7 +2060,7 @@ centraleventprocessor:
   replicaCount: 1
   image:
     repository: mojaloop/central-event-processor
-    tag: v5.5.0
+    tag: v7.1.0
     pullPolicy: Always
 
   init:

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -35,7 +35,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v6.2.5
+          tag: v7.1.0
           pullPolicy: Always
           command: '["node", "src/api/index.js"]'
         service:
@@ -164,7 +164,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v6.2.5
+          tag: v7.1.0
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
         service:
@@ -302,7 +302,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v6.2.5
+          tag: v7.1.0
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--position"]'
         service:
@@ -439,7 +439,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v6.2.5
+          tag: v7.1.0
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--get"]'
         service:
@@ -577,7 +577,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v6.2.5
+          tag: v7.1.0
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
         service:
@@ -714,7 +714,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v6.2.5
+          tag: v7.1.0
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
         service:
@@ -851,7 +851,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v6.2.5
+          tag: v7.1.0
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--admin"]'
         service:

--- a/centraleventprocessor/Chart.yaml
+++ b/centraleventprocessor/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central Event Processor for Mojaloop
 name: centraleventprocessor
-version: 6.3.0
-appVersion: "5.5.0"
+version: 7.1.0
+appVersion: "7.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centraleventprocessor/values.yaml
+++ b/centraleventprocessor/values.yaml
@@ -22,7 +22,7 @@ global:
 replicaCount: 1
 image:
   repository: mojaloop/central-event-processor
-  tag: v5.5.0
+  tag: v7.1.0
   pullPolicy: Always
 
 init:

--- a/centralledger/Chart.yaml
+++ b/centralledger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Helm chart for Kubernetes
 name: centralledger
-version: 6.2.5
-appVersion: "6.2.5"
+version: 7.1.0
+appVersion: "7.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/Chart.yaml
+++ b/centralledger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Helm chart for Kubernetes
 name: centralledger
-version: 7.1.0
-appVersion: "7.1.0"
+version: 7.1.2
+appVersion: "7.1.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-admin-transfer/Chart.yaml
+++ b/centralledger/chart-handler-admin-transfer/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-admin-transfer
-version: 7.1.0
-appVersion: "7.1.0"
+version: 7.1.2
+appVersion: "7.1.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-admin-transfer/Chart.yaml
+++ b/centralledger/chart-handler-admin-transfer/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-admin-transfer
-version: 6.2.5
-appVersion: "6.2.5"
+version: 7.1.0
+appVersion: "7.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-admin-transfer/configs/default.json
+++ b/centralledger/chart-handler-admin-transfer/configs/default.json
@@ -1,4 +1,5 @@
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+{{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
 {
     "PORT": {{ .Values.containers.api.service.ports.api.internalPort }},
     "HOSTNAME": "{{ .Values.ingress.hosts.api }}",
@@ -17,6 +18,10 @@
     "DB_CONNECTION": {
         "POOL_MIN": {{ .Values.config.db_connection_pool_min }},
         "POOL_MAX": {{ .Values.config.db_connection_pool_max }}
+    },
+    "MONGODB": {
+        "DISABLED": {{ .Values.config.objstore_disabled }},
+        "URI": {{ (default .Values.config.objstore_uri $objStoreUri) | quote }}
     },
     "HANDLERS": {
         "DISABLED": false,

--- a/centralledger/chart-handler-admin-transfer/values.yaml
+++ b/centralledger/chart-handler-admin-transfer/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v6.2.5
+      tag: v7.1.0
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--admin"]'
     service:

--- a/centralledger/chart-handler-admin-transfer/values.yaml
+++ b/centralledger/chart-handler-admin-transfer/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v7.1.0
+      tag: v7.1.2
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--admin"]'
     service:
@@ -75,6 +75,10 @@ config:
   db_database: central_ledger
   db_connection_pool_min: 10
   db_connection_pool_max: 30
+
+  ## MongoDB Configuration for Object Store
+  objstore_disabled: true
+  objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
 
   ## Kafka Configuration
   # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.

--- a/centralledger/chart-handler-timeout/Chart.yaml
+++ b/centralledger/chart-handler-timeout/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Timeout Handler Helm chart for Kubernetes
 name: centralledger-handler-timeout
-version: 7.1.0
-appVersion: "7.1.0"
+version: 7.1.2
+appVersion: "7.1.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-timeout/Chart.yaml
+++ b/centralledger/chart-handler-timeout/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Timeout Handler Helm chart for Kubernetes
 name: centralledger-handler-timeout
-version: 6.2.5
-appVersion: "6.2.5"
+version: 7.1.0
+appVersion: "7.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-timeout/configs/default.json
+++ b/centralledger/chart-handler-timeout/configs/default.json
@@ -1,4 +1,5 @@
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+{{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
 {
     "PORT": {{ .Values.containers.api.service.ports.api.internalPort }},
     "HOSTNAME": "{{ .Values.ingress.hosts.api }}",
@@ -17,6 +18,10 @@
     "DB_CONNECTION": {
         "POOL_MIN": {{ .Values.config.db_connection_pool_min }},
         "POOL_MAX": {{ .Values.config.db_connection_pool_max }}
+    },
+    "MONGODB": {
+        "DISABLED": {{ .Values.config.objstore_disabled }},
+        "URI": {{ (default .Values.config.objstore_uri $objStoreUri) | quote }}
     },
     "HANDLERS": {
         "DISABLED": false,

--- a/centralledger/chart-handler-timeout/values.yaml
+++ b/centralledger/chart-handler-timeout/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v6.2.5
+      tag: v7.1.0
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
     service:

--- a/centralledger/chart-handler-timeout/values.yaml
+++ b/centralledger/chart-handler-timeout/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v7.1.0
+      tag: v7.1.2
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
     service:
@@ -75,6 +75,10 @@ config:
   db_database: central_ledger
   db_connection_pool_min: 10
   db_connection_pool_max: 30
+
+  ## MongoDB Configuration for Object Store
+  objstore_disabled: true
+  objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
 
   ## Kafka Configuration
   # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.

--- a/centralledger/chart-handler-transfer-fulfil/Chart.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Fulfil Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-fulfil
-version: 7.1.0
-appVersion: "7.1.0"
+version: 7.1.2
+appVersion: "7.1.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-fulfil/Chart.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Fulfil Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-fulfil
-version: 6.2.5
-appVersion: "6.2.5"
+version: 7.1.0
+appVersion: "7.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-fulfil/configs/default.json
+++ b/centralledger/chart-handler-transfer-fulfil/configs/default.json
@@ -1,4 +1,5 @@
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+{{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
 {
     "PORT": {{ .Values.containers.api.service.ports.api.internalPort }},
     "HOSTNAME": "{{ .Values.ingress.hosts.api }}",
@@ -17,6 +18,10 @@
     "DB_CONNECTION": {
         "POOL_MIN": {{ .Values.config.db_connection_pool_min }},
         "POOL_MAX": {{ .Values.config.db_connection_pool_max }}
+    },
+    "MONGODB": {
+        "DISABLED": {{ .Values.config.objstore_disabled }},
+        "URI": {{ (default .Values.config.objstore_uri $objStoreUri) | quote }}
     },
     "HANDLERS": {
         "DISABLED": false,

--- a/centralledger/chart-handler-transfer-fulfil/values.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v7.1.0
+      tag: v7.1.2
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
     service:
@@ -75,6 +75,10 @@ config:
   db_database: central_ledger
   db_connection_pool_min: 10
   db_connection_pool_max: 30
+
+  ## MongoDB Configuration for Object Store
+  objstore_disabled: true
+  objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
 
   ## Kafka Configuration
   # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.

--- a/centralledger/chart-handler-transfer-fulfil/values.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v6.2.5
+      tag: v7.1.0
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
     service:

--- a/centralledger/chart-handler-transfer-get/Chart.yaml
+++ b/centralledger/chart-handler-transfer-get/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Get Transfer Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-get
-version: 7.1.0
-appVersion: "7.1.0"
+version: 7.1.2
+appVersion: "7.1.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-get/Chart.yaml
+++ b/centralledger/chart-handler-transfer-get/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Get Transfer Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-get
-version: 6.2.5
-appVersion: "6.2.5"
+version: 7.1.0
+appVersion: "7.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-get/configs/default.json
+++ b/centralledger/chart-handler-transfer-get/configs/default.json
@@ -1,4 +1,5 @@
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+{{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
 {
     "PORT": {{ .Values.containers.api.service.ports.api.internalPort }},
     "HOSTNAME": "{{ .Values.ingress.hosts.api }}",
@@ -17,6 +18,10 @@
     "DB_CONNECTION": {
         "POOL_MIN": {{ .Values.config.db_connection_pool_min }},
         "POOL_MAX": {{ .Values.config.db_connection_pool_max }}
+    },
+    "MONGODB": {
+        "DISABLED": {{ .Values.config.objstore_disabled }},
+        "URI": {{ (default .Values.config.objstore_uri $objStoreUri) | quote }}
     },
     "HANDLERS": {
         "DISABLED": false,

--- a/centralledger/chart-handler-transfer-get/values.yaml
+++ b/centralledger/chart-handler-transfer-get/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v6.2.5
+      tag: v7.1.0
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--get"]'
     service:

--- a/centralledger/chart-handler-transfer-get/values.yaml
+++ b/centralledger/chart-handler-transfer-get/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v7.1.0
+      tag: v7.1.2
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--get"]'
     service:
@@ -75,6 +75,10 @@ config:
   db_database: central_ledger
   db_connection_pool_min: 10
   db_connection_pool_max: 30
+
+  ## MongoDB Configuration for Object Store
+  objstore_disabled: true
+  objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
 
   ## Kafka Configuration
   # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.

--- a/centralledger/chart-handler-transfer-position/Chart.yaml
+++ b/centralledger/chart-handler-transfer-position/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Position Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-position
-version: 6.2.5
-appVersion: "6.2.5"
+version: 7.1.0
+appVersion: "7.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-position/Chart.yaml
+++ b/centralledger/chart-handler-transfer-position/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Position Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-position
-version: 7.1.0
-appVersion: "7.1.0"
+version: 7.1.2
+appVersion: "7.1.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-position/configs/default.json
+++ b/centralledger/chart-handler-transfer-position/configs/default.json
@@ -1,4 +1,5 @@
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+{{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
 {
     "PORT": {{ .Values.containers.api.service.ports.api.internalPort }},
     "HOSTNAME": "{{ .Values.ingress.hosts.api }}",
@@ -17,6 +18,10 @@
     "DB_CONNECTION": {
         "POOL_MIN": {{ .Values.config.db_connection_pool_min }},
         "POOL_MAX": {{ .Values.config.db_connection_pool_max }}
+    },
+    "MONGODB": {
+        "DISABLED": {{ .Values.config.objstore_disabled }},
+        "URI": {{ (default .Values.config.objstore_uri $objStoreUri) | quote }}
     },
     "HANDLERS": {
         "DISABLED": false,

--- a/centralledger/chart-handler-transfer-position/values.yaml
+++ b/centralledger/chart-handler-transfer-position/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v6.2.5
+      tag: v7.1.0
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--position"]'
     service:

--- a/centralledger/chart-handler-transfer-position/values.yaml
+++ b/centralledger/chart-handler-transfer-position/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v7.1.0
+      tag: v7.1.2
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--position"]'
     service:
@@ -75,6 +75,10 @@ config:
   db_database: central_ledger
   db_connection_pool_min: 10
   db_connection_pool_max: 30
+
+  ## MongoDB Configuration for Object Store
+  objstore_disabled: true
+  objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
 
   ## Kafka Configuration
   # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.

--- a/centralledger/chart-handler-transfer-prepare/Chart.yaml
+++ b/centralledger/chart-handler-transfer-prepare/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-prepare
-version: 7.1.0
-appVersion: "7.1.0"
+version: 7.1.2
+appVersion: "7.1.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-prepare/Chart.yaml
+++ b/centralledger/chart-handler-transfer-prepare/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-prepare
-version: 6.2.5
-appVersion: "6.2.5"
+version: 7.1.0
+appVersion: "7.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-prepare/configs/default.json
+++ b/centralledger/chart-handler-transfer-prepare/configs/default.json
@@ -1,4 +1,5 @@
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+{{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
 {
     "PORT": {{ .Values.containers.api.service.ports.api.internalPort }},
     "HOSTNAME": "{{ .Values.ingress.hosts.api }}",
@@ -17,6 +18,10 @@
     "DB_CONNECTION": {
         "POOL_MIN": {{ .Values.config.db_connection_pool_min }},
         "POOL_MAX": {{ .Values.config.db_connection_pool_max }}
+    },
+    "MONGODB": {
+        "DISABLED": {{ .Values.config.objstore_disabled }},
+        "URI": {{ (default .Values.config.objstore_uri $objStoreUri) | quote }}
     },
     "HANDLERS": {
         "DISABLED": false,

--- a/centralledger/chart-handler-transfer-prepare/values.yaml
+++ b/centralledger/chart-handler-transfer-prepare/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v6.2.5
+      tag: v7.1.0
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
     service:

--- a/centralledger/chart-handler-transfer-prepare/values.yaml
+++ b/centralledger/chart-handler-transfer-prepare/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v7.1.0
+      tag: v7.1.2
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
     service:
@@ -75,6 +75,10 @@ config:
   db_database: central_ledger
   db_connection_pool_min: 10
   db_connection_pool_max: 30
+
+  ## MongoDB Configuration for Object Store
+  objstore_disabled: true
+  objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
 
   ## Kafka Configuration
   # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.

--- a/centralledger/chart-service/Chart.yaml
+++ b/centralledger/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Service Helm chart for Kubernetes
 name: centralledger-service
-version: 6.2.5
-appVersion: "6.2.5"
+version: 7.1.0
+appVersion: "7.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-service/Chart.yaml
+++ b/centralledger/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Service Helm chart for Kubernetes
 name: centralledger-service
-version: 7.1.0
-appVersion: "7.1.0"
+version: 7.1.2
+appVersion: "7.1.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-service/configs/default.json
+++ b/centralledger/chart-service/configs/default.json
@@ -1,4 +1,5 @@
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
+{{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
 {
     "PORT": {{ .Values.containers.api.service.ports.api.internalPort }},
     "HOSTNAME": "{{ .Values.ingress.hosts.api }}",
@@ -17,6 +18,10 @@
     "DB_CONNECTION": {
         "POOL_MIN": {{ .Values.config.db_connection_pool_min }},
         "POOL_MAX": {{ .Values.config.db_connection_pool_max }}
+    },
+    "MONGODB": {
+        "DISABLED": {{ .Values.config.objstore_disabled }},
+        "URI": {{ (default .Values.config.objstore_uri $objStoreUri) | quote }}
     },
     "HANDLERS": {
         "DISABLED": true,

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v7.1.0
+      tag: v7.1.2
       pullPolicy: Always
       command: '["node", "src/api/index.js"]'
     service:
@@ -75,6 +75,10 @@ config:
   db_database: central_ledger
   db_connection_pool_min: 10
   db_connection_pool_max: 30
+
+  ## MongoDB Configuration for Object Store
+  objstore_disabled: true
+  objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
 
   ## Kafka Configuration
   # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v6.2.5
+      tag: v7.1.0
       pullPolicy: Always
       command: '["node", "src/api/index.js"]'
     service:

--- a/centralledger/requirements.yaml
+++ b/centralledger/requirements.yaml
@@ -1,31 +1,31 @@
 # requirements.yaml
 dependencies:
 - name: centralledger-service
-  version: 7.1.0
+  version: 7.1.2
   repository: "file://./chart-service"
   condition: centralledger-service.enabled
 - name: centralledger-handler-transfer-prepare
-  version: 7.1.0
+  version: 7.1.2
   repository: "file://./chart-handler-transfer-prepare"
   condition: centralledger-handler-transfer-prepare.enabled
 - name: centralledger-handler-transfer-position
-  version: 7.1.0
+  version: 7.1.2
   repository: "file://./chart-handler-transfer-position"
   condition: centralledger-handler-transfer-position.enabled
 - name: centralledger-handler-transfer-get
-  version: 7.1.0
+  version: 7.1.2
   repository: "file://./chart-handler-transfer-get"
   condition: centralledger-handler-transfer-get.enabled
 - name: centralledger-handler-transfer-fulfil
-  version: 7.1.0
+  version: 7.1.2
   repository: "file://./chart-handler-transfer-fulfil"
   condition: centralledger-handler-transfer-fulfil.enabled
 - name: centralledger-handler-timeout
-  version: 7.1.0
+  version: 7.1.2
   repository: "file://./chart-handler-timeout"
   condition: centralledger-handler-timeout.enabled
 - name: centralledger-handler-admin-transfer
-  version: 7.1.0
+  version: 7.1.2
   repository: "file://./chart-handler-admin-transfer"
   condition: centralledger-handler-transfer-get.enabled
 - name: forensicloggingsidecar

--- a/centralledger/requirements.yaml
+++ b/centralledger/requirements.yaml
@@ -1,31 +1,31 @@
 # requirements.yaml
 dependencies:
 - name: centralledger-service
-  version: 6.2.5
+  version: 7.1.0
   repository: "file://./chart-service"
   condition: centralledger-service.enabled
 - name: centralledger-handler-transfer-prepare
-  version: 6.2.5
+  version: 7.1.0
   repository: "file://./chart-handler-transfer-prepare"
   condition: centralledger-handler-transfer-prepare.enabled
 - name: centralledger-handler-transfer-position
-  version: 6.2.5
+  version: 7.1.0
   repository: "file://./chart-handler-transfer-position"
   condition: centralledger-handler-transfer-position.enabled
 - name: centralledger-handler-transfer-get
-  version: 6.2.5
+  version: 7.1.0
   repository: "file://./chart-handler-transfer-get"
   condition: centralledger-handler-transfer-get.enabled
 - name: centralledger-handler-transfer-fulfil
-  version: 6.2.5
+  version: 7.1.0
   repository: "file://./chart-handler-transfer-fulfil"
   condition: centralledger-handler-transfer-fulfil.enabled
 - name: centralledger-handler-timeout
-  version: 6.2.5
+  version: 7.1.0
   repository: "file://./chart-handler-timeout"
   condition: centralledger-handler-timeout.enabled
 - name: centralledger-handler-admin-transfer
-  version: 6.2.5
+  version: 7.1.0
   repository: "file://./chart-handler-admin-transfer"
   condition: centralledger-handler-transfer-get.enabled
 - name: forensicloggingsidecar

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -30,7 +30,7 @@ centralledger-service:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v6.2.5
+        tag: v7.1.0
         pullPolicy: Always
         command: '["node", "src/api/index.js"]'
       service:
@@ -159,7 +159,7 @@ centralledger-handler-transfer-prepare:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v6.2.5
+        tag: v7.1.0
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
       service:
@@ -297,7 +297,7 @@ centralledger-handler-transfer-position:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v6.2.5
+        tag: v7.1.0
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--position"]'
       service:
@@ -434,7 +434,7 @@ centralledger-handler-transfer-get:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v6.2.5
+        tag: v7.1.0
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--get"]'
       service:
@@ -572,7 +572,7 @@ centralledger-handler-transfer-fulfil:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v6.2.5
+        tag: v7.1.0
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
       service:
@@ -709,7 +709,7 @@ centralledger-handler-timeout:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v6.2.5
+        tag: v7.1.0
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
       service:
@@ -846,7 +846,7 @@ centralledger-handler-admin-transfer:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v6.2.5
+        tag: v7.1.0
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--admin"]'
       service:

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -30,7 +30,7 @@ centralledger-service:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v7.1.0
+        tag: v7.1.2
         pullPolicy: Always
         command: '["node", "src/api/index.js"]'
       service:
@@ -147,7 +147,6 @@ centralledger-service:
     #  cpu: 100m
     #  memory: 128Mi
 
-
 centralledger-handler-transfer-prepare:
   # Default values for central-ledger.
   # This is a YAML-formatted file.
@@ -159,7 +158,7 @@ centralledger-handler-transfer-prepare:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v7.1.0
+        tag: v7.1.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
       service:
@@ -285,7 +284,6 @@ centralledger-handler-transfer-prepare:
     #  cpu: 100m
     #  memory: 128Mi
 
-
 centralledger-handler-transfer-position:
   # Default values for central-ledger.
   # This is a YAML-formatted file.
@@ -297,7 +295,7 @@ centralledger-handler-transfer-position:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v7.1.0
+        tag: v7.1.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--position"]'
       service:
@@ -434,7 +432,7 @@ centralledger-handler-transfer-get:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v7.1.0
+        tag: v7.1.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--get"]'
       service:
@@ -560,7 +558,6 @@ centralledger-handler-transfer-get:
     #  cpu: 100m
     #  memory: 128Mi
 
-
 centralledger-handler-transfer-fulfil:
   # Default values for central-ledger.
   # This is a YAML-formatted file.
@@ -572,7 +569,7 @@ centralledger-handler-transfer-fulfil:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v7.1.0
+        tag: v7.1.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
       service:
@@ -709,7 +706,7 @@ centralledger-handler-timeout:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v7.1.0
+        tag: v7.1.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
       service:
@@ -846,7 +843,7 @@ centralledger-handler-admin-transfer:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v7.1.0
+        tag: v7.1.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--admin"]'
       service:

--- a/emailnotifier/Chart.yaml
+++ b/emailnotifier/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Email Notifier For Mojaloop
 name: emailnotifier
-version: 6.3.0
-appVersion: "5.5.0"
+version: 7.1.0
+appVersion: "7.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/emailnotifier/values.yaml
+++ b/emailnotifier/values.yaml
@@ -22,7 +22,7 @@ global:
 replicaCount: 1
 image:
   repository: mojaloop/email-notifier
-  tag: v5.5.0
+  tag: v7.1.0
   pullPolicy: Always
 
 init:

--- a/ml-api-adapter/Chart.yaml
+++ b/ml-api-adapter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Helm chart for Kubernetes
 name: ml-api-adapter
-version: 6.2.1
-appVersion: "6.2.1"
+version: 7.1.0
+appVersion: "7.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -12,4 +12,5 @@ sources:
 maintainers:
   - name: Murthy Kakarlamudi
     email: murthy@modusbox.com
-
+  - name: Miguel de Barros
+    email: miguel.debarros@modusbox.com

--- a/ml-api-adapter/chart-handler-notification/Chart.yaml
+++ b/ml-api-adapter/chart-handler-notification/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: ml-api-adapter-handler-notification
-version: 6.2.1
-appVersion: "6.2.1"
+version: 7.1.0
+appVersion: "7.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v6.2.1
+  tag: v7.1.0
   command: '["node", "src/handlers/index.js", "handler", "--notification"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/chart-service/Chart.yaml
+++ b/ml-api-adapter/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter API component Helm chart for Kubernetes
 name: ml-api-adapter-service
-version: 6.2.1
-appVersion: "6.2.1"
+version: 7.1.0
+appVersion: "7.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-service/values.yaml
+++ b/ml-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v6.2.1
+  tag: v7.1.0
   command: '["node", "src/api/index.js"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/requirements.yaml
+++ b/ml-api-adapter/requirements.yaml
@@ -1,11 +1,11 @@
 # requirements.yaml
 dependencies:
 - name: ml-api-adapter-service
-  version: 6.2.1
+  version: 7.1.0
   repository: "file://./chart-service"
   condition: ml-api-adapter-service.enabled
 - name: ml-api-adapter-handler-notification
-  version: 6.2.1
+  version: 7.1.0
   repository: "file://./chart-handler-notification"
   condition: ml-api-adapter-handler-notification.enabled
 ## This is used for testing ml-api-adapter deployments

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -26,7 +26,7 @@ ml-api-adapter-service:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v6.2.1
+    tag: v7.1.0
     command: '["node", "src/api/index.js"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -107,7 +107,7 @@ ml-api-adapter-handler-notification:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v6.2.1
+    tag: v7.1.0
     command: '["node", "src/handlers/index.js", "handler", "--notification"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.

--- a/mojaloop-bulk/Chart.yaml
+++ b/mojaloop-bulk/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+description: Mojaloop Bulk Helm chart for Kubernetes
+name: mojaloop-bulk
+version: 7.1.0
+appVersion: "7.1.0-snapshot"
+home: http://mojaloop.io
+icon: http://mojaloop.io/images/logo.png
+sources:
+  - https://github.com/mojaloop/mojaloop
+  - https://github.com/mojaloop/helm
+maintainers:
+  - name: Miguel de Barros
+    email: miguel.debarros@modusbox.com
+

--- a/mojaloop-bulk/requirements.yaml
+++ b/mojaloop-bulk/requirements.yaml
@@ -12,4 +12,4 @@ dependencies:
   version: 4.9.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   alias: mongodb
-  condition: mongo.enabled
+  condition: mongodb.enabled

--- a/mojaloop-bulk/requirements.yaml
+++ b/mojaloop-bulk/requirements.yaml
@@ -1,0 +1,15 @@
+# requirements.yaml
+dependencies:
+- name: bulk-api-adapter
+  version: 7.1.0
+  repository: "file://./bulk-api-adapter"
+  condition: bulk-api-adapter.enabled
+- name: bulk-centralledger
+  version: 7.1.0
+  repository: "file://./bulk-centralledger"
+  condition: bulk-centralledger.enabled
+- name: mongodb
+  version: 4.9.0
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  alias: mongodb
+  condition: mongo.enabled

--- a/mojaloop-bulk/requirements.yaml
+++ b/mojaloop-bulk/requirements.yaml
@@ -2,11 +2,11 @@
 dependencies:
 - name: bulk-api-adapter
   version: 7.1.0
-  repository: "file://./bulk-api-adapter"
+  repository: "file://../bulk-api-adapter"
   condition: bulk-api-adapter.enabled
 - name: bulk-centralledger
   version: 7.1.0
-  repository: "file://./bulk-centralledger"
+  repository: "file://../bulk-centralledger"
   condition: bulk-centralledger.enabled
 - name: mongodb
   version: 4.9.0

--- a/mojaloop-bulk/values.yaml
+++ b/mojaloop-bulk/values.yaml
@@ -240,7 +240,7 @@ bulk-api-adapter:
 
 bulk-centralledger:
 
-  centralledger-handler-bulk-transfer-prepare:
+  cl-handler-bulk-transfer-prepare:
     enabled: true
     # Default values for centralledger-handler-bulk-transfer-prepare.
     # This is a YAML-formatted file.
@@ -285,7 +285,7 @@ bulk-centralledger:
     config:
       ## Forensic Logging sidecar
       # this is for Forensic Logging Sidecar
-      forensicloggingsidecar_disabled: false
+      forensicloggingsidecar_disabled: true
       forensicloggingsidecar_host: forensicloggingsidecar-ledger
       forensicloggingsidecar_port: 5678
 
@@ -394,7 +394,7 @@ bulk-centralledger:
     #  cpu: 100m
     #  memory: 128Mi
 
-  centralledger-handler-bulk-transfer-fulfil:
+  cl-handler-bulk-transfer-fulfil:
     enabled: true
     # Default values for centralledger-handler-bulk-transfer-fulfil.
     # This is a YAML-formatted file.
@@ -439,7 +439,7 @@ bulk-centralledger:
     config:
       ## Forensic Logging sidecar
       # this is for Forensic Logging Sidecar
-      forensicloggingsidecar_disabled: false
+      forensicloggingsidecar_disabled: true
       forensicloggingsidecar_host: forensicloggingsidecar-ledger
       forensicloggingsidecar_port: 5678
 
@@ -548,7 +548,7 @@ bulk-centralledger:
     #  cpu: 100m
     #  memory: 128Mi
 
-  centralledger-handler-bulk-transfer-processing:
+  cl-handler-bulk-transfer-processing:
     enabled: true
     # Default values for centralledger-handler-bulk-transfer-processing.
     # This is a YAML-formatted file.
@@ -558,7 +558,7 @@ bulk-centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v7.1.0
+          tag: v7.1.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
         service:
@@ -593,7 +593,7 @@ bulk-centralledger:
     config:
       ## Forensic Logging sidecar
       # this is for Forensic Logging Sidecar
-      forensicloggingsidecar_disabled: false
+      forensicloggingsidecar_disabled: true
       forensicloggingsidecar_host: forensicloggingsidecar-ledger
       forensicloggingsidecar_port: 5678
 

--- a/mojaloop-bulk/values.yaml
+++ b/mojaloop-bulk/values.yaml
@@ -16,6 +16,692 @@ global:
     ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
     tolerations: []
 
+bulk-api-adapter:
+
+  bulk-api-adapter-service:
+    enabled: true
+    # Default values for bulk-api-adapter.
+    # This is a YAML-formatted file.
+    # Declare variables to be passed into your templates.
+    replicaCount: 1
+    image:
+      repository: mojaloop/bulk-api-adapter
+      tag: v7.1.1-snapshot
+      command: '["node", "src/api/index.js"]'
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+      ##
+      #  imagePullSecrets:
+      #    - name: myregistrykey
+      pullPolicy: Always
+
+    init:
+      enabled: true
+      image:
+        name: wait-for-kafka
+        repository: solsson/kafka
+        tag: latest
+        pullPolicy: Always
+        command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
+        env: {}
+        ## Env example
+        # env:
+        #   envItem1:
+        #     name: hello
+        #     value: world
+        #
+      mongodb:
+        name: wait-for-mongodb
+        repository: bitnami/mongodb
+        tag: latest
+        pullPolicy: Always
+        command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+
+    readinessProbe:
+      enabled: true
+      httpGet:
+        path: /health
+      initialDelaySeconds: 120
+      periodSeconds: 15
+    livenessProbe:
+      enabled: true
+      httpGet:
+        path: /health
+      initialDelaySeconds: 90
+      periodSeconds: 15
+
+    ## metric configuration for prometheus instrumentation
+    metrics:
+      ## flag to enable/disable the metrics end-points
+      enabled: true
+      config:
+        timeout: 5000
+        prefix: moja_
+        defaultLabels:
+          serviceName: bulk-service
+
+    config:
+      # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+      kafka_host: '$release_name-kafka'
+      kafka_port: 9092
+      central_services_host: '$release_name-centralledger-service'
+      central_services_port: 80
+      security:
+        callback:
+          rejectUnauthorized: true
+      log_level: 'info'
+
+      ## MongoDB Configuration for Object Store
+      objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
+
+    service:
+      type: ClusterIP
+      externalPort: 80
+      internalPort: 8088
+
+    ingress:
+      enabled: true
+      externalPath: /
+      # Used to create an Ingress record.
+      hosts:
+        api: bulk-api-adapter.local
+
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: '/'
+        # kubernetes.io/ingress.class: nginx
+        # kubernetes.io/tls-acme: "true"
+      tls:
+      # Secrets must be manually created in the namespace.
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local
+    resources: {}
+      # We usually recommend not to specify default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      # limits:
+      #  cpu: 100m
+      #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+
+  bulk-api-adapter-handler-notification:
+    enabled: true
+    # Default values for bulk-api-adapter-handler-notification.
+    # This is a YAML-formatted file.
+    # Declare variables to be passed into your templates.
+    replicaCount: 1
+    image:
+      repository: mojaloop/bulk-api-adapter
+      tag: v7.1.1-snapshot
+      command: '["node", "src/handlers/index.js", "handler", "--notification"]'
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+      ##
+      #  imagePullSecrets:
+      #    - name: myregistrykey
+      pullPolicy: Always
+
+    init:
+      enabled: true
+      image:
+        name: wait-for-kafka
+        repository: solsson/kafka
+        tag: latest
+        pullPolicy: Always
+        command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
+        env: {}
+        ## Env example
+        # env:
+        #   envItem1:
+        #     name: hello
+        #     value: world
+        #
+      mongodb:
+        name: wait-for-mongodb
+        repository: bitnami/mongodb
+        tag: latest
+        pullPolicy: Always
+        command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+
+    readinessProbe:
+      enabled: true
+      httpGet:
+        path: /health
+      initialDelaySeconds: 120
+      periodSeconds: 15
+    livenessProbe:
+      enabled: true
+      httpGet:
+        path: /health
+      initialDelaySeconds: 90
+      periodSeconds: 15
+
+    ## metric configuration for prometheus instrumentation
+    metrics:
+      ## flag to enable/disable the metrics end-points
+      enabled: true
+      config:
+        timeout: 5000
+        prefix: moja_
+        defaultLabels:
+          serviceName: bulk-handler-notification
+
+    config:
+      # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+      kafka_host: '$release_name-kafka'
+      kafka_port: 9092
+      central_services_host: '$release_name-centralledger-service'
+      central_services_port: 80
+      security:
+        callback:
+          rejectUnauthorized: true
+      log_level: 'info'
+
+      ## MongoDB Configuration for Object Store
+      objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
+
+    service:
+      type: ClusterIP
+      externalPort: 80
+      internalPort: 8088
+
+    ingress:
+      enabled: true
+      externalPath: /
+      # Used to create an Ingress record.
+      hosts:
+        api: bulk-api-adapter-notification.local
+
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: '/'
+        # kubernetes.io/ingress.class: nginx
+        # kubernetes.io/tls-acme: "true"
+      tls:
+      # Secrets must be manually created in the namespace.
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local
+    resources: {}
+      # We usually recommend not to specify default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      # limits:
+      #  cpu: 100m
+      #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+
+bulk-centralledger:
+
+  centralledger-handler-bulk-transfer-prepare:
+    enabled: true
+    # Default values for centralledger-handler-bulk-transfer-prepare.
+    # This is a YAML-formatted file.
+    # Declare variables to be passed into your templates.
+    replicaCount: 1
+    containers:
+      api:
+        image:
+          repository: mojaloop/central-ledger
+          tag: v7.1.2
+          pullPolicy: Always
+          command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
+        service:
+          ports:
+            api:
+              name: http-api
+              externalPort: 80
+              internalPort: 3001
+        readinessProbe:
+          enabled: true
+          httpGet:
+            path: /health
+          initialDelaySeconds: 60
+          periodSeconds: 15
+        livenessProbe:
+          enabled: true
+          httpGet:
+            path: /health
+          initialDelaySeconds: 60
+          periodSeconds: 15
+
+    ## metric configuration for prometheus instrumentation
+    metrics:
+      ## flag to enable/disable the metrics end-points
+      enabled: true
+      config:
+        timeout: 5000
+        prefix: moja_
+        defaultLabels:
+          serviceName: central-handler-bulkprepare
+
+    config:
+      ## Forensic Logging sidecar
+      # this is for Forensic Logging Sidecar
+      forensicloggingsidecar_disabled: false
+      forensicloggingsidecar_host: forensicloggingsidecar-ledger
+      forensicloggingsidecar_port: 5678
+
+      ## DB Configuration
+      # db_type can either be 'postgres' or 'mysql'. Ensure the correct DB is enabled and configured below: postgresql.enabled or mysql.enabled
+      db_type: 'mysql'
+      # db_driver can either be 'pg' or 'mysql'. Ensure the correct corresponding db_type above has been set.
+      db_driver: 'mysql'
+      db_host: '$release_name-centralledger-mysql'
+      db_port: 3306
+      db_user: central_ledger
+      db_password: oyMxgZChuu
+      db_database: central_ledger
+      db_connection_pool_min: 10
+      db_connection_pool_max: 30
+
+      ## MongoDB Configuration for Object Store
+      objstore_disabled: false
+      objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
+
+      ## Kafka Configuration
+      # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+      kafka_host: '$release_name-kafka'
+      kafka_port: 9092
+
+      ## Node Configuration
+      log_level: 'info'
+
+    init:
+      enabled: true
+      kafka:
+        name: wait-for-kafka
+        repository: solsson/kafka
+        tag: latest
+        pullPolicy: Always
+        command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
+        env: {}
+        ## Env example
+        # env:
+        #   envItem1:
+        #     name: hello
+        #     value: world
+        #
+      psql:
+        name: wait-for-postgres
+        repository: bowerswilkins/awaitpostgres
+        tag: latest
+        pullPolicy: Always
+      mysql:
+        name: wait-for-mysql
+        repository: mysql
+        tag: latest
+        pullPolicy: Always
+        command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
+      mongodb:
+        name: wait-for-mongodb
+        repository: bitnami/mongodb
+        tag: latest
+        pullPolicy: Always
+        command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+
+    service:
+      type: ClusterIP
+
+      annotations: {}
+
+      # This allows one to point the service to an external backend.
+      # This is useful for local development where one wishes to hijack
+      # the communication from the service to the node layer and point
+      # to a specific endpoint (IP, Port, etc).
+      external:
+        enabled: false
+        # 10.0.2.2 is the magic IP for the host on virtualbox's network
+        ip: 10.0.2.2
+        ports:
+          api:
+            name: http-api
+            externalPort: 3001
+
+    ingress:
+      enabled: true
+      type: http
+      externalPath:
+        api: /
+      # Used to create an Ingress record.
+      hosts:
+        api: central-ledger-transfer-bulkprepare.local
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: '/'
+        # kubernetes.io/ingress.class: nginx
+        # kubernetes.io/tls-acme: "true"
+      tls:
+      # Secrets must be manually created in the namespace.
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local
+    resources: {}
+      # We usually recommend not to specify default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      # limits:
+      #  cpu: 100m
+      #  memory: 128Mi
+      # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+
+  centralledger-handler-bulk-transfer-fulfil:
+    enabled: true
+    # Default values for centralledger-handler-bulk-transfer-fulfil.
+    # This is a YAML-formatted file.
+    # Declare variables to be passed into your templates.
+    replicaCount: 1
+    containers:
+      api:
+        image:
+          repository: mojaloop/central-ledger
+          tag: v7.1.2
+          pullPolicy: Always
+          command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
+        service:
+          ports:
+            api:
+              name: http-api
+              externalPort: 80
+              internalPort: 3001
+        readinessProbe:
+          enabled: true
+          httpGet:
+            path: /health
+          initialDelaySeconds: 60
+          periodSeconds: 15
+        livenessProbe:
+          enabled: true
+          httpGet:
+            path: /health
+          initialDelaySeconds: 60
+          periodSeconds: 15
+
+    ## metric configuration for prometheus instrumentation
+    metrics:
+      ## flag to enable/disable the metrics end-points
+      enabled: true
+      config:
+        timeout: 5000
+        prefix: moja_
+        defaultLabels:
+          serviceName: central-handler-bulkfulfil
+
+    config:
+      ## Forensic Logging sidecar
+      # this is for Forensic Logging Sidecar
+      forensicloggingsidecar_disabled: false
+      forensicloggingsidecar_host: forensicloggingsidecar-ledger
+      forensicloggingsidecar_port: 5678
+
+      ## DB Configuration
+      # db_type can either be 'postgres' or 'mysql'. Ensure the correct DB is enabled and configured below: postgresql.enabled or mysql.enabled
+      db_type: 'mysql'
+      # db_driver can either be 'pg' or 'mysql'. Ensure the correct corresponding db_type above has been set.
+      db_driver: 'mysql'
+      db_host: '$release_name-centralledger-mysql'
+      db_port: 3306
+      db_user: central_ledger
+      db_password: oyMxgZChuu
+      db_database: central_ledger
+      db_connection_pool_min: 10
+      db_connection_pool_max: 30
+
+      ## MongoDB Configuration for Object Store
+      objstore_disabled: false
+      objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
+
+      ## Kafka Configuration
+      # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+      kafka_host: '$release_name-kafka'
+      kafka_port: 9092
+
+      ## Node Configuration
+      log_level: 'info'
+
+    init:
+      enabled: true
+      kafka:
+        name: wait-for-kafka
+        repository: solsson/kafka
+        tag: latest
+        pullPolicy: Always
+        command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
+        env: {}
+        ## Env example
+        # env:
+        #   envItem1:
+        #     name: hello
+        #     value: world
+        #
+      psql:
+        name: wait-for-postgres
+        repository: bowerswilkins/awaitpostgres
+        tag: latest
+        pullPolicy: Always
+      mysql:
+        name: wait-for-mysql
+        repository: mysql
+        tag: latest
+        pullPolicy: Always
+        command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
+      mongodb:
+        name: wait-for-mongodb
+        repository: bitnami/mongodb
+        tag: latest
+        pullPolicy: Always
+        command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+
+    service:
+      type: ClusterIP
+
+      annotations: {}
+
+      # This allows one to point the service to an external backend.
+      # This is useful for local development where one wishes to hijack
+      # the communication from the service to the node layer and point
+      # to a specific endpoint (IP, Port, etc).
+      external:
+        enabled: false
+        # 10.0.2.2 is the magic IP for the host on virtualbox's network
+        ip: 10.0.2.2
+        ports:
+          api:
+            name: http-api
+            externalPort: 3001
+
+    ingress:
+      enabled: true
+      type: http
+      externalPath:
+        api: /
+      # Used to create an Ingress record.
+      hosts:
+        api: central-ledger-transfer-bulkfulfil.local
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: '/'
+        # kubernetes.io/ingress.class: nginx
+        # kubernetes.io/tls-acme: "true"
+      tls:
+      # Secrets must be manually created in the namespace.
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local
+    resources: {}
+      # We usually recommend not to specify default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      # limits:
+      #  cpu: 100m
+      #  memory: 128Mi
+      # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+
+  centralledger-handler-bulk-transfer-processing:
+    enabled: true
+    # Default values for centralledger-handler-bulk-transfer-processing.
+    # This is a YAML-formatted file.
+    # Declare variables to be passed into your templates.
+    replicaCount: 1
+    containers:
+      api:
+        image:
+          repository: mojaloop/central-ledger
+          tag: v7.1.0
+          pullPolicy: Always
+          command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
+        service:
+          ports:
+            api:
+              name: http-api
+              externalPort: 80
+              internalPort: 3001
+        readinessProbe:
+          enabled: true
+          httpGet:
+            path: /health
+          initialDelaySeconds: 60
+          periodSeconds: 15
+        livenessProbe:
+          enabled: true
+          httpGet:
+            path: /health
+          initialDelaySeconds: 60
+          periodSeconds: 15
+
+    ## metric configuration for prometheus instrumentation
+    metrics:
+      ## flag to enable/disable the metrics end-points
+      enabled: true
+      config:
+        timeout: 5000
+        prefix: moja_
+        defaultLabels:
+          serviceName: central-handler-bulkprocessing
+
+    config:
+      ## Forensic Logging sidecar
+      # this is for Forensic Logging Sidecar
+      forensicloggingsidecar_disabled: false
+      forensicloggingsidecar_host: forensicloggingsidecar-ledger
+      forensicloggingsidecar_port: 5678
+
+      ## DB Configuration
+      # db_type can either be 'postgres' or 'mysql'. Ensure the correct DB is enabled and configured below: postgresql.enabled or mysql.enabled
+      db_type: 'mysql'
+      # db_driver can either be 'pg' or 'mysql'. Ensure the correct corresponding db_type above has been set.
+      db_driver: 'mysql'
+      db_host: '$release_name-centralledger-mysql'
+      db_port: 3306
+      db_user: central_ledger
+      db_password: oyMxgZChuu
+      db_database: central_ledger
+      db_connection_pool_min: 10
+      db_connection_pool_max: 30
+
+      ## MongoDB Configuration for Object Store
+      objstore_disabled: false
+      objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
+
+      ## Kafka Configuration
+      # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+      kafka_host: '$release_name-kafka'
+      kafka_port: 9092
+
+      ## Node Configuration
+      log_level: 'info'
+
+    init:
+      enabled: true
+      kafka:
+        name: wait-for-kafka
+        repository: solsson/kafka
+        tag: latest
+        pullPolicy: Always
+        command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
+        env: {}
+        ## Env example
+        # env:
+        #   envItem1:
+        #     name: hello
+        #     value: world
+        #
+      psql:
+        name: wait-for-postgres
+        repository: bowerswilkins/awaitpostgres
+        tag: latest
+        pullPolicy: Always
+      mysql:
+        name: wait-for-mysql
+        repository: mysql
+        tag: latest
+        pullPolicy: Always
+        command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
+      mongodb:
+        name: wait-for-mongodb
+        repository: bitnami/mongodb
+        tag: latest
+        pullPolicy: Always
+        command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+
+    service:
+      type: ClusterIP
+
+      annotations: {}
+
+      # This allows one to point the service to an external backend.
+      # This is useful for local development where one wishes to hijack
+      # the communication from the service to the node layer and point
+      # to a specific endpoint (IP, Port, etc).
+      external:
+        enabled: false
+        # 10.0.2.2 is the magic IP for the host on virtualbox's network
+        ip: 10.0.2.2
+        ports:
+          api:
+            name: http-api
+            externalPort: 3001
+
+    ingress:
+      enabled: true
+      type: http
+      externalPath:
+        api: /
+      # Used to create an Ingress record.
+      hosts:
+        api: central-ledger-transfer-bulkprocessing.local
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: '/'
+        # kubernetes.io/ingress.class: nginx
+        # kubernetes.io/tls-acme: "true"
+      tls:
+      # Secrets must be manually created in the namespace.
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local
+    resources: {}
+      # We usually recommend not to specify default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      # limits:
+      #  cpu: 100m
+      #  memory: 128Mi
+      # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+
 # Declare variables to be passed into your templates.
 mongodb:
   ## Global Docker image registry

--- a/mojaloop-bulk/values.yaml
+++ b/mojaloop-bulk/values.yaml
@@ -1,0 +1,290 @@
+# Default values for central.
+# This is a YAML-formatted file.
+# Declare global configurations
+global:
+  config:
+    ## Pod scheduling preferences.
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ##
+    affinity: {}
+
+    ## Node labels for pod assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+    nodeSelector: {}
+
+    ## Set toleration for schedular
+    ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    tolerations: []
+
+# Declare variables to be passed into your templates.
+mongodb:
+  ## Global Docker image registry
+  ## Please, note that this will override the image registry for all the images, including dependencies, configured to use the global value
+  ##
+  # global:
+  #   imageRegistry:
+  enabled: true
+  nameOverride: centralledger-obj
+
+  image:
+    ## Bitnami MongoDB registry
+    ##
+    registry: docker.io
+    ## Bitnami MongoDB image name
+    ##
+    repository: bitnami/mongodb
+    ## Bitnami MongoDB image tag
+    ## ref: https://hub.docker.com/r/bitnami/mongodb/tags/
+    ##
+    tag: 4.0.3
+
+    ## Specify a imagePullPolicy
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: Always
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistrKeySecretName
+
+  ## Enable authentication
+  ## ref: https://docs.mongodb.com/manual/tutorial/enable-authentication/
+  #
+  usePassword: true
+  # existingSecret: name-of-existing-secret
+
+  ## MongoDB admin password
+  ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#setting-the-root-password-on-first-run
+  ##
+  mongodbRootPassword: adminpass
+
+  ## MongoDB custom user and database
+  ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#creating-a-user-and-database-on-first-run
+  ##
+  mongodbUsername: mojaloop
+  mongodbPassword: password
+  mongodbDatabase: mojaloop
+
+
+  ## Whether enable/disable IPv6 on MongoDB
+  ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#enabling/disabling-ipv6
+  ##
+  mongodbEnableIPv6: true
+
+  ## MongoDB additional command line flags
+  ##
+  ## Can be used to specify command line flags, for example:
+  ##
+  ## mongodbExtraFlags:
+  ##  - "--wiredTigerCacheSizeGB=2"
+  mongodbExtraFlags: []
+
+  ## Pod Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ##
+  securityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+
+  ## Kubernetes Cluster Domain
+  clusterDomain: cluster.local
+
+  ## Kubernetes service type
+  service:
+    annotations: {}
+    type: ClusterIP
+    # clusterIP: None
+    port: 27017
+
+    ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ##
+    # nodePort:
+
+  ## Setting up replication
+  ## ref: https://github.com/bitnami/bitnami-docker-mongodb#setting-up-a-replication
+  #
+  replicaSet:
+    ## Whether to create a MongoDB replica set for high availability or not
+    enabled: false
+    useHostnames: true
+
+    ## Name of the replica set
+    ##
+    name: rs0
+
+    ## Key used for replica set authentication
+    ##
+    # key: key
+
+    ## Number of replicas per each node type
+    ##
+    replicas:
+      secondary: 1
+      arbiter: 1
+    ## Pod Disruption Budget
+    ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+    pdb:
+      minAvailable:
+        primary: 1
+        secondary: 1
+        arbiter: 1
+
+  # Annotations to be added to MongoDB pods
+  podAnnotations: {}
+
+  # Additional pod labels to apply
+  podLabels: {}
+
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+  # limits:
+  #   cpu: 500m
+  #   memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 256Mi
+
+  ## Node selector
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  nodeSelector: {}
+
+  ## Affinity
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+
+  ## Tolerations
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
+
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    enabled: false
+    ## A manually managed Persistent Volume and Claim
+    ## Requires persistence.enabled: true
+    ## If defined, PVC must be created manually before volume will be bound
+    # existingClaim:
+
+    ## mongodb data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    accessModes:
+      - ReadWriteOnce
+    size: 8Gi
+    annotations: {}
+
+  ## Configure extra options for liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+
+  # Entries for the MongoDB config file
+  configmap:
+  #  # Where and how to store data.
+  #  storage:
+  #    dbPath: /opt/bitnami/mongodb/data/db
+  #    journal:
+  #      enabled: true
+  #    #engine:
+  #    #wiredTiger:
+  #  # where to write logging data.
+  #  systemLog:
+  #    destination: file
+  #    logAppend: true
+  #    path: /opt/bitnami/mongodb/logs/mongodb.log
+  #  # network interfaces
+  #  net:
+  #    port: 27017
+  #    bindIp: 0.0.0.0
+  #    unixDomainSocket:
+  #      enabled: true
+  #      pathPrefix: /opt/bitnami/mongodb/tmp
+  #  # replica set options
+  #  #replication:
+  #  #  replSetName: replicaset
+  #  # process management options
+  #  processManagement:
+  #     fork: false
+  #     pidFilePath: /opt/bitnami/mongodb/tmp/mongodb.pid
+  #  # set parameter options
+  #  setParameter:
+  #     enableLocalhostAuthBypass: true
+  #  # security options
+  #  security:
+  #  authorization: enabled
+  #keyFile: /opt/bitnami/mongodb/conf/keyfile
+
+  ## Prometheus Exporter / Metrics
+  ##
+  metrics:
+    enabled: false
+
+    image:
+      registry: docker.io
+      repository: forekshub/percona-mongodb-exporter
+      tag: latest
+      pullPolicy: IfNotPresent
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ##
+      # pullSecrets:
+      #   - myRegistrKeySecretName
+
+    ## Metrics exporter resource requests and limits
+    ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+    ##
+    # resources: {}
+
+    ## Metrics exporter pod Annotation
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9216"
+
+    ## Prometheus Service Monitor
+    ## ref: https://github.com/coreos/prometheus-operator
+    ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md
+    serviceMonitor:
+      ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
+      enabled: false
+      ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
+      ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+      additionalLabels: {}
+
+      ## Specify Metric Relabellings to add to the scrape endpoint
+      ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+      # relabellings:
+
+      alerting:
+        ## Define individual alerting rules as required
+        ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#rulegroup
+        ##      https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+        rules: {}
+
+        ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Prometheus Rules to work with
+        ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+  additionalLabels: {}

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
-version: 6.3.1
-appVersion: "6.2.5"
+version: 7.1.0
+appVersion: "7.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
-version: 7.1.0
-appVersion: "7.1.0"
+version: 7.1.2
+appVersion: "7.1.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -14,7 +14,7 @@ dependencies:
   repository: "file://../ml-api-adapter"
   condition: ml-api-adapter.enabled
 - name: emailnotifier
-  version: 6.3.0
+  version: 7.1.0
   repository: "file://../emailnotifier"
   condition: emailnotifier.enabled
 - name: account-lookup-service
@@ -29,3 +29,7 @@ dependencies:
   version: 6.3.3
   repository: "file://../simulator"
   condition: simulator.enabled
+- name: mojaloop-bulk
+  version: 7.1.0
+  repository: "file://../mojaloop-bulk"
+  condition: mojaloop-bulk.enabled

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: central
-  version: 6.3.0
+  version: 7.1.0
   repository: "file://../central"
   condition: central.enabled
 ## Deprecated - to be removed shortly
@@ -10,7 +10,7 @@ dependencies:
 #  repository: "file://../interop-switch"
 #  condition: interop-switch.enabled
 - name: ml-api-adapter
-  version: 6.2.1
+  version: 7.1.0
   repository: "file://../ml-api-adapter"
   condition: ml-api-adapter.enabled
 - name: emailnotifier

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: central
-  version: 7.1.0
+  version: 7.1.2
   repository: "file://../central"
   condition: central.enabled
 ## Deprecated - to be removed shortly

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -37,7 +37,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v7.1.0
+            tag: v7.1.2
             pullPolicy: Always
             command: '["node", "src/api/index.js"]'
           service:
@@ -166,7 +166,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v7.1.0
+            tag: v7.1.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
           service:
@@ -303,7 +303,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v7.1.0
+            tag: v7.1.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--admin"]'
           service:
@@ -440,7 +440,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v7.1.0
+            tag: v7.1.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--position"]'
           service:
@@ -577,7 +577,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v7.1.0
+            tag: v7.1.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--get"]'
           service:
@@ -714,7 +714,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v7.1.0
+            tag: v7.1.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
           service:
@@ -851,7 +851,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v7.1.0
+            tag: v7.1.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
           service:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2061,7 +2061,7 @@ central:
     replicaCount: 1
     image:
       repository: mojaloop/central-event-processor
-      tag: v5.5.0
+      tag: v7.1.0
       pullPolicy: Always
     init:
       enabled: true
@@ -2677,7 +2677,7 @@ emailnotifier:
 
   image:
     repository: mojaloop/email-notifier
-    tag: v5.5.0
+    tag: v7.1.0
     pullPolicy: Always
 
   init:
@@ -3304,3 +3304,965 @@ simulator:
   tolerations: []
 
   affinity: {}
+
+mojaloop-bulk:
+  enabled: false
+
+  bulk-api-adapter:
+
+    bulk-api-adapter-service:
+      enabled: true
+      # Default values for bulk-api-adapter.
+      # This is a YAML-formatted file.
+      # Declare variables to be passed into your templates.
+      replicaCount: 1
+      image:
+        repository: mojaloop/bulk-api-adapter
+        tag: v7.1.1-snapshot
+        command: '["node", "src/api/index.js"]'
+        ## Optionally specify an array of imagePullSecrets.
+        ## Secrets must be manually created in the namespace.
+        ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+        ##
+        #  imagePullSecrets:
+        #    - name: myregistrykey
+        pullPolicy: Always
+
+      init:
+        enabled: true
+        image:
+          name: wait-for-kafka
+          repository: solsson/kafka
+          tag: latest
+          pullPolicy: Always
+          command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
+          env: {}
+          ## Env example
+          # env:
+          #   envItem1:
+          #     name: hello
+          #     value: world
+          #
+        mongodb:
+          name: wait-for-mongodb
+          repository: bitnami/mongodb
+          tag: latest
+          pullPolicy: Always
+          command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+
+      readinessProbe:
+        enabled: true
+        httpGet:
+          path: /health
+        initialDelaySeconds: 120
+        periodSeconds: 15
+      livenessProbe:
+        enabled: true
+        httpGet:
+          path: /health
+        initialDelaySeconds: 90
+        periodSeconds: 15
+
+      ## metric configuration for prometheus instrumentation
+      metrics:
+        ## flag to enable/disable the metrics end-points
+        enabled: true
+        config:
+          timeout: 5000
+          prefix: moja_
+          defaultLabels:
+            serviceName: bulk-service
+
+      config:
+        # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+        kafka_host: '$release_name-kafka'
+        kafka_port: 9092
+        central_services_host: '$release_name-centralledger-service'
+        central_services_port: 80
+        security:
+          callback:
+            rejectUnauthorized: true
+        log_level: 'info'
+
+        ## MongoDB Configuration for Object Store
+        objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
+
+      service:
+        type: ClusterIP
+        externalPort: 80
+        internalPort: 8088
+
+      ingress:
+        enabled: true
+        externalPath: /
+        # Used to create an Ingress record.
+        hosts:
+          api: bulk-api-adapter.local
+
+        annotations:
+          nginx.ingress.kubernetes.io/rewrite-target: '/'
+          # kubernetes.io/ingress.class: nginx
+          # kubernetes.io/tls-acme: "true"
+        tls:
+        # Secrets must be manually created in the namespace.
+        # - secretName: chart-example-tls
+        #   hosts:
+        #     - chart-example.local
+      resources: {}
+        # We usually recommend not to specify default resources and to leave this as a conscious
+        # choice for the user. This also increases chances charts run on environments with little
+        # resources, such as Minikube. If you do want to specify resources, uncomment the following
+        # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+        # limits:
+      #  cpu: 100m
+      #  memory: 128Mi
+      # requests:
+      #  cpu: 100m
+      #  memory: 128Mi
+
+    bulk-api-adapter-handler-notification:
+      enabled: true
+      # Default values for bulk-api-adapter-handler-notification.
+      # This is a YAML-formatted file.
+      # Declare variables to be passed into your templates.
+      replicaCount: 1
+      image:
+        repository: mojaloop/bulk-api-adapter
+        tag: v7.1.1-snapshot
+        command: '["node", "src/handlers/index.js", "handler", "--notification"]'
+        ## Optionally specify an array of imagePullSecrets.
+        ## Secrets must be manually created in the namespace.
+        ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+        ##
+        #  imagePullSecrets:
+        #    - name: myregistrykey
+        pullPolicy: Always
+
+      init:
+        enabled: true
+        image:
+          name: wait-for-kafka
+          repository: solsson/kafka
+          tag: latest
+          pullPolicy: Always
+          command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
+          env: {}
+          ## Env example
+          # env:
+          #   envItem1:
+          #     name: hello
+          #     value: world
+          #
+        mongodb:
+          name: wait-for-mongodb
+          repository: bitnami/mongodb
+          tag: latest
+          pullPolicy: Always
+          command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+
+      readinessProbe:
+        enabled: true
+        httpGet:
+          path: /health
+        initialDelaySeconds: 120
+        periodSeconds: 15
+      livenessProbe:
+        enabled: true
+        httpGet:
+          path: /health
+        initialDelaySeconds: 90
+        periodSeconds: 15
+
+      ## metric configuration for prometheus instrumentation
+      metrics:
+        ## flag to enable/disable the metrics end-points
+        enabled: true
+        config:
+          timeout: 5000
+          prefix: moja_
+          defaultLabels:
+            serviceName: bulk-handler-notification
+
+      config:
+        # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+        kafka_host: '$release_name-kafka'
+        kafka_port: 9092
+        central_services_host: '$release_name-centralledger-service'
+        central_services_port: 80
+        security:
+          callback:
+            rejectUnauthorized: true
+        log_level: 'info'
+
+        ## MongoDB Configuration for Object Store
+        objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
+
+      service:
+        type: ClusterIP
+        externalPort: 80
+        internalPort: 8088
+
+      ingress:
+        enabled: true
+        externalPath: /
+        # Used to create an Ingress record.
+        hosts:
+          api: bulk-api-adapter-notification.local
+
+        annotations:
+          nginx.ingress.kubernetes.io/rewrite-target: '/'
+          # kubernetes.io/ingress.class: nginx
+          # kubernetes.io/tls-acme: "true"
+        tls:
+        # Secrets must be manually created in the namespace.
+        # - secretName: chart-example-tls
+        #   hosts:
+        #     - chart-example.local
+      resources: {}
+        # We usually recommend not to specify default resources and to leave this as a conscious
+        # choice for the user. This also increases chances charts run on environments with little
+        # resources, such as Minikube. If you do want to specify resources, uncomment the following
+        # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+        # limits:
+      #  cpu: 100m
+      #  memory: 128Mi
+      # requests:
+      #  cpu: 100m
+      #  memory: 128Mi
+
+  bulk-centralledger:
+
+    cl-handler-bulk-transfer-prepare:
+      enabled: true
+      # Default values for centralledger-handler-bulk-transfer-prepare.
+      # This is a YAML-formatted file.
+      # Declare variables to be passed into your templates.
+      replicaCount: 1
+      containers:
+        api:
+          image:
+            repository: mojaloop/central-ledger
+            tag: v7.1.2
+            pullPolicy: Always
+            command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
+          service:
+            ports:
+              api:
+                name: http-api
+                externalPort: 80
+                internalPort: 3001
+          readinessProbe:
+            enabled: true
+            httpGet:
+              path: /health
+            initialDelaySeconds: 60
+            periodSeconds: 15
+          livenessProbe:
+            enabled: true
+            httpGet:
+              path: /health
+            initialDelaySeconds: 60
+            periodSeconds: 15
+
+      ## metric configuration for prometheus instrumentation
+      metrics:
+        ## flag to enable/disable the metrics end-points
+        enabled: true
+        config:
+          timeout: 5000
+          prefix: moja_
+          defaultLabels:
+            serviceName: central-handler-bulkprepare
+
+      config:
+        ## Forensic Logging sidecar
+        # this is for Forensic Logging Sidecar
+        forensicloggingsidecar_disabled: true
+        forensicloggingsidecar_host: forensicloggingsidecar-ledger
+        forensicloggingsidecar_port: 5678
+
+        ## DB Configuration
+        # db_type can either be 'postgres' or 'mysql'. Ensure the correct DB is enabled and configured below: postgresql.enabled or mysql.enabled
+        db_type: 'mysql'
+        # db_driver can either be 'pg' or 'mysql'. Ensure the correct corresponding db_type above has been set.
+        db_driver: 'mysql'
+        db_host: '$release_name-centralledger-mysql'
+        db_port: 3306
+        db_user: central_ledger
+        db_password: oyMxgZChuu
+        db_database: central_ledger
+        db_connection_pool_min: 10
+        db_connection_pool_max: 30
+
+        ## MongoDB Configuration for Object Store
+        objstore_disabled: false
+        objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
+
+        ## Kafka Configuration
+        # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+        kafka_host: '$release_name-kafka'
+        kafka_port: 9092
+
+        ## Node Configuration
+        log_level: 'info'
+
+      init:
+        enabled: true
+        kafka:
+          name: wait-for-kafka
+          repository: solsson/kafka
+          tag: latest
+          pullPolicy: Always
+          command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
+          env: {}
+          ## Env example
+          # env:
+          #   envItem1:
+          #     name: hello
+          #     value: world
+          #
+        psql:
+          name: wait-for-postgres
+          repository: bowerswilkins/awaitpostgres
+          tag: latest
+          pullPolicy: Always
+        mysql:
+          name: wait-for-mysql
+          repository: mysql
+          tag: latest
+          pullPolicy: Always
+          command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
+        mongodb:
+          name: wait-for-mongodb
+          repository: bitnami/mongodb
+          tag: latest
+          pullPolicy: Always
+          command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+
+      service:
+        type: ClusterIP
+
+        annotations: {}
+
+        # This allows one to point the service to an external backend.
+        # This is useful for local development where one wishes to hijack
+        # the communication from the service to the node layer and point
+        # to a specific endpoint (IP, Port, etc).
+        external:
+          enabled: false
+          # 10.0.2.2 is the magic IP for the host on virtualbox's network
+          ip: 10.0.2.2
+          ports:
+            api:
+              name: http-api
+              externalPort: 3001
+
+      ingress:
+        enabled: true
+        type: http
+        externalPath:
+          api: /
+        # Used to create an Ingress record.
+        hosts:
+          api: central-ledger-transfer-bulkprepare.local
+        annotations:
+          nginx.ingress.kubernetes.io/rewrite-target: '/'
+          # kubernetes.io/ingress.class: nginx
+          # kubernetes.io/tls-acme: "true"
+        tls:
+        # Secrets must be manually created in the namespace.
+        # - secretName: chart-example-tls
+        #   hosts:
+        #     - chart-example.local
+      resources: {}
+        # We usually recommend not to specify default resources and to leave this as a conscious
+        # choice for the user. This also increases chances charts run on environments with little
+        # resources, such as Minikube. If you do want to specify resources, uncomment the following
+        # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+        # limits:
+        #  cpu: 100m
+      #  memory: 128Mi
+      # requests:
+      #  cpu: 100m
+      #  memory: 128Mi
+
+    cl-handler-bulk-transfer-fulfil:
+      enabled: true
+      # Default values for centralledger-handler-bulk-transfer-fulfil.
+      # This is a YAML-formatted file.
+      # Declare variables to be passed into your templates.
+      replicaCount: 1
+      containers:
+        api:
+          image:
+            repository: mojaloop/central-ledger
+            tag: v7.1.2
+            pullPolicy: Always
+            command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
+          service:
+            ports:
+              api:
+                name: http-api
+                externalPort: 80
+                internalPort: 3001
+          readinessProbe:
+            enabled: true
+            httpGet:
+              path: /health
+            initialDelaySeconds: 60
+            periodSeconds: 15
+          livenessProbe:
+            enabled: true
+            httpGet:
+              path: /health
+            initialDelaySeconds: 60
+            periodSeconds: 15
+
+      ## metric configuration for prometheus instrumentation
+      metrics:
+        ## flag to enable/disable the metrics end-points
+        enabled: true
+        config:
+          timeout: 5000
+          prefix: moja_
+          defaultLabels:
+            serviceName: central-handler-bulkfulfil
+
+      config:
+        ## Forensic Logging sidecar
+        # this is for Forensic Logging Sidecar
+        forensicloggingsidecar_disabled: true
+        forensicloggingsidecar_host: forensicloggingsidecar-ledger
+        forensicloggingsidecar_port: 5678
+
+        ## DB Configuration
+        # db_type can either be 'postgres' or 'mysql'. Ensure the correct DB is enabled and configured below: postgresql.enabled or mysql.enabled
+        db_type: 'mysql'
+        # db_driver can either be 'pg' or 'mysql'. Ensure the correct corresponding db_type above has been set.
+        db_driver: 'mysql'
+        db_host: '$release_name-centralledger-mysql'
+        db_port: 3306
+        db_user: central_ledger
+        db_password: oyMxgZChuu
+        db_database: central_ledger
+        db_connection_pool_min: 10
+        db_connection_pool_max: 30
+
+        ## MongoDB Configuration for Object Store
+        objstore_disabled: false
+        objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
+
+        ## Kafka Configuration
+        # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+        kafka_host: '$release_name-kafka'
+        kafka_port: 9092
+
+        ## Node Configuration
+        log_level: 'info'
+
+      init:
+        enabled: true
+        kafka:
+          name: wait-for-kafka
+          repository: solsson/kafka
+          tag: latest
+          pullPolicy: Always
+          command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
+          env: {}
+          ## Env example
+          # env:
+          #   envItem1:
+          #     name: hello
+          #     value: world
+          #
+        psql:
+          name: wait-for-postgres
+          repository: bowerswilkins/awaitpostgres
+          tag: latest
+          pullPolicy: Always
+        mysql:
+          name: wait-for-mysql
+          repository: mysql
+          tag: latest
+          pullPolicy: Always
+          command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
+        mongodb:
+          name: wait-for-mongodb
+          repository: bitnami/mongodb
+          tag: latest
+          pullPolicy: Always
+          command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+
+      service:
+        type: ClusterIP
+
+        annotations: {}
+
+        # This allows one to point the service to an external backend.
+        # This is useful for local development where one wishes to hijack
+        # the communication from the service to the node layer and point
+        # to a specific endpoint (IP, Port, etc).
+        external:
+          enabled: false
+          # 10.0.2.2 is the magic IP for the host on virtualbox's network
+          ip: 10.0.2.2
+          ports:
+            api:
+              name: http-api
+              externalPort: 3001
+
+      ingress:
+        enabled: true
+        type: http
+        externalPath:
+          api: /
+        # Used to create an Ingress record.
+        hosts:
+          api: central-ledger-transfer-bulkfulfil.local
+        annotations:
+          nginx.ingress.kubernetes.io/rewrite-target: '/'
+          # kubernetes.io/ingress.class: nginx
+          # kubernetes.io/tls-acme: "true"
+        tls:
+        # Secrets must be manually created in the namespace.
+        # - secretName: chart-example-tls
+        #   hosts:
+        #     - chart-example.local
+      resources: {}
+        # We usually recommend not to specify default resources and to leave this as a conscious
+        # choice for the user. This also increases chances charts run on environments with little
+        # resources, such as Minikube. If you do want to specify resources, uncomment the following
+        # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+        # limits:
+        #  cpu: 100m
+      #  memory: 128Mi
+      # requests:
+      #  cpu: 100m
+      #  memory: 128Mi
+
+    cl-handler-bulk-transfer-processing:
+      enabled: true
+      # Default values for centralledger-handler-bulk-transfer-processing.
+      # This is a YAML-formatted file.
+      # Declare variables to be passed into your templates.
+      replicaCount: 1
+      containers:
+        api:
+          image:
+            repository: mojaloop/central-ledger
+            tag: v7.1.2
+            pullPolicy: Always
+            command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
+          service:
+            ports:
+              api:
+                name: http-api
+                externalPort: 80
+                internalPort: 3001
+          readinessProbe:
+            enabled: true
+            httpGet:
+              path: /health
+            initialDelaySeconds: 60
+            periodSeconds: 15
+          livenessProbe:
+            enabled: true
+            httpGet:
+              path: /health
+            initialDelaySeconds: 60
+            periodSeconds: 15
+
+      ## metric configuration for prometheus instrumentation
+      metrics:
+        ## flag to enable/disable the metrics end-points
+        enabled: true
+        config:
+          timeout: 5000
+          prefix: moja_
+          defaultLabels:
+            serviceName: central-handler-bulkprocessing
+
+      config:
+        ## Forensic Logging sidecar
+        # this is for Forensic Logging Sidecar
+        forensicloggingsidecar_disabled: true
+        forensicloggingsidecar_host: forensicloggingsidecar-ledger
+        forensicloggingsidecar_port: 5678
+
+        ## DB Configuration
+        # db_type can either be 'postgres' or 'mysql'. Ensure the correct DB is enabled and configured below: postgresql.enabled or mysql.enabled
+        db_type: 'mysql'
+        # db_driver can either be 'pg' or 'mysql'. Ensure the correct corresponding db_type above has been set.
+        db_driver: 'mysql'
+        db_host: '$release_name-centralledger-mysql'
+        db_port: 3306
+        db_user: central_ledger
+        db_password: oyMxgZChuu
+        db_database: central_ledger
+        db_connection_pool_min: 10
+        db_connection_pool_max: 30
+
+        ## MongoDB Configuration for Object Store
+        objstore_disabled: false
+        objstore_uri: 'mongodb://$release_name-centralledger-obj:27017/mlos'
+
+        ## Kafka Configuration
+        # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
+        kafka_host: '$release_name-kafka'
+        kafka_port: 9092
+
+        ## Node Configuration
+        log_level: 'info'
+
+      init:
+        enabled: true
+        kafka:
+          name: wait-for-kafka
+          repository: solsson/kafka
+          tag: latest
+          pullPolicy: Always
+          command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
+          env: {}
+          ## Env example
+          # env:
+          #   envItem1:
+          #     name: hello
+          #     value: world
+          #
+        psql:
+          name: wait-for-postgres
+          repository: bowerswilkins/awaitpostgres
+          tag: latest
+          pullPolicy: Always
+        mysql:
+          name: wait-for-mysql
+          repository: mysql
+          tag: latest
+          pullPolicy: Always
+          command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
+        mongodb:
+          name: wait-for-mongodb
+          repository: bitnami/mongodb
+          tag: latest
+          pullPolicy: Always
+          command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+
+      service:
+        type: ClusterIP
+
+        annotations: {}
+
+        # This allows one to point the service to an external backend.
+        # This is useful for local development where one wishes to hijack
+        # the communication from the service to the node layer and point
+        # to a specific endpoint (IP, Port, etc).
+        external:
+          enabled: false
+          # 10.0.2.2 is the magic IP for the host on virtualbox's network
+          ip: 10.0.2.2
+          ports:
+            api:
+              name: http-api
+              externalPort: 3001
+
+      ingress:
+        enabled: true
+        type: http
+        externalPath:
+          api: /
+        # Used to create an Ingress record.
+        hosts:
+          api: central-ledger-transfer-bulkprocessing.local
+        annotations:
+          nginx.ingress.kubernetes.io/rewrite-target: '/'
+          # kubernetes.io/ingress.class: nginx
+          # kubernetes.io/tls-acme: "true"
+        tls:
+        # Secrets must be manually created in the namespace.
+        # - secretName: chart-example-tls
+        #   hosts:
+        #     - chart-example.local
+      resources: {}
+        # We usually recommend not to specify default resources and to leave this as a conscious
+        # choice for the user. This also increases chances charts run on environments with little
+        # resources, such as Minikube. If you do want to specify resources, uncomment the following
+        # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+        # limits:
+        #  cpu: 100m
+      #  memory: 128Mi
+      # requests:
+      #  cpu: 100m
+      #  memory: 128Mi
+
+  # Declare variables to be passed into your templates.
+  mongodb:
+    ## Global Docker image registry
+    ## Please, note that this will override the image registry for all the images, including dependencies, configured to use the global value
+    ##
+    # global:
+    #   imageRegistry:
+    enabled: true
+    nameOverride: centralledger-obj
+
+    image:
+      ## Bitnami MongoDB registry
+      ##
+      registry: docker.io
+      ## Bitnami MongoDB image name
+      ##
+      repository: bitnami/mongodb
+      ## Bitnami MongoDB image tag
+      ## ref: https://hub.docker.com/r/bitnami/mongodb/tags/
+      ##
+      tag: 4.0.3
+
+      ## Specify a imagePullPolicy
+      ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+      ##
+      pullPolicy: Always
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ##
+      # pullSecrets:
+      #   - myRegistrKeySecretName
+
+    ## Enable authentication
+    ## ref: https://docs.mongodb.com/manual/tutorial/enable-authentication/
+    #
+    usePassword: true
+    # existingSecret: name-of-existing-secret
+
+    ## MongoDB admin password
+    ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#setting-the-root-password-on-first-run
+    ##
+    mongodbRootPassword: adminpass
+
+    ## MongoDB custom user and database
+    ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#creating-a-user-and-database-on-first-run
+    ##
+    mongodbUsername: mojaloop
+    mongodbPassword: password
+    mongodbDatabase: mojaloop
+
+
+    ## Whether enable/disable IPv6 on MongoDB
+    ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#enabling/disabling-ipv6
+    ##
+    mongodbEnableIPv6: true
+
+    ## MongoDB additional command line flags
+    ##
+    ## Can be used to specify command line flags, for example:
+    ##
+    ## mongodbExtraFlags:
+    ##  - "--wiredTigerCacheSizeGB=2"
+    mongodbExtraFlags: []
+
+    ## Pod Security Context
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+    ##
+    securityContext:
+      enabled: true
+      fsGroup: 1001
+      runAsUser: 1001
+
+    ## Kubernetes Cluster Domain
+    clusterDomain: cluster.local
+
+    ## Kubernetes service type
+    service:
+      annotations: {}
+      type: ClusterIP
+      # clusterIP: None
+      port: 27017
+
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+
+    ## Setting up replication
+    ## ref: https://github.com/bitnami/bitnami-docker-mongodb#setting-up-a-replication
+    #
+    replicaSet:
+      ## Whether to create a MongoDB replica set for high availability or not
+      enabled: false
+      useHostnames: true
+
+      ## Name of the replica set
+      ##
+      name: rs0
+
+      ## Key used for replica set authentication
+      ##
+      # key: key
+
+      ## Number of replicas per each node type
+      ##
+      replicas:
+        secondary: 1
+        arbiter: 1
+      ## Pod Disruption Budget
+      ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+      pdb:
+        minAvailable:
+          primary: 1
+          secondary: 1
+          arbiter: 1
+
+    # Annotations to be added to MongoDB pods
+    podAnnotations: {}
+
+    # Additional pod labels to apply
+    podLabels: {}
+
+    ## Configure resource requests and limits
+    ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+    ##
+    resources: {}
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 256Mi
+
+    ## Node selector
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+    nodeSelector: {}
+
+    ## Affinity
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    affinity: {}
+
+    ## Tolerations
+    ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    tolerations: []
+
+    ## Enable persistence using Persistent Volume Claims
+    ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
+    persistence:
+      enabled: false
+      ## A manually managed Persistent Volume and Claim
+      ## Requires persistence.enabled: true
+      ## If defined, PVC must be created manually before volume will be bound
+      # existingClaim:
+
+      ## mongodb data Persistent Volume Storage Class
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If undefined (the default) or set to null, no storageClassName spec is
+      ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+      ##   GKE, AWS & OpenStack)
+      ##
+      # storageClass: "-"
+      accessModes:
+        - ReadWriteOnce
+      size: 8Gi
+      annotations: {}
+
+    ## Configure extra options for liveness and readiness probes
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+      successThreshold: 1
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+      successThreshold: 1
+
+    # Entries for the MongoDB config file
+    configmap:
+    #  # Where and how to store data.
+    #  storage:
+    #    dbPath: /opt/bitnami/mongodb/data/db
+    #    journal:
+    #      enabled: true
+    #    #engine:
+    #    #wiredTiger:
+    #  # where to write logging data.
+    #  systemLog:
+    #    destination: file
+    #    logAppend: true
+    #    path: /opt/bitnami/mongodb/logs/mongodb.log
+    #  # network interfaces
+    #  net:
+    #    port: 27017
+    #    bindIp: 0.0.0.0
+    #    unixDomainSocket:
+    #      enabled: true
+    #      pathPrefix: /opt/bitnami/mongodb/tmp
+    #  # replica set options
+    #  #replication:
+    #  #  replSetName: replicaset
+    #  # process management options
+    #  processManagement:
+    #     fork: false
+    #     pidFilePath: /opt/bitnami/mongodb/tmp/mongodb.pid
+    #  # set parameter options
+    #  setParameter:
+    #     enableLocalhostAuthBypass: true
+    #  # security options
+    #  security:
+    #  authorization: enabled
+    #keyFile: /opt/bitnami/mongodb/conf/keyfile
+
+    ## Prometheus Exporter / Metrics
+    ##
+    metrics:
+      enabled: false
+
+      image:
+        registry: docker.io
+        repository: forekshub/percona-mongodb-exporter
+        tag: latest
+        pullPolicy: IfNotPresent
+        ## Optionally specify an array of imagePullSecrets.
+        ## Secrets must be manually created in the namespace.
+        ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+        ##
+        # pullSecrets:
+        #   - myRegistrKeySecretName
+
+      ## Metrics exporter resource requests and limits
+      ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+      ##
+      # resources: {}
+
+      ## Metrics exporter pod Annotation
+      podAnnotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9216"
+
+      ## Prometheus Service Monitor
+      ## ref: https://github.com/coreos/prometheus-operator
+      ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md
+      serviceMonitor:
+        ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
+        enabled: false
+        ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
+        ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+        additionalLabels: {}
+
+        ## Specify Metric Relabellings to add to the scrape endpoint
+        ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+        # relabellings:
+
+        alerting:
+          ## Define individual alerting rules as required
+          ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#rulegroup
+          ##      https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+          rules: {}
+
+          ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Prometheus Rules to work with
+          ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+    additionalLabels: {}

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -37,7 +37,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v6.2.5
+            tag: v7.1.0
             pullPolicy: Always
             command: '["node", "src/api/index.js"]'
           service:
@@ -166,7 +166,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v6.2.5
+            tag: v7.1.0
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
           service:
@@ -303,7 +303,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v6.2.5
+            tag: v7.1.0
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--admin"]'
           service:
@@ -440,7 +440,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v6.2.5
+            tag: v7.1.0
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--position"]'
           service:
@@ -577,7 +577,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v6.2.5
+            tag: v7.1.0
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--get"]'
           service:
@@ -714,7 +714,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v6.2.5
+            tag: v7.1.0
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
           service:
@@ -851,7 +851,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v6.2.5
+            tag: v7.1.0
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
           service:
@@ -2545,7 +2545,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v6.2.1
+      tag: v7.1.0
       command: '["node", "src/api/index.js"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -2611,7 +2611,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v6.2.1
+      tag: v7.1.0
       command: '["node", "src/handlers/index.js", "handler", "--notification"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/package.sh
+++ b/package.sh
@@ -94,7 +94,19 @@ checkCommandResult
 echo "Packaging Mojaloop..." 
 helm package -u -d ./repo ./mojaloop 
 checkCommandResult
- 
+
+echo "Updating bulk-centralledger..."
+helm package -u -d ./repo ./bulk-centralledger/
+checkCommandResult
+
+echo "Updating bulk-api-adapter..."
+helm package -u -d ./repo ./bulk-api-adapter/
+checkCommandResult
+
+echo "Updating Mojaloop Bulk..."
+helm package -u -d ./repo ./mojaloop-bulk/
+checkCommandResult
+
 echo "Packaging Ingress-Nginx..."
 helm package -u -d ./repo ./kube-public/ingress-nginx/
 checkCommandResult

--- a/package.sh
+++ b/package.sh
@@ -91,10 +91,6 @@ echo "Packaging quoting-service..."
 helm package -u -d ./repo ./quoting-service
 checkCommandResult
 
-echo "Packaging Mojaloop..." 
-helm package -u -d ./repo ./mojaloop 
-checkCommandResult
-
 echo "Updating bulk-centralledger..."
 helm package -u -d ./repo ./bulk-centralledger/
 checkCommandResult
@@ -105,6 +101,10 @@ checkCommandResult
 
 echo "Updating Mojaloop Bulk..."
 helm package -u -d ./repo ./mojaloop-bulk/
+checkCommandResult
+
+echo "Packaging Mojaloop..." 
+helm package -u -d ./repo ./mojaloop 
 checkCommandResult
 
 echo "Packaging Ingress-Nginx..."

--- a/update-charts-dep.sh
+++ b/update-charts-dep.sh
@@ -89,10 +89,6 @@ echo "Updating Central..."
 helm dep up ./central
 checkCommandResult
 
-echo "Updating Mojaloop..."
-helm dep up ./mojaloop
-checkCommandResult
-
 echo "Updating bulk-centralledger..."
 helm dep up ./bulk-centralledger/
 checkCommandResult
@@ -103,6 +99,10 @@ checkCommandResult
 
 echo "Updating Mojaloop Bulk..."
 helm dep up ./mojaloop-bulk
+checkCommandResult
+
+echo "Updating Mojaloop..."
+helm dep up ./mojaloop
 checkCommandResult
 
 echo "\

--- a/update-charts-dep.sh
+++ b/update-charts-dep.sh
@@ -93,6 +93,18 @@ echo "Updating Mojaloop..."
 helm dep up ./mojaloop
 checkCommandResult
 
+echo "Updating bulk-centralledger..."
+helm dep up ./bulk-centralledger/
+checkCommandResult
+
+echo "Updating bulk-api-adapter..."
+helm dep up ./bulk-api-adapter/
+checkCommandResult
+
+echo "Updating Mojaloop Bulk..."
+helm dep up ./mojaloop-bulk
+checkCommandResult
+
 echo "\
 Chart updates completed.\n \
 Ensure you check the output for any errors. \n \


### PR DESCRIPTION
- Updated central-event-process for v7.1.0 release
- Updated email-notifier for v7.1.0 release
- Re-worked update and publish scripts to correctly handle dependency ordering
- Changes for #821-Bulk Transfers Initial Release - https://github.com/mojaloop/project/issues/821
    - Added bulk-api-handler chart
    - Added bulk-centralledger chart
    - Added mojaloop-bulk chart
    - Updated update chart shell script to include bulk charts
    - Updated package chart shell script to include bulk charts
    - Added mojaloop-bulk as an optional dependency to main mojaloop helm chart (note is is disabled by default)
    - Added mongodb init-containers to bulk-api-adapter and bulk-centralledger