### PR TITLE
Fixes for centraleventprocessor

### DIFF
--- a/central/Chart.yaml
+++ b/central/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Central Helm chart for Kubernetes
 name: central
-version: 8.4.0
+version: 8.6.0
 appVersion: "central-ledger: v8.4.0; central-settlement: v8.3.0; central-event-processor: v8.4.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png

--- a/central/requirements.yaml
+++ b/central/requirements.yaml
@@ -9,6 +9,6 @@ dependencies:
   repository: "file://../centralsettlement"
   condition: centralsettlement.enabled
 - name: centraleventprocessor
-  version: 8.4.0
+  version: 8.6.0
   repository: "file://../centraleventprocessor"
   condition: centraleventprocessor.enabled

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -2060,9 +2060,7 @@ centraleventprocessor:
     mongo_password: password
     mongo_database: mojaloop
     central_ledger_admin_host: '$release_name-centralledger-service'
-    central_ledger_admin_port: 3001
-    central_ledger_api_host: 'centralledger-service'
-    central_ledger_api_port: 3000
+    central_ledger_admin_port: 80
     hub_participant:
       name: hub
 

--- a/centraleventprocessor/Chart.yaml
+++ b/centraleventprocessor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Central Event Processor for Mojaloop
 name: centraleventprocessor
-version: 8.4.0
+version: 8.6.0
 appVersion: "8.4.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png

--- a/centraleventprocessor/configs/default.json
+++ b/centraleventprocessor/configs/default.json
@@ -1,7 +1,6 @@
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
 {{- $mongodbHost := ( .Values.config.mongo_host | replace "$release_name" .Release.Name ) -}}
 {{- $centralLedgerAdminHost := ( .Values.config.central_ledger_admin_host | replace "$release_name" .Release.Name ) -}}
-{{- $centralLedgerApiHost := ( .Values.config.central_ledger_admin_host | replace "$release_name" .Release.Name ) -}}
 {
     "notificationMinutes": {
         "resetPeriod": 60,
@@ -25,9 +24,7 @@
     },
     "centralLedgerAPI": {
         "adminHost": "{{ $centralLedgerAdminHost }}",
-        "adminPort": {{ .Values.config.central_ledger_admin_port }},
-        "apiHost": "{{ $centralLedgerApiHost }}",
-        "apiPort": {{ .Values.config.central_ledger_api_port }}
+        "adminPort": {{ .Values.config.central_ledger_admin_port }}
     },
     "mongo": {
         "user": "{{ .Values.config.mongo_user }}",

--- a/centraleventprocessor/values.yaml
+++ b/centraleventprocessor/values.yaml
@@ -124,9 +124,7 @@ config:
   mongo_password: password
   mongo_database: mojaloop
   central_ledger_admin_host: '$release_name-centralledger-service'
-  central_ledger_admin_port: 3001
-  central_ledger_api_host: 'centralledger-service'
-  central_ledger_api_port: 3000
+  central_ledger_admin_port: 80
   hub_participant:
     name: hub
   log_level: 'info'

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: central
-  version: 8.4.0
+  version: 8.6.0
   repository: "file://../central"
   condition: central.enabled
 - name: ml-api-adapter

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2058,9 +2058,7 @@ central:
       mongo_password: password
       mongo_database: mojaloop
       central_ledger_admin_host: '$release_name-centralledger-service'
-      central_ledger_admin_port: 3001
-      central_ledger_api_host: 'centralledger-service'
-      central_ledger_api_port: 3000
+      central_ledger_admin_port: 80
       hub_participant:
         name: hub
 


### PR DESCRIPTION
1. Port configs for centralledger were not updated to reflect that all service ports within k8s are now using 80 as standard
2. Removed unused central_ledger_api_host and central_ledger_api_port env vars/config that are deprecated
