### PR TITLE
new event-stream-processor version

### DIFF
--- a/eventstreamprocessor/Chart.yaml
+++ b/eventstreamprocessor/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Event Stream Processor for Mojaloop
 name: eventstreamprocessor
 version: 8.4.0
-appVersion: "8.4.2-snapshot"
+appVersion: "8.5.0-snapshot"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/eventstreamprocessor/values.yaml
+++ b/eventstreamprocessor/values.yaml
@@ -22,7 +22,7 @@ global:
 replicaCount: 1
 image:
   repository: mojaloop/event-stream-processor
-  tag: v8.4.2-snapshot
+  tag: v8.5.0-snapshot
   pullPolicy: Always
 
 init:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -34,7 +34,7 @@ central:
       enabled: true
       replicaCount: 1
       containers:
-        api:
+        api:  
           image:
             repository: mojaloop/central-ledger
             tag: v8.4.0


### PR DESCRIPTION
new event-stream-processor version, that handles sending of stale transfers to the APM Kibana dashboard, so they are not lost. 