### PR TITLE
Updates for https://github.com/mojaloop/project/issues/940

### DIFF
--- a/bulk-centralledger/Chart.yaml
+++ b/bulk-centralledger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Bulk Services Helm chart for Kubernetes
 name: bulk-centralledger
-version: 7.4.0
-appVersion: "7.4.1"
+version: 7.4.3
+appVersion: "7.4.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Bulk Transfer Fulfil Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-fulfil
-version: 7.4.0
-appVersion: "7.4.1"
+version: 7.4.3
+appVersion: "7.4.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/configs/default.json
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/configs/default.json
@@ -8,8 +8,8 @@
         "RUN_DATA_MIGRATIONS": true
     },
     "AMOUNT": {
-        "PRECISION": 10,
-        "SCALE": 2
+        "PRECISION": 18,
+        "SCALE": 4
     },
     "SIDECAR": {
         "DISABLED": {{ .Values.config.forensicloggingsidecar_disabled }},

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v7.4.1
+      tag: v7.4.3
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
     service:

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Bulk Transfer Prepare Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-prepare
-version: 7.4.0
-appVersion: "7.4.1"
+version: 7.4.3
+appVersion: "7.4.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/configs/default.json
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/configs/default.json
@@ -8,8 +8,8 @@
         "RUN_DATA_MIGRATIONS": true
     },
     "AMOUNT": {
-        "PRECISION": 10,
-        "SCALE": 2
+        "PRECISION": 18,
+        "SCALE": 4
     },
     "SIDECAR": {
         "DISABLED": {{ .Values.config.forensicloggingsidecar_disabled }},

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v7.4.1
+      tag: v7.4.3
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
     service:

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Bulk Transfer Processing Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-processing
-version: 7.4.0
-appVersion: "7.4.1"
+version: 7.4.3
+appVersion: "7.4.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/configs/default.json
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/configs/default.json
@@ -8,8 +8,8 @@
         "RUN_DATA_MIGRATIONS": true
     },
     "AMOUNT": {
-        "PRECISION": 10,
-        "SCALE": 2
+        "PRECISION": 18,
+        "SCALE": 4
     },
     "SIDECAR": {
         "DISABLED": {{ .Values.config.forensicloggingsidecar_disabled }},

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v7.4.1
+      tag: v7.4.3
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
     service:

--- a/bulk-centralledger/requirements.yaml
+++ b/bulk-centralledger/requirements.yaml
@@ -1,14 +1,14 @@
 # requirements.yaml
 dependencies:
 - name: cl-handler-bulk-transfer-prepare
-  version: 7.4.0
+  version: 7.4.3
   repository: "file://./chart-handler-bulk-transfer-prepare"
   condition: cl-handler-bulk-transfer-prepare.enabled
 - name: cl-handler-bulk-transfer-fulfil
-  version: 7.4.0
+  version: 7.4.3
   repository: "file://./chart-handler-bulk-transfer-fulfil"
   condition: cl-handler-bulk-transfer-fulfil.enabled
 - name: cl-handler-bulk-transfer-processing
-  version: 7.4.0
+  version: 7.4.3
   repository: "file://./chart-handler-bulk-transfer-processing"
   condition: cl-handler-bulk-transfer-processing.enabled

--- a/bulk-centralledger/values.yaml
+++ b/bulk-centralledger/values.yaml
@@ -27,7 +27,7 @@ cl-handler-bulk-transfer-prepare:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v7.4.1
+        tag: v7.4.3
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
       service:
@@ -181,7 +181,7 @@ cl-handler-bulk-transfer-fulfil:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v7.4.1
+        tag: v7.4.3
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
       service:
@@ -335,7 +335,7 @@ cl-handler-bulk-transfer-processing:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v7.4.1
+        tag: v7.4.3
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
       service:

--- a/central/Chart.yaml
+++ b/central/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central Helm chart for Kubernetes
 name: central
-version: 7.4.1
-appVersion: "central-ledger: v7.4.1; central-settlement: v7.4.0; central-event-processor: v7.3.0"
+version: 7.4.2
+appVersion: "central-ledger: v7.4.3; central-settlement: v7.4.0; central-event-processor: v7.3.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/central/requirements.yaml
+++ b/central/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: centralledger
-  version: 7.4.1
+  version: 7.4.3
   repository: "file://../centralledger"
   condition: centralledger.enabled
 ## Deprecated - to be removed shortly

--- a/central/requirements.yaml
+++ b/central/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
 #  repository: "file://../centraldirectory"
 #  condition: centraldirectory.enabled
 - name: centralsettlement
-  version: 7.4.0
+  version: 7.4.1
   repository: "file://../centralsettlement"
   condition: centralsettlement.enabled
 - name: centraleventprocessor

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -1961,7 +1961,7 @@ centralsettlement:
   replicaCount: 1
   image:
     repository: mojaloop/central-settlement
-    tag: v7.3.0
+    tag: v7.4.0
     pullPolicy: Always
 
   readinessProbe:

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -35,7 +35,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v7.4.1
+          tag: v7.4.3
           pullPolicy: Always
           command: '["node", "src/api/index.js"]'
         service:
@@ -163,7 +163,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v7.4.1
+          tag: v7.4.3
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
         service:
@@ -300,7 +300,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v7.4.1
+          tag: v7.4.3
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--position"]'
         service:
@@ -437,7 +437,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v7.4.1
+          tag: v7.4.3
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--get"]'
         service:
@@ -574,7 +574,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v7.4.1
+          tag: v7.4.3
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
         service:
@@ -711,7 +711,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v7.4.1
+          tag: v7.4.3
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
         service:
@@ -848,7 +848,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v7.4.1
+          tag: v7.4.3
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--admin"]'
         service:

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -104,6 +104,8 @@ centralledger:
         enabled: true
         name: run-migration
         command: npm run migrate
+        config:
+          run_data_migration: true
 
     service:
       type: ClusterIP

--- a/centralledger/Chart.yaml
+++ b/centralledger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Helm chart for Kubernetes
 name: centralledger
-version: 7.4.1
-appVersion: "7.4.1"
+version: 7.4.3
+appVersion: "7.4.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-admin-transfer/Chart.yaml
+++ b/centralledger/chart-handler-admin-transfer/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-admin-transfer
-version: 7.4.1
-appVersion: "7.4.1"
+version: 7.4.3
+appVersion: "7.4.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-admin-transfer/configs/default.json
+++ b/centralledger/chart-handler-admin-transfer/configs/default.json
@@ -8,8 +8,8 @@
         "RUN_DATA_MIGRATIONS": true
     },
     "AMOUNT": {
-        "PRECISION": 10,
-        "SCALE": 2
+        "PRECISION": 18,
+        "SCALE": 4
     },
     "SIDECAR": {
         "DISABLED": {{ .Values.config.forensicloggingsidecar_disabled }},

--- a/centralledger/chart-handler-admin-transfer/values.yaml
+++ b/centralledger/chart-handler-admin-transfer/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v7.4.1
+      tag: v7.4.3
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--admin"]'
     service:

--- a/centralledger/chart-handler-timeout/Chart.yaml
+++ b/centralledger/chart-handler-timeout/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Timeout Handler Helm chart for Kubernetes
 name: centralledger-handler-timeout
-version: 7.4.1
-appVersion: "7.4.1"
+version: 7.4.3
+appVersion: "7.4.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-timeout/configs/default.json
+++ b/centralledger/chart-handler-timeout/configs/default.json
@@ -8,8 +8,8 @@
         "RUN_DATA_MIGRATIONS": true
     },
     "AMOUNT": {
-        "PRECISION": 10,
-        "SCALE": 2
+        "PRECISION": 18,
+        "SCALE": 4
     },
     "SIDECAR": {
         "DISABLED": {{ .Values.config.forensicloggingsidecar_disabled }},

--- a/centralledger/chart-handler-timeout/values.yaml
+++ b/centralledger/chart-handler-timeout/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v7.4.1
+      tag: v7.4.3
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
     service:

--- a/centralledger/chart-handler-transfer-fulfil/Chart.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Fulfil Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-fulfil
-version: 7.4.1
-appVersion: "7.4.1"
+version: 7.4.3
+appVersion: "7.4.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-fulfil/configs/default.json
+++ b/centralledger/chart-handler-transfer-fulfil/configs/default.json
@@ -8,8 +8,8 @@
         "RUN_DATA_MIGRATIONS": true
     },
     "AMOUNT": {
-        "PRECISION": 10,
-        "SCALE": 2
+        "PRECISION": 18,
+        "SCALE": 4
     },
     "SIDECAR": {
         "DISABLED": {{ .Values.config.forensicloggingsidecar_disabled }},

--- a/centralledger/chart-handler-transfer-fulfil/values.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v7.4.1
+      tag: v7.4.3
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
     service:

--- a/centralledger/chart-handler-transfer-get/Chart.yaml
+++ b/centralledger/chart-handler-transfer-get/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Get Transfer Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-get
-version: 7.4.1
-appVersion: "7.4.1"
+version: 7.4.3
+appVersion: "7.4.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-get/configs/default.json
+++ b/centralledger/chart-handler-transfer-get/configs/default.json
@@ -8,8 +8,8 @@
         "RUN_DATA_MIGRATIONS": true
     },
     "AMOUNT": {
-        "PRECISION": 10,
-        "SCALE": 2
+        "PRECISION": 18,
+        "SCALE": 4
     },
     "SIDECAR": {
         "DISABLED": {{ .Values.config.forensicloggingsidecar_disabled }},

--- a/centralledger/chart-handler-transfer-position/Chart.yaml
+++ b/centralledger/chart-handler-transfer-position/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Position Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-position
-version: 7.4.1
-appVersion: "7.4.1"
+version: 7.4.3
+appVersion: "7.4.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-position/configs/default.json
+++ b/centralledger/chart-handler-transfer-position/configs/default.json
@@ -8,8 +8,8 @@
         "RUN_DATA_MIGRATIONS": true
     },
     "AMOUNT": {
-        "PRECISION": 10,
-        "SCALE": 2
+        "PRECISION": 18,
+        "SCALE": 4
     },
     "SIDECAR": {
         "DISABLED": {{ .Values.config.forensicloggingsidecar_disabled }},

--- a/centralledger/chart-handler-transfer-position/values.yaml
+++ b/centralledger/chart-handler-transfer-position/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v7.4.1
+      tag: v7.4.3
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--position"]'
     service:

--- a/centralledger/chart-handler-transfer-prepare/Chart.yaml
+++ b/centralledger/chart-handler-transfer-prepare/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-prepare
-version: 7.4.1
-appVersion: "7.4.1"
+version: 7.4.3
+appVersion: "7.4.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-prepare/configs/default.json
+++ b/centralledger/chart-handler-transfer-prepare/configs/default.json
@@ -8,8 +8,8 @@
         "RUN_DATA_MIGRATIONS": true
     },
     "AMOUNT": {
-        "PRECISION": 10,
-        "SCALE": 2
+        "PRECISION": 18,
+        "SCALE": 4
     },
     "SIDECAR": {
         "DISABLED": {{ .Values.config.forensicloggingsidecar_disabled }},

--- a/centralledger/chart-handler-transfer-prepare/values.yaml
+++ b/centralledger/chart-handler-transfer-prepare/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v7.4.1
+      tag: v7.4.3
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
     service:

--- a/centralledger/chart-service/Chart.yaml
+++ b/centralledger/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Service Helm chart for Kubernetes
 name: centralledger-service
-version: 7.4.1
-appVersion: "7.4.1"
+version: 7.4.3
+appVersion: "7.4.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-service/configs/default.json
+++ b/centralledger/chart-service/configs/default.json
@@ -8,8 +8,8 @@
         "RUN_DATA_MIGRATIONS": true
     },
     "AMOUNT": {
-        "PRECISION": 10,
-        "SCALE": 2
+        "PRECISION": 18,
+        "SCALE": 4
     },
     "SIDECAR": {
         "DISABLED": {{ .Values.config.forensicloggingsidecar_disabled }},

--- a/centralledger/chart-service/templates/deployment.yaml
+++ b/centralledger/chart-service/templates/deployment.yaml
@@ -62,6 +62,8 @@ spec:
           env:
             - name: "CLEDG_DATABASE_URI"
               value: "{{ .Values.config.db_type }}://{{ .Values.config.db_user }}:{{ .Values.config.db_password }}@{{ (default .Values.config.db_host $dbHost) }}:{{ .Values.config.db_port }}/{{ .Values.config.db_database }}"
+            - name: "CLEDG_MIGRATIONS__RUN_DATA_MIGRATIONS"
+              value: {{ .Values.init.migration.config.run_data_migration | quote }}
         {{- end }}
       {{- end }}
       containers:

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -105,6 +105,8 @@ init:
     enabled: true
     name: run-migration
     command: npm run migrate
+    config:
+      run_data_migration: true
 
 service:
   type: ClusterIP

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v7.4.1
+      tag: v7.4.3
       pullPolicy: Always
       command: '["node", "src/api/index.js"]'
     service:

--- a/centralledger/requirements.yaml
+++ b/centralledger/requirements.yaml
@@ -1,31 +1,31 @@
 # requirements.yaml
 dependencies:
 - name: centralledger-service
-  version: 7.4.1
+  version: 7.4.3
   repository: "file://./chart-service"
   condition: centralledger-service.enabled
 - name: centralledger-handler-transfer-prepare
-  version: 7.4.1
+  version: 7.4.3
   repository: "file://./chart-handler-transfer-prepare"
   condition: centralledger-handler-transfer-prepare.enabled
 - name: centralledger-handler-transfer-position
-  version: 7.4.1
+  version: 7.4.3
   repository: "file://./chart-handler-transfer-position"
   condition: centralledger-handler-transfer-position.enabled
 - name: centralledger-handler-transfer-get
-  version: 7.4.1
+  version: 7.4.3
   repository: "file://./chart-handler-transfer-get"
   condition: centralledger-handler-transfer-get.enabled
 - name: centralledger-handler-transfer-fulfil
-  version: 7.4.1
+  version: 7.4.3
   repository: "file://./chart-handler-transfer-fulfil"
   condition: centralledger-handler-transfer-fulfil.enabled
 - name: centralledger-handler-timeout
-  version: 7.4.1
+  version: 7.4.3
   repository: "file://./chart-handler-timeout"
   condition: centralledger-handler-timeout.enabled
 - name: centralledger-handler-admin-transfer
-  version: 7.4.1
+  version: 7.4.3
   repository: "file://./chart-handler-admin-transfer"
   condition: centralledger-handler-transfer-get.enabled
 - name: forensicloggingsidecar

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -30,7 +30,7 @@ centralledger-service:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v7.4.1
+        tag: v7.4.3
         pullPolicy: Always
         command: '["node", "src/api/index.js"]'
       service:
@@ -158,7 +158,7 @@ centralledger-handler-transfer-prepare:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v7.4.1
+        tag: v7.4.3
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
       service:
@@ -295,7 +295,7 @@ centralledger-handler-transfer-position:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v7.4.1
+        tag: v7.4.3
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--position"]'
       service:
@@ -432,7 +432,7 @@ centralledger-handler-transfer-get:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v7.4.1
+        tag: v7.4.3
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--get"]'
       service:
@@ -569,7 +569,7 @@ centralledger-handler-transfer-fulfil:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v7.4.1
+        tag: v7.4.3
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
       service:
@@ -706,7 +706,7 @@ centralledger-handler-timeout:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v7.4.1
+        tag: v7.4.3
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
       service:
@@ -843,7 +843,7 @@ centralledger-handler-admin-transfer:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v7.4.1
+        tag: v7.4.3
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--admin"]'
       service:

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -99,6 +99,8 @@ centralledger-service:
       enabled: true
       name: run-migration
       command: npm run migrate
+      config:
+        run_data_migration: true
 
   service:
     type: ClusterIP

--- a/centralsettlement/Chart.yaml
+++ b/centralsettlement/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Settlement Helm chart for Kubernetes
 name: centralsettlement
-version: 7.4.0
-appVersion: "7.3.0"
+version: 7.4.1
+appVersion: "7.4.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralsettlement/values.yaml
+++ b/centralsettlement/values.yaml
@@ -21,7 +21,7 @@ global:
 replicaCount: 1
 image:
   repository: mojaloop/central-settlement
-  tag: v7.3.0
+  tag: v7.4.0
   pullPolicy: Always
 
 readinessProbe:

--- a/ml-api-adapter/Chart.yaml
+++ b/ml-api-adapter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Helm chart for Kubernetes
 name: ml-api-adapter
-version: 7.4.0
-appVersion: "7.4.0"
+version: 7.4.1
+appVersion: "7.4.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/Chart.yaml
+++ b/ml-api-adapter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Helm chart for Kubernetes
 name: ml-api-adapter
-version: 7.3.0
-appVersion: "7.3.0"
+version: 7.4.0
+appVersion: "7.4.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-handler-notification/Chart.yaml
+++ b/ml-api-adapter/chart-handler-notification/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: ml-api-adapter-handler-notification
-version: 7.4.0
-appVersion: "7.4.0"
+version: 7.4.1
+appVersion: "7.4.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-handler-notification/Chart.yaml
+++ b/ml-api-adapter/chart-handler-notification/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: ml-api-adapter-handler-notification
-version: 7.3.0
-appVersion: "7.3.0"
+version: 7.4.0
+appVersion: "7.4.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-handler-notification/configs/default.json
+++ b/ml-api-adapter/chart-handler-notification/configs/default.json
@@ -14,6 +14,8 @@
         }
     },
     "HOSTNAME": "{{ .Values.ingress.hosts.api }}",
+    "MAX_CALLBACK_TIME_LAG_DILATION_MILLISECONDS": {{ .Values.config.max_callback_time_lag_dilation_milliseconds }},
+    "MAX_FULFIL_TIMEOUT_DURATION_SECONDS": {{ .Values.config.max_fulfil_timeout_duration_seconds }},
     "AMOUNT": {
         "PRECISION": 10,
         "SCALE": 2

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -63,7 +63,7 @@ config:
     callback:
       rejectUnauthorized: true
   log_level: 'info'
-  max_callback_time_lag_dilation_milliseconds: 0
+  max_callback_time_lag_dilation_milliseconds: 100
   max_fulfil_timeout_duration_seconds: 240
 
 service:

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v7.3.0
+  tag: v7.4.0
   command: '["node", "src/handlers/index.js", "handler", "--notification"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.
@@ -63,6 +63,8 @@ config:
     callback:
       rejectUnauthorized: true
   log_level: 'info'
+  max_callback_time_lag_dilation_milliseconds: 0
+  max_fulfil_timeout_duration_seconds: 0
 
 service:
   type: ClusterIP

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v7.4.0
+  tag: v7.4.1
   command: '["node", "src/handlers/index.js", "handler", "--notification"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.
@@ -64,7 +64,7 @@ config:
       rejectUnauthorized: true
   log_level: 'info'
   max_callback_time_lag_dilation_milliseconds: 0
-  max_fulfil_timeout_duration_seconds: 0
+  max_fulfil_timeout_duration_seconds: 240
 
 service:
   type: ClusterIP

--- a/ml-api-adapter/chart-service/Chart.yaml
+++ b/ml-api-adapter/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter API component Helm chart for Kubernetes
 name: ml-api-adapter-service
-version: 7.3.0
-appVersion: "7.3.0"
+version: 7.4.0
+appVersion: "7.4.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-service/Chart.yaml
+++ b/ml-api-adapter/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter API component Helm chart for Kubernetes
 name: ml-api-adapter-service
-version: 7.4.0
-appVersion: "7.4.0"
+version: 7.4.1
+appVersion: "7.4.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-service/configs/default.json
+++ b/ml-api-adapter/chart-service/configs/default.json
@@ -14,6 +14,8 @@
         }
     },
     "HOSTNAME": "{{ .Values.ingress.hosts.api }}",
+    "MAX_CALLBACK_TIME_LAG_DILATION_MILLISECONDS": {{ .Values.config.max_callback_time_lag_dilation_milliseconds }},
+    "MAX_FULFIL_TIMEOUT_DURATION_SECONDS": {{ .Values.config.max_fulfil_timeout_duration_seconds }},
     "AMOUNT": {
         "PRECISION": 10,
         "SCALE": 2

--- a/ml-api-adapter/chart-service/values.yaml
+++ b/ml-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v7.3.0
+  tag: v7.4.0
   command: '["node", "src/api/index.js"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.
@@ -63,6 +63,8 @@ config:
     callback:
       rejectUnauthorized: true
   log_level: 'info'
+  max_callback_time_lag_dilation_milliseconds: 0
+  max_fulfil_timeout_duration_seconds: 0
 
 service:
   type: ClusterIP

--- a/ml-api-adapter/chart-service/values.yaml
+++ b/ml-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v7.4.0
+  tag: v7.4.1
   command: '["node", "src/api/index.js"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.
@@ -64,7 +64,7 @@ config:
       rejectUnauthorized: true
   log_level: 'info'
   max_callback_time_lag_dilation_milliseconds: 0
-  max_fulfil_timeout_duration_seconds: 0
+  max_fulfil_timeout_duration_seconds: 240
 
 service:
   type: ClusterIP

--- a/ml-api-adapter/chart-service/values.yaml
+++ b/ml-api-adapter/chart-service/values.yaml
@@ -63,7 +63,7 @@ config:
     callback:
       rejectUnauthorized: true
   log_level: 'info'
-  max_callback_time_lag_dilation_milliseconds: 0
+  max_callback_time_lag_dilation_milliseconds: 100
   max_fulfil_timeout_duration_seconds: 240
 
 service:

--- a/ml-api-adapter/requirements.yaml
+++ b/ml-api-adapter/requirements.yaml
@@ -1,11 +1,11 @@
 # requirements.yaml
 dependencies:
 - name: ml-api-adapter-service
-  version: 7.3.0
+  version: 7.4.0
   repository: "file://./chart-service"
   condition: ml-api-adapter-service.enabled
 - name: ml-api-adapter-handler-notification
-  version: 7.3.0
+  version: 7.4.0
   repository: "file://./chart-handler-notification"
   condition: ml-api-adapter-handler-notification.enabled
 ## This is used for testing ml-api-adapter deployments

--- a/ml-api-adapter/requirements.yaml
+++ b/ml-api-adapter/requirements.yaml
@@ -1,11 +1,11 @@
 # requirements.yaml
 dependencies:
 - name: ml-api-adapter-service
-  version: 7.4.0
+  version: 7.4.1
   repository: "file://./chart-service"
   condition: ml-api-adapter-service.enabled
 - name: ml-api-adapter-handler-notification
-  version: 7.4.0
+  version: 7.4.1
   repository: "file://./chart-handler-notification"
   condition: ml-api-adapter-handler-notification.enabled
 ## This is used for testing ml-api-adapter deployments

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -26,7 +26,7 @@ ml-api-adapter-service:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v7.3.0
+    tag: v7.4.0
     command: '["node", "src/api/index.js"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -80,6 +80,8 @@ ml-api-adapter-service:
       callback:
         rejectUnauthorized: true
     log_level: 'info'
+    max_callback_time_lag_dilation_milliseconds: 0
+    max_fulfil_timeout_duration_seconds: 0
 
   service:
     type: ClusterIP
@@ -123,7 +125,7 @@ ml-api-adapter-handler-notification:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v7.3.0
+    tag: v7.4.0
     command: '["node", "src/handlers/index.js", "handler", "--notification"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -164,6 +166,8 @@ ml-api-adapter-handler-notification:
       callback:
         rejectUnauthorized: true
     log_level: 'info'
+    max_callback_time_lag_dilation_milliseconds: 0
+    max_fulfil_timeout_duration_seconds: 0
 
   service:
     type: ClusterIP

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -80,7 +80,7 @@ ml-api-adapter-service:
       callback:
         rejectUnauthorized: true
     log_level: 'info'
-    max_callback_time_lag_dilation_milliseconds: 0
+    max_callback_time_lag_dilation_milliseconds: 100
     max_fulfil_timeout_duration_seconds: 240
 
   service:
@@ -166,7 +166,7 @@ ml-api-adapter-handler-notification:
       callback:
         rejectUnauthorized: true
     log_level: 'info'
-    max_callback_time_lag_dilation_milliseconds: 0
+    max_callback_time_lag_dilation_milliseconds: 100
     max_fulfil_timeout_duration_seconds: 240
 
   service:

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -26,7 +26,7 @@ ml-api-adapter-service:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v7.4.0
+    tag: v7.4.1
     command: '["node", "src/api/index.js"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -81,7 +81,7 @@ ml-api-adapter-service:
         rejectUnauthorized: true
     log_level: 'info'
     max_callback_time_lag_dilation_milliseconds: 0
-    max_fulfil_timeout_duration_seconds: 0
+    max_fulfil_timeout_duration_seconds: 240
 
   service:
     type: ClusterIP
@@ -125,7 +125,7 @@ ml-api-adapter-handler-notification:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v7.4.0
+    tag: v7.4.1
     command: '["node", "src/handlers/index.js", "handler", "--notification"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -167,7 +167,7 @@ ml-api-adapter-handler-notification:
         rejectUnauthorized: true
     log_level: 'info'
     max_callback_time_lag_dilation_milliseconds: 0
-    max_fulfil_timeout_duration_seconds: 0
+    max_fulfil_timeout_duration_seconds: 240
 
   service:
     type: ClusterIP

--- a/mojaloop-bulk/Chart.yaml
+++ b/mojaloop-bulk/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Mojaloop Bulk Helm chart for Kubernetes
 name: mojaloop-bulk
-version: 7.4.0
-appVersion: "bulk-api-adapter: v7.3.1-snapshot; central-ledger: v7.4.1"
+version: 7.4.1
+appVersion: "bulk-api-adapter: v7.3.1-snapshot; central-ledger: v7.4.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop-bulk/requirements.yaml
+++ b/mojaloop-bulk/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
   repository: "file://../bulk-api-adapter"
   condition: bulk-api-adapter.enabled
 - name: bulk-centralledger
-  version: 7.4.0
+  version: 7.4.3
   repository: "file://../bulk-centralledger"
   condition: bulk-centralledger.enabled
 - name: mongodb

--- a/mojaloop-bulk/values.yaml
+++ b/mojaloop-bulk/values.yaml
@@ -250,7 +250,7 @@ bulk-centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v7.4.1
+          tag: v7.4.3
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
         service:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 7.4.3
-appVersion: "ml-api-adapter: v7.4.1; central-ledger: v7.4.1; account-lookup-service: v7.4.0-snapshot; quoting-service: v7.4.0-snapshot; central-settlement: v7.4.0; central-event-processor: v7.3.0; bulk-api-adapter: v7.3.1-snapshot; email-notifier: v7.3.0; simulator: v7.2.1"
+appVersion: "ml-api-adapter: v7.4.1; central-ledger: v7.4.3; account-lookup-service: v7.4.0-snapshot; quoting-service: v7.4.0-snapshot; central-settlement: v7.4.0; central-event-processor: v7.3.0; bulk-api-adapter: v7.3.1-snapshot; email-notifier: v7.3.0; simulator: v7.2.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
-version: 7.4.2
-appVersion: "ml-api-adapter: v7.3.0; central-ledger: v7.4.1; account-lookup-service: v7.4.0-snapshot; quoting-service: v7.4.0-snapshot; central-settlement: v7.4.0; central-event-processor: v7.3.0; bulk-api-adapter: v7.3.1-snapshot; email-notifier: v7.3.0; simulator: v7.2.1"
+version: 7.4.3
+appVersion: "ml-api-adapter: v7.4.0; central-ledger: v7.4.1; account-lookup-service: v7.4.0-snapshot; quoting-service: v7.4.0-snapshot; central-settlement: v7.4.0; central-event-processor: v7.3.0; bulk-api-adapter: v7.3.1-snapshot; email-notifier: v7.3.0; simulator: v7.2.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 7.4.3
-appVersion: "ml-api-adapter: v7.4.0; central-ledger: v7.4.1; account-lookup-service: v7.4.0-snapshot; quoting-service: v7.4.0-snapshot; central-settlement: v7.4.0; central-event-processor: v7.3.0; bulk-api-adapter: v7.3.1-snapshot; email-notifier: v7.3.0; simulator: v7.2.1"
+appVersion: "ml-api-adapter: v7.4.1; central-ledger: v7.4.1; account-lookup-service: v7.4.0-snapshot; quoting-service: v7.4.0-snapshot; central-settlement: v7.4.0; central-event-processor: v7.3.0; bulk-api-adapter: v7.3.1-snapshot; email-notifier: v7.3.0; simulator: v7.2.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: central
-  version: 7.4.1
+  version: 7.4.2
   repository: "file://../central"
   condition: central.enabled
 ## Deprecated - to be removed shortly
@@ -30,6 +30,6 @@ dependencies:
   repository: "file://../simulator"
   condition: simulator.enabled
 - name: mojaloop-bulk
-  version: 7.4.0
+  version: 7.4.1
   repository: "file://../mojaloop-bulk"
   condition: mojaloop-bulk.enabled

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
 #  repository: "file://../interop-switch"
 #  condition: interop-switch.enabled
 - name: ml-api-adapter
-  version: 7.3.0
+  version: 7.4.0
   repository: "file://../ml-api-adapter"
   condition: ml-api-adapter.enabled
 - name: emailnotifier

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
 #  repository: "file://../interop-switch"
 #  condition: interop-switch.enabled
 - name: ml-api-adapter
-  version: 7.4.0
+  version: 7.4.1
   repository: "file://../ml-api-adapter"
   condition: ml-api-adapter.enabled
 - name: emailnotifier

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -106,6 +106,8 @@ central:
           enabled: true
           name: run-migration
           command: npm run migrate
+          config:
+            run_data_migration: true
 
       service:
         type: ClusterIP

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -37,7 +37,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v7.4.1
+            tag: v7.4.3
             pullPolicy: Always
             command: '["node", "src/api/index.js"]'
           service:
@@ -165,7 +165,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v7.4.1
+            tag: v7.4.3
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
           service:
@@ -302,7 +302,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v7.4.1
+            tag: v7.4.3
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--admin"]'
           service:
@@ -439,7 +439,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v7.4.1
+            tag: v7.4.3
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--position"]'
           service:
@@ -576,7 +576,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v7.4.1
+            tag: v7.4.3
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--get"]'
           service:
@@ -713,7 +713,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v7.4.1
+            tag: v7.4.3
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
           service:
@@ -850,7 +850,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v7.4.1
+            tag: v7.4.3
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
           service:
@@ -3563,7 +3563,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v7.4.1
+            tag: v7.4.3
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
           service:
@@ -3717,7 +3717,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v7.4.1
+            tag: v7.4.3
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
           service:
@@ -3871,7 +3871,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v7.4.1
+            tag: v7.4.3
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
           service:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2587,7 +2587,7 @@ ml-api-adapter:
         callback:
           rejectUnauthorized: true
       log_level: 'info'
-      max_callback_time_lag_dilation_milliseconds: 0
+      max_callback_time_lag_dilation_milliseconds: 100
       max_fulfil_timeout_duration_seconds: 240
 
     service:
@@ -2659,7 +2659,7 @@ ml-api-adapter:
         callback:
           rejectUnauthorized: true
       log_level: 'info'
-      max_callback_time_lag_dilation_milliseconds: 0
+      max_callback_time_lag_dilation_milliseconds: 100
       max_fulfil_timeout_duration_seconds: 240
 
     service:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -1961,7 +1961,7 @@ central:
     replicaCount: 1
     image:
       repository: mojaloop/central-settlement
-      tag: v7.3.0
+      tag: v7.4.0
       pullPolicy: Always
 
     readinessProbe:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2544,7 +2544,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v7.3.0
+      tag: v7.4.0
       command: '["node", "src/api/index.js"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -2584,6 +2584,9 @@ ml-api-adapter:
       security:
         callback:
           rejectUnauthorized: true
+      log_level: 'info'
+      max_callback_time_lag_dilation_milliseconds: 0
+      max_fulfil_timeout_duration_seconds: 0
 
     service:
       type: ClusterIP
@@ -2626,7 +2629,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v7.3.0
+      tag: v7.4.0
       command: '["node", "src/handlers/index.js", "handler", "--notification"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -2653,6 +2656,9 @@ ml-api-adapter:
       security:
         callback:
           rejectUnauthorized: true
+      log_level: 'info'
+      max_callback_time_lag_dilation_milliseconds: 0
+      max_fulfil_timeout_duration_seconds: 0
 
     service:
       type: ClusterIP

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2544,7 +2544,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v7.4.0
+      tag: v7.4.1
       command: '["node", "src/api/index.js"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -2586,7 +2586,7 @@ ml-api-adapter:
           rejectUnauthorized: true
       log_level: 'info'
       max_callback_time_lag_dilation_milliseconds: 0
-      max_fulfil_timeout_duration_seconds: 0
+      max_fulfil_timeout_duration_seconds: 240
 
     service:
       type: ClusterIP
@@ -2629,7 +2629,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v7.4.0
+      tag: v7.4.1
       command: '["node", "src/handlers/index.js", "handler", "--notification"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -2658,7 +2658,7 @@ ml-api-adapter:
           rejectUnauthorized: true
       log_level: 'info'
       max_callback_time_lag_dilation_milliseconds: 0
-      max_fulfil_timeout_duration_seconds: 0
+      max_fulfil_timeout_duration_seconds: 240
 
     service:
       type: ClusterIP


### PR DESCRIPTION
- Added missing config items to ml-api-adapter config for:
    - MAX_CALLBACK_TIME_LAG_DILATION_MILLISECONDS <-- default to 100ms
    - MAX_FULFIL_TIMEOUT_DURATION_SECONDS <-- default to 240s (4m)
- Added configs for the above config items in the values.yaml
- Bump to mojaloop chart to reflect the above changes
- Updated central-ledger MIGRATION init-container configs to include:
    - RUN_DATA_MIGRATIONS: true <-- this will enable or disable the data migration to run as part of the DB migration scripts. By default this is set to true.
- App versions in this PR:
    - ml-api-adapter: v7.4.1
    - central-ledger: v7.4.3
    - account-lookup-service: v7.4.0-snapshot
    - quoting-service: v7.4.0-snapshot
    - central-settlement: v7.4.0
    - central-event-processor: v7.3.0
    - bulk-api-adapter: v7.3.1-snapshot
    - email-notifier: v7.3.0
    - simulator: v7.2.1

