### PR TITLE
Add license scanner file upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,6 @@ jobs:
       - run:
           name: Run the license-scanner
           command: |
-            # TODO: get the list of docker images from the helm charts
             source $BASH_ENV
             env | grep docker
             cd /tmp/license-scanner && make run 
@@ -119,6 +118,15 @@ jobs:
           command: |
             node --version
             cd /tmp/license-scanner && make postprocess
+      - run:
+          name: If this is a release, upload the license-scanner file to the github release
+          command: |
+            if [ "${CIRCLE_TAG}" = "" ]; then
+              exit 0
+            fi
+            mv /tmp/license-scanner/results/license-summary.xlsx ./license-summary-${CIRCLE_TAG}.xlsx
+            .circleci/upload-github-release-asset.sh github_api_token=$GITHUB_TOKEN owner=mojaloop repo=helm tag=${CIRCLE_TAG} filename=license-summary-${CIRCLE_TAG}.xlsx
+
       - store_artifacts:
           path: /tmp/license-scanner/results
           prefix: licenses

--- a/.circleci/upload-github-release-asset.sh
+++ b/.circleci/upload-github-release-asset.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Author: Stefan Buck
+# License: MIT
+# https://gist.github.com/stefanbuck/ce788fee19ab6eb0b4447a85fc99f447
+#
+#
+# This script accepts the following parameters:
+#
+# * owner
+# * repo
+# * tag
+# * filename
+# * github_api_token
+#
+# Script to upload a release asset using the GitHub API v3.
+#
+# Example:
+#
+# upload-github-release-asset.sh github_api_token=TOKEN owner=stefanbuck repo=playground tag=v0.1.0 filename=./build.zip
+#
+
+# Check dependencies.
+set -e
+xargs=$(which gxargs || which xargs)
+
+# Validate settings.
+[ "$TRACE" ] && set -x
+
+CONFIG=$@
+
+for line in $CONFIG; do
+  eval "$line"
+done
+
+# Define variables.
+GH_API="https://api.github.com"
+GH_REPO="$GH_API/repos/$owner/$repo"
+GH_TAGS="$GH_REPO/releases/tags/$tag"
+AUTH="Authorization: token $github_api_token"
+WGET_ARGS="--content-disposition --auth-no-challenge --no-cookie"
+CURL_ARGS="-LJO#"
+
+if [[ "$tag" == 'LATEST' ]]; then
+  GH_TAGS="$GH_REPO/releases/latest"
+fi
+
+# Validate token.
+curl -o /dev/null -sH "$AUTH" $GH_REPO || { echo "Error: Invalid repo, token or network issue!";  exit 1; }
+
+# Read asset tags.
+response=$(curl -sH "$AUTH" $GH_TAGS)
+
+# Get ID of the asset based on given filename.
+eval $(echo "$response" | grep -m 1 "id.:" | grep -w id | tr : = | tr -cd '[[:alnum:]]=')
+[ "$id" ] || { echo "Error: Failed to get release id for tag: $tag"; echo "$response" | awk 'length($0)<100' >&2; exit 1; }
+
+# Upload asset
+echo "Uploading asset... "
+
+# Construct url
+GH_ASSET="https://uploads.github.com/repos/$owner/$repo/releases/$id/assets?name=$(basename $filename)"
+
+curl --data-binary @"$filename" -H "Authorization: token $github_api_token" -H "Content-Type: application/octet-stream" $GH_ASSET


### PR DESCRIPTION
- Adds a script to automatically upload the license-summary.xlsx to a helm release as a part of the CI/CD process

I verified this manually with a temp release that I deleted from github afterwards.