### PR TITLE
Changes for v8.3.0 - helm - WIP

### DIFF
--- a/centralledger/chart-handler-admin-transfer/values.yaml
+++ b/centralledger/chart-handler-admin-transfer/values.yaml
@@ -69,7 +69,7 @@ sidecar:
     periodSeconds: 15
   config:
     event_logger_grpc_host: localhost
-    event_logger_grpc_port: 50051
+    event_logger_grpc_port: 50055
     log_level: info
 
 ## metric configuration for prometheus instrumentation

--- a/centralledger/chart-handler-timeout/values.yaml
+++ b/centralledger/chart-handler-timeout/values.yaml
@@ -69,7 +69,7 @@ sidecar:
     periodSeconds: 15
   config:
     event_logger_grpc_host: localhost
-    event_logger_grpc_port: 50051
+    event_logger_grpc_port: 50055
     log_level: info
 
 ## metric configuration for prometheus instrumentation

--- a/centralledger/chart-handler-transfer-fulfil/values.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/values.yaml
@@ -69,7 +69,7 @@ sidecar:
     periodSeconds: 15
   config:
     event_logger_grpc_host: localhost
-    event_logger_grpc_port: 50051
+    event_logger_grpc_port: 50055
     log_level: info
 
 ## metric configuration for prometheus instrumentation

--- a/centralledger/chart-handler-transfer-get/values.yaml
+++ b/centralledger/chart-handler-transfer-get/values.yaml
@@ -69,7 +69,7 @@ sidecar:
     periodSeconds: 15
   config:
     event_logger_grpc_host: localhost
-    event_logger_grpc_port: 50051
+    event_logger_grpc_port: 50055
     log_level: info
 
 ## metric configuration for prometheus instrumentation

--- a/centralledger/chart-handler-transfer-position/values.yaml
+++ b/centralledger/chart-handler-transfer-position/values.yaml
@@ -69,7 +69,7 @@ sidecar:
     periodSeconds: 15
   config:
     event_logger_grpc_host: localhost
-    event_logger_grpc_port: 50051
+    event_logger_grpc_port: 50055
     log_level: info
 
 ## metric configuration for prometheus instrumentation

--- a/centralledger/chart-handler-transfer-prepare/values.yaml
+++ b/centralledger/chart-handler-transfer-prepare/values.yaml
@@ -69,7 +69,7 @@ sidecar:
     periodSeconds: 15
   config:
     event_logger_grpc_host: localhost
-    event_logger_grpc_port: 50051
+    event_logger_grpc_port: 50055
     log_level: info
 
 ## metric configuration for prometheus instrumentation

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -69,7 +69,7 @@ sidecar:
     periodSeconds: 15
   config:
     event_logger_grpc_host: localhost
-    event_logger_grpc_port: 50051
+    event_logger_grpc_port: 50055
     log_level: info
 
 ## metric configuration for prometheus instrumentation

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -37,7 +37,7 @@ sidecar:
     periodSeconds: 15
   config:
     event_logger_grpc_host: localhost
-    event_logger_grpc_port: 50051
+    event_logger_grpc_port: 50055
     log_level: info
 
 init:

--- a/ml-api-adapter/chart-service/values.yaml
+++ b/ml-api-adapter/chart-service/values.yaml
@@ -37,7 +37,7 @@ sidecar:
     periodSeconds: 15
   config:
     event_logger_grpc_host: localhost
-    event_logger_grpc_port: 50051
+    event_logger_grpc_port: 50055
     log_level: info
 
 init:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3002,7 +3002,7 @@ quoting-service:
   replicaCount: 1
   image:
     repository: mojaloop/quoting-service
-    tag: v8.3.1-snapshot
+    tag: v8.3.2-snapshot
     pullPolicy: Always
 
   readinessProbe:
@@ -3042,6 +3042,23 @@ quoting-service:
     simple_routing_mode_enabled: true
     log_level: 'info'
 
+  sidecar:
+        enabled: true
+        image:
+          repository: mojaloop/event-sidecar
+          tag: v8.1.0
+          pullPolicy: Always
+        readinessProbe:
+          enabled: true
+          initialDelaySeconds: 120
+          periodSeconds: 15
+        livenessProbe:
+          enabled: true
+          initialDelaySeconds: 90
+          periodSeconds: 15
+        config:
+          log_level: info
+  
   init:
     enabled: true
     mysql:

--- a/quoting-service/Chart.yaml
+++ b/quoting-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Quoting-Service Helm chart for Kubernetes
 name: quoting-service
 version: 8.3.0
-appVersion: "8.3.1-snapshot"
+appVersion: "8.3.2-snapshot"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/quoting-service/values.yaml
+++ b/quoting-service/values.yaml
@@ -21,7 +21,7 @@ global:
 replicaCount: 1
 image:
   repository: mojaloop/quoting-service
-  tag: v8.3.1-snapshot
+  tag: v8.3.2-snapshot
   pullPolicy: Always
 
 readinessProbe:


### PR DESCRIPTION
## Overview of Helm changes:
- Replacing port 50051 with 50055 as per - https://github.com/mojaloop/project/issues/1015#issuecomment-544926397

## Maintenance:
- Updated DB config for below services in PR #215
  - ALS
  - central-ledger
  - quoting-service

## Releases
- ml-api-adapter: v8.3.0
- central-ledger: v8.3.0
- account-lookup-service: v8.3.0
- quoting-service: v8.3.2-snapshot
- central-settlement: v8.3.0
- central-event-processor: v8.2.0
- bulk-api-adapter: v8.1.0-snapshot
- email-notifier: v7.3.0
- simulator: v8.1.1