### PR TITLE
Updates for Helm 8.8.0 release

### DIFF
--- a/account-lookup-service/Chart.yaml
+++ b/account-lookup-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 8.7.1
-appVersion: "account-lookup-service: v8.7.0; als-oracle-pathfinder: v8.7.1"
+version: 8.8.0
+appVersion: "account-lookup-service: v9.2.0; als-oracle-pathfinder: v8.7.1"
 description: Account Lookup Service Helm Chart for Mojaloop
 name: account-lookup-service

--- a/account-lookup-service/Chart.yaml
+++ b/account-lookup-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 8.8.0
-appVersion: "account-lookup-service: v8.8.1; als-oracle-pathfinder: v8.7.1"
+version: 8.7.1
+appVersion: "account-lookup-service: v8.7.0; als-oracle-pathfinder: v8.7.1"
 description: Account Lookup Service Helm Chart for Mojaloop
 name: account-lookup-service

--- a/account-lookup-service/Chart.yaml
+++ b/account-lookup-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 8.7.1
-appVersion: "account-lookup-service: v8.7.0; als-oracle-pathfinder: v8.7.1"
+version: 8.8.0
+appVersion: "account-lookup-service: v8.8.1; als-oracle-pathfinder: v8.7.1"
 description: Account Lookup Service Helm Chart for Mojaloop
 name: account-lookup-service

--- a/account-lookup-service/chart-admin/Chart.yaml
+++ b/account-lookup-service/chart-admin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 8.7.1
-appVersion: "8.7.0"
+version: 8.8.0
+appVersion: "8.8.1"
 description: A Helm chart for Kubernetes
 name: account-lookup-service-admin

--- a/account-lookup-service/chart-admin/Chart.yaml
+++ b/account-lookup-service/chart-admin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 8.7.1
-appVersion: "8.7.0"
+version: 8.8.0
+appVersion: "9.2.0"
 description: A Helm chart for Kubernetes
 name: account-lookup-service-admin

--- a/account-lookup-service/chart-admin/Chart.yaml
+++ b/account-lookup-service/chart-admin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 8.8.0
-appVersion: "8.8.1"
+version: 8.7.1
+appVersion: "8.7.0"
 description: A Helm chart for Kubernetes
 name: account-lookup-service-admin

--- a/account-lookup-service/chart-admin/values.yaml
+++ b/account-lookup-service/chart-admin/values.yaml
@@ -7,7 +7,7 @@ containers:
   api:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v8.7.0
+      tag: v8.8.1
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--api"]'
     service:
@@ -18,7 +18,7 @@ containers:
   admin:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v8.7.0
+      tag: v8.8.1
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--admin"]'
     service:

--- a/account-lookup-service/chart-admin/values.yaml
+++ b/account-lookup-service/chart-admin/values.yaml
@@ -7,7 +7,7 @@ containers:
   api:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v8.8.1
+      tag: v8.7.0
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--api"]'
     service:
@@ -18,7 +18,7 @@ containers:
   admin:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v8.8.1
+      tag: v8.7.0
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--admin"]'
     service:

--- a/account-lookup-service/chart-admin/values.yaml
+++ b/account-lookup-service/chart-admin/values.yaml
@@ -7,7 +7,7 @@ containers:
   api:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v8.7.0
+      tag: v9.2.0
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--api"]'
     service:
@@ -18,7 +18,7 @@ containers:
   admin:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v8.7.0
+      tag: v9.2.0
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--admin"]'
     service:

--- a/account-lookup-service/chart-service/Chart.yaml
+++ b/account-lookup-service/chart-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 8.7.1
-appVersion: "8.7.0"
+version: 8.8.0
+appVersion: "9.2.0"
 description: A Helm chart for Kubernetes
 name: account-lookup-service

--- a/account-lookup-service/chart-service/Chart.yaml
+++ b/account-lookup-service/chart-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 8.7.1
-appVersion: "8.7.0"
+version: 8.8.0
+appVersion: "8.8.1"
 description: A Helm chart for Kubernetes
 name: account-lookup-service

--- a/account-lookup-service/chart-service/Chart.yaml
+++ b/account-lookup-service/chart-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 8.8.0
-appVersion: "8.8.1"
+version: 8.7.1
+appVersion: "8.7.0"
 description: A Helm chart for Kubernetes
 name: account-lookup-service

--- a/account-lookup-service/chart-service/values.yaml
+++ b/account-lookup-service/chart-service/values.yaml
@@ -8,7 +8,7 @@ containers:
   api:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v8.8.1
+      tag: v8.7.0
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--api"]'
     service:
@@ -19,7 +19,7 @@ containers:
   admin:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v8.8.1
+      tag: v8.7.0
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--admin"]'
     service:

--- a/account-lookup-service/chart-service/values.yaml
+++ b/account-lookup-service/chart-service/values.yaml
@@ -8,7 +8,7 @@ containers:
   api:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v8.7.0
+      tag: v8.8.1
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--api"]'
     service:
@@ -19,7 +19,7 @@ containers:
   admin:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v8.7.0
+      tag: v8.8.1
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--admin"]'
     service:

--- a/account-lookup-service/chart-service/values.yaml
+++ b/account-lookup-service/chart-service/values.yaml
@@ -8,7 +8,7 @@ containers:
   api:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v8.7.0
+      tag: v9.2.0
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--api"]'
     service:
@@ -19,7 +19,7 @@ containers:
   admin:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v8.7.0
+      tag: v9.2.0
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--admin"]'
     service:

--- a/account-lookup-service/requirements.yaml
+++ b/account-lookup-service/requirements.yaml
@@ -1,11 +1,11 @@
 # requirements.yaml
 dependencies:
 - name: account-lookup-service
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://./chart-service"
   condition: account-lookup-service.enabled
 - name: account-lookup-service-admin
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://./chart-admin"
   condition: account-lookup-service-admin.enabled
 - name: als-oracle-pathfinder

--- a/account-lookup-service/requirements.yaml
+++ b/account-lookup-service/requirements.yaml
@@ -1,11 +1,11 @@
 # requirements.yaml
 dependencies:
 - name: account-lookup-service
-  version: 8.8.0
+  version: 8.7.1
   repository: "file://./chart-service"
   condition: account-lookup-service.enabled
 - name: account-lookup-service-admin
-  version: 8.8.0
+  version: 8.7.1
   repository: "file://./chart-admin"
   condition: account-lookup-service-admin.enabled
 - name: als-oracle-pathfinder

--- a/account-lookup-service/values.yaml
+++ b/account-lookup-service/values.yaml
@@ -9,7 +9,7 @@ account-lookup-service:
     api:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v8.8.1
+        tag: v8.7.0
         pullPolicy: Always
         command: '["node", "src/index.js", "server", "--api"]'
       service:
@@ -20,7 +20,7 @@ account-lookup-service:
     admin:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v8.8.1
+        tag: v8.7.0
         pullPolicy: Always
         command: '["node", "src/index.js", "server", "--admin"]'
       service:
@@ -138,7 +138,7 @@ account-lookup-service-admin:
     api:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v8.8.1
+        tag: v8.7.0
         pullPolicy: IfNotPresent
         command: '["node", "src/index.js", "server", "--api"]'
       service:
@@ -149,7 +149,7 @@ account-lookup-service-admin:
     admin:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v8.8.1
+        tag: v8.7.0
         pullPolicy: IfNotPresent
         command: '["node", "src/index.js", "server", "--admin"]'
       service:

--- a/account-lookup-service/values.yaml
+++ b/account-lookup-service/values.yaml
@@ -9,7 +9,7 @@ account-lookup-service:
     api:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v8.7.0
+        tag: v8.8.1
         pullPolicy: Always
         command: '["node", "src/index.js", "server", "--api"]'
       service:
@@ -20,7 +20,7 @@ account-lookup-service:
     admin:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v8.7.0
+        tag: v8.8.1
         pullPolicy: Always
         command: '["node", "src/index.js", "server", "--admin"]'
       service:
@@ -138,7 +138,7 @@ account-lookup-service-admin:
     api:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v8.7.0
+        tag: v8.8.1
         pullPolicy: IfNotPresent
         command: '["node", "src/index.js", "server", "--api"]'
       service:
@@ -149,7 +149,7 @@ account-lookup-service-admin:
     admin:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v8.7.0
+        tag: v8.8.1
         pullPolicy: IfNotPresent
         command: '["node", "src/index.js", "server", "--admin"]'
       service:

--- a/account-lookup-service/values.yaml
+++ b/account-lookup-service/values.yaml
@@ -9,7 +9,7 @@ account-lookup-service:
     api:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v8.7.0
+        tag: v9.2.0
         pullPolicy: Always
         command: '["node", "src/index.js", "server", "--api"]'
       service:
@@ -20,7 +20,7 @@ account-lookup-service:
     admin:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v8.7.0
+        tag: v9.2.0
         pullPolicy: Always
         command: '["node", "src/index.js", "server", "--admin"]'
       service:
@@ -138,7 +138,7 @@ account-lookup-service-admin:
     api:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v8.7.0
+        tag: v9.2.0
         pullPolicy: IfNotPresent
         command: '["node", "src/index.js", "server", "--api"]'
       service:
@@ -149,7 +149,7 @@ account-lookup-service-admin:
     admin:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v8.7.0
+        tag: v9.2.0
         pullPolicy: IfNotPresent
         command: '["node", "src/index.js", "server", "--admin"]'
       service:

--- a/bulk-api-adapter/Chart.yaml
+++ b/bulk-api-adapter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: bulk-api-adapter Helm chart for Kubernetes
 name: bulk-api-adapter
-version: 8.7.1
-appVersion: "8.7.0-snapshot"
+version: 8.8.0
+appVersion: "8.8.0-snapshot"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/chart-handler-notification/Chart.yaml
+++ b/bulk-api-adapter/chart-handler-notification/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: bulk-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: bulk-api-adapter-handler-notification
-version: 8.7.1
-appVersion: "8.7.0-snapshot"
+version: 8.8.0
+appVersion: "8.8.0-snapshot"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/chart-handler-notification/values.yaml
+++ b/bulk-api-adapter/chart-handler-notification/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/bulk-api-adapter
-  tag: v8.7.0-snapshot
+  tag: v8.8.0-snapshot
   command: '["node", "src/handlers/index.js", "handler", "--notification"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/bulk-api-adapter/chart-service/Chart.yaml
+++ b/bulk-api-adapter/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: bulk-api-adapter API component Helm chart for Kubernetes
 name: bulk-api-adapter-service
-version: 8.7.1
-appVersion: "8.7.0-snapshot"
+version: 8.8.0
+appVersion: "8.8.0-snapshot"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/chart-service/values.yaml
+++ b/bulk-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/bulk-api-adapter
-  tag: v8.7.0-snapshot
+  tag: v8.8.0-snapshot
   command: '["node", "src/api/index.js"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/bulk-api-adapter/requirements.yaml
+++ b/bulk-api-adapter/requirements.yaml
@@ -1,10 +1,10 @@
 # requirements.yaml
 dependencies:
 - name: bulk-api-adapter-service
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://./chart-service"
   condition: bulk-api-adapter-service.enabled
 - name: bulk-api-adapter-handler-notification
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://./chart-handler-notification"
   condition: bulk-api-adapter-handler-notification.enabled

--- a/bulk-api-adapter/values.yaml
+++ b/bulk-api-adapter/values.yaml
@@ -25,7 +25,7 @@ bulk-api-adapter-service:
   replicaCount: 1
   image:
     repository: mojaloop/bulk-api-adapter
-    tag: v8.7.0-snapshot
+    tag: v8.8.0-snapshot
     command: '["node", "src/api/index.js"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -140,7 +140,7 @@ bulk-api-adapter-handler-notification:
   replicaCount: 1
   image:
     repository: mojaloop/bulk-api-adapter
-    tag: v8.7.0-snapshot
+    tag: v8.8.0-snapshot
     command: '["node", "src/handlers/index.js", "handler", "--notification"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bulk-centralledger/Chart.yaml
+++ b/bulk-centralledger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Bulk Services Helm chart for Kubernetes
 name: bulk-centralledger
-version: 8.7.1
-appVersion: "8.7.1"
+version: 8.8.0
+appVersion: "8.8.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Bulk Transfer Fulfil Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-fulfil
-version: 8.7.1
-appVersion: "8.7.1"
+version: 8.8.0
+appVersion: "8.8.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/configs/default.json
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/configs/default.json
@@ -91,6 +91,9 @@
         ]
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+    "CACHE": {
+        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }}
+    },
     "KAFKA": {
         "TOPIC_TEMPLATES": {
             "PARTICIPANT_TOPIC_TEMPLATE": {

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
@@ -100,6 +100,9 @@ config:
   log_level: 'info'
   log_transport: file
 
+  ## Cache configuration
+  cache_max_byte_size: 10000000
+
 init:
   enabled: true
   kafka:

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v8.7.1
+      tag: v8.8.2
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
     service:

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Bulk Transfer Prepare Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-prepare
-version: 8.7.1
-appVersion: "8.7.1"
+version: 8.8.0
+appVersion: "8.8.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/configs/default.json
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/configs/default.json
@@ -91,6 +91,9 @@
         ]
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+    "CACHE": {
+        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }}
+    },
     "KAFKA": {
         "TOPIC_TEMPLATES": {
             "PARTICIPANT_TOPIC_TEMPLATE": {

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
@@ -100,6 +100,9 @@ config:
   log_level: 'info'
   log_transport: file
 
+  ## Cache configuration
+  cache_max_byte_size: 10000000
+
 init:
   enabled: true
   kafka:

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v8.7.1
+      tag: v8.8.2
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
     service:

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Bulk Transfer Processing Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-processing
-version: 8.7.1
-appVersion: "8.7.1"
+version: 8.8.0
+appVersion: "8.8.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/configs/default.json
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/configs/default.json
@@ -91,6 +91,9 @@
         ]
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+    "CACHE": {
+        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }}
+    },
     "KAFKA": {
         "TOPIC_TEMPLATES": {
             "PARTICIPANT_TOPIC_TEMPLATE": {

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
@@ -100,6 +100,9 @@ config:
   log_level: 'info'
   log_transport: file
 
+  ## Cache configuration
+  cache_max_byte_size: 10000000
+
 init:
   enabled: true
   kafka:

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v8.7.1
+      tag: v8.8.2
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
     service:

--- a/bulk-centralledger/requirements.yaml
+++ b/bulk-centralledger/requirements.yaml
@@ -1,14 +1,14 @@
 # requirements.yaml
 dependencies:
 - name: cl-handler-bulk-transfer-prepare
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://./chart-handler-bulk-transfer-prepare"
   condition: cl-handler-bulk-transfer-prepare.enabled
 - name: cl-handler-bulk-transfer-fulfil
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://./chart-handler-bulk-transfer-fulfil"
   condition: cl-handler-bulk-transfer-fulfil.enabled
 - name: cl-handler-bulk-transfer-processing
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://./chart-handler-bulk-transfer-processing"
   condition: cl-handler-bulk-transfer-processing.enabled

--- a/bulk-centralledger/values.yaml
+++ b/bulk-centralledger/values.yaml
@@ -27,7 +27,7 @@ cl-handler-bulk-transfer-prepare:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v8.7.1
+        tag: v8.8.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
       service:
@@ -193,7 +193,7 @@ cl-handler-bulk-transfer-fulfil:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v8.7.1
+        tag: v8.8.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
       service:
@@ -359,7 +359,7 @@ cl-handler-bulk-transfer-processing:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v8.7.1
+        tag: v8.8.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
       service:

--- a/central/Chart.yaml
+++ b/central/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central Helm chart for Kubernetes
 name: central
-version: 8.7.1
-appVersion: "central-ledger: v8.7.1; central-settlement: v8.6.0; central-event-processor: v8.7.0"
+version: 8.8.0
+appVersion: "central-ledger: v8.8.2; central-settlement: v8.6.0; central-event-processor: v8.7.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/central/Chart.yaml
+++ b/central/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central Helm chart for Kubernetes
 name: central
 version: 8.8.0
-appVersion: "central-ledger: v8.8.2; central-settlement: v8.6.0; central-event-processor: v8.7.0"
+appVersion: "central-ledger: v8.8.2; central-settlement: v8.8.0; central-event-processor: v8.8.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/central/requirements.yaml
+++ b/central/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: centralledger
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://../centralledger"
   condition: centralledger.enabled
 - name: centralsettlement

--- a/central/requirements.yaml
+++ b/central/requirements.yaml
@@ -5,10 +5,10 @@ dependencies:
   repository: "file://../centralledger"
   condition: centralledger.enabled
 - name: centralsettlement
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://../centralsettlement"
   condition: centralsettlement.enabled
 - name: centraleventprocessor
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://../centraleventprocessor"
   condition: centraleventprocessor.enabled

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -1810,7 +1810,7 @@ centralsettlement:
   replicaCount: 1
   image:
     repository: mojaloop/central-settlement
-    tag: v8.6.0
+    tag: v8.8.0
     pullPolicy: Always
 
   readinessProbe:
@@ -1920,7 +1920,7 @@ centraleventprocessor:
   replicaCount: 1
   image:
     repository: mojaloop/central-event-processor
-    tag: v8.7.0
+    tag: v8.8.0
     pullPolicy: Always
 
   init:

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -35,7 +35,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v8.7.1
+          tag: v8.8.2
           pullPolicy: Always
           command: '["node", "src/api/index.js"]'
         service:
@@ -61,7 +61,7 @@ centralledger:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v8.7.1
+        tag: v8.7.3
         pullPolicy: Always
       readinessProbe:
         enabled: true
@@ -196,7 +196,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v8.7.1
+          tag: v8.8.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
         service:
@@ -222,7 +222,7 @@ centralledger:
       enabled: true
       image:
         repository: mojaloop/event-sidecar
-        tag: v8.7.1
+        tag: v8.7.3
         pullPolicy: Always
       readinessProbe:
         enabled: true
@@ -364,7 +364,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v8.7.1
+          tag: v8.8.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--position"]'
         service:
@@ -390,7 +390,7 @@ centralledger:
       enabled: true
       image:
         repository: mojaloop/event-sidecar
-        tag: v8.7.1
+        tag: v8.7.3
         pullPolicy: Always
       readinessProbe:
         enabled: true
@@ -532,7 +532,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v8.7.1
+          tag: v8.8.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--get"]'
         service:
@@ -558,7 +558,7 @@ centralledger:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v8.7.1
+        tag: v8.7.3
         pullPolicy: Always
       readinessProbe:
         enabled: true
@@ -700,7 +700,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v8.7.1
+          tag: v8.8.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
         service:
@@ -726,7 +726,7 @@ centralledger:
       enabled: true
       image:
         repository: mojaloop/event-sidecar
-        tag: v8.7.1
+        tag: v8.7.3
         pullPolicy: Always
       readinessProbe:
         enabled: true
@@ -868,7 +868,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v8.7.1
+          tag: v8.8.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
         service:
@@ -894,7 +894,7 @@ centralledger:
       enabled: true
       image:
         repository: mojaloop/event-sidecar
-        tag: v8.7.1
+        tag: v8.7.3
         pullPolicy: Always
       readinessProbe:
         enabled: true
@@ -1036,7 +1036,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v8.7.1
+          tag: v8.8.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--admin"]'
         service:
@@ -1062,7 +1062,7 @@ centralledger:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v8.7.1
+        tag: v8.7.3
         pullPolicy: Always
       readinessProbe:
         enabled: true

--- a/centraleventprocessor/Chart.yaml
+++ b/centraleventprocessor/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central Event Processor for Mojaloop
 name: centraleventprocessor
-version: 8.7.1
-appVersion: "8.7.0"
+version: 8.8.0
+appVersion: "8.8.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centraleventprocessor/values.yaml
+++ b/centraleventprocessor/values.yaml
@@ -22,7 +22,7 @@ global:
 replicaCount: 1
 image:
   repository: mojaloop/central-event-processor
-  tag: v8.7.0
+  tag: v8.8.0
   pullPolicy: Always
 
 init:

--- a/centralledger/Chart.yaml
+++ b/centralledger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Helm chart for Kubernetes
 name: centralledger
-version: 8.7.1
-appVersion: "8.7.1"
+version: 8.8.0
+appVersion: "8.8.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-admin-transfer/Chart.yaml
+++ b/centralledger/chart-handler-admin-transfer/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-admin-transfer
-version: 8.7.1
-appVersion: "8.7.1"
+version: 8.8.0
+appVersion: "8.8.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-admin-transfer/configs/default.json
+++ b/centralledger/chart-handler-admin-transfer/configs/default.json
@@ -91,6 +91,9 @@
         ]
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+    "CACHE": {
+        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }},
+    },
     "KAFKA": {
         "TOPIC_TEMPLATES": {
             "PARTICIPANT_TOPIC_TEMPLATE": {

--- a/centralledger/chart-handler-admin-transfer/configs/default.json
+++ b/centralledger/chart-handler-admin-transfer/configs/default.json
@@ -92,7 +92,7 @@
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
     "CACHE": {
-        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }},
+        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }}
     },
     "KAFKA": {
         "TOPIC_TEMPLATES": {

--- a/centralledger/chart-handler-admin-transfer/values.yaml
+++ b/centralledger/chart-handler-admin-transfer/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v8.7.1
+      tag: v8.8.2
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--admin"]'
     service:
@@ -50,7 +50,7 @@ sidecar:
   enabled: false
   image:
     repository: mojaloop/event-sidecar
-    tag: v8.7.1
+    tag: v8.7.3
     pullPolicy: Always
     command: '["npm", "run", "start"]'
   service:
@@ -134,6 +134,9 @@ config:
   log_transport: file
   ## Enable local logging of events being recorded
   log_events_locally_enabled: false
+
+  ## Cache configuration
+  cache_max_byte_size: 10000000
 
 init:
   enabled: true

--- a/centralledger/chart-handler-timeout/Chart.yaml
+++ b/centralledger/chart-handler-timeout/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Timeout Handler Helm chart for Kubernetes
 name: centralledger-handler-timeout
-version: 8.7.1
-appVersion: "8.7.1"
+version: 8.8.0
+appVersion: "8.8.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-timeout/configs/default.json
+++ b/centralledger/chart-handler-timeout/configs/default.json
@@ -91,6 +91,9 @@
         ]
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+    "CACHE": {
+        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }},
+    },
     "KAFKA": {
         "TOPIC_TEMPLATES": {
             "PARTICIPANT_TOPIC_TEMPLATE": {

--- a/centralledger/chart-handler-timeout/configs/default.json
+++ b/centralledger/chart-handler-timeout/configs/default.json
@@ -92,7 +92,7 @@
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
     "CACHE": {
-        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }},
+        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }}
     },
     "KAFKA": {
         "TOPIC_TEMPLATES": {

--- a/centralledger/chart-handler-timeout/values.yaml
+++ b/centralledger/chart-handler-timeout/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v8.7.1
+      tag: v8.8.2
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
     service:
@@ -50,7 +50,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v8.7.1
+    tag: v8.7.3
     pullPolicy: Always
     command: '["npm", "run", "start"]'
   service:
@@ -134,6 +134,9 @@ config:
   log_transport: file
   ## Enable local logging of events being recorded
   log_events_locally_enabled: false
+
+  ## Cache configuration
+  cache_max_byte_size: 10000000
 
 init:
   enabled: true

--- a/centralledger/chart-handler-transfer-fulfil/Chart.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Fulfil Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-fulfil
-version: 8.7.1
-appVersion: "8.7.1"
+version: 8.8.0
+appVersion: "8.8.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-fulfil/configs/default.json
+++ b/centralledger/chart-handler-transfer-fulfil/configs/default.json
@@ -91,6 +91,9 @@
         ]
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+    "CACHE": {
+        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }},
+    },
     "KAFKA": {
         "TOPIC_TEMPLATES": {
             "PARTICIPANT_TOPIC_TEMPLATE": {

--- a/centralledger/chart-handler-transfer-fulfil/configs/default.json
+++ b/centralledger/chart-handler-transfer-fulfil/configs/default.json
@@ -92,7 +92,7 @@
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
     "CACHE": {
-        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }},
+        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }}
     },
     "KAFKA": {
         "TOPIC_TEMPLATES": {

--- a/centralledger/chart-handler-transfer-fulfil/values.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v8.7.1
+      tag: v8.8.2
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
     service:
@@ -50,7 +50,7 @@ sidecar:
   enabled: false
   image:
     repository: mojaloop/event-sidecar
-    tag: v8.7.1
+    tag: v8.7.3
     pullPolicy: Always
     command: '["npm", "run", "start"]'
   service:
@@ -134,6 +134,9 @@ config:
   log_transport: file
   ## Enable local logging of events being recorded
   log_events_locally_enabled: false
+
+  ## Cache configuration
+  cache_max_byte_size: 10000000
 
 init:
   enabled: true

--- a/centralledger/chart-handler-transfer-get/Chart.yaml
+++ b/centralledger/chart-handler-transfer-get/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Get Transfer Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-get
-version: 8.7.1
-appVersion: "8.7.1"
+version: 8.8.0
+appVersion: "8.8.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-get/configs/default.json
+++ b/centralledger/chart-handler-transfer-get/configs/default.json
@@ -91,6 +91,9 @@
         ]
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+    "CACHE": {
+        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }},
+    },
     "KAFKA": {
         "TOPIC_TEMPLATES": {
             "PARTICIPANT_TOPIC_TEMPLATE": {

--- a/centralledger/chart-handler-transfer-get/configs/default.json
+++ b/centralledger/chart-handler-transfer-get/configs/default.json
@@ -92,7 +92,7 @@
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
     "CACHE": {
-        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }},
+        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }}
     },
     "KAFKA": {
         "TOPIC_TEMPLATES": {

--- a/centralledger/chart-handler-transfer-get/values.yaml
+++ b/centralledger/chart-handler-transfer-get/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v8.7.1
+      tag: v8.8.2
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--get"]'
     service:
@@ -50,7 +50,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v8.7.1
+    tag: v8.7.3
     pullPolicy: Always
     command: '["npm", "run", "start"]'
   service:
@@ -134,6 +134,9 @@ config:
   log_transport: file
   ## Enable local logging of events being recorded
   log_events_locally_enabled: false
+
+  ## Cache configuration
+  cache_max_byte_size: 10000000
 
 init:
   enabled: true

--- a/centralledger/chart-handler-transfer-position/Chart.yaml
+++ b/centralledger/chart-handler-transfer-position/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Position Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-position
-version: 8.7.1
-appVersion: "8.7.1"
+version: 8.8.0
+appVersion: "8.8.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-position/configs/default.json
+++ b/centralledger/chart-handler-transfer-position/configs/default.json
@@ -91,6 +91,9 @@
         ]
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+    "CACHE": {
+        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }},
+    },
     "KAFKA": {
         "TOPIC_TEMPLATES": {
             "PARTICIPANT_TOPIC_TEMPLATE": {

--- a/centralledger/chart-handler-transfer-position/configs/default.json
+++ b/centralledger/chart-handler-transfer-position/configs/default.json
@@ -92,7 +92,7 @@
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
     "CACHE": {
-        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }},
+        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }}
     },
     "KAFKA": {
         "TOPIC_TEMPLATES": {

--- a/centralledger/chart-handler-transfer-position/values.yaml
+++ b/centralledger/chart-handler-transfer-position/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v8.7.1
+      tag: v8.8.2
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--position"]'
     service:
@@ -50,7 +50,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v8.7.1
+    tag: v8.7.3
     pullPolicy: Always
     command: '["npm", "run", "start"]'
   service:
@@ -134,6 +134,9 @@ config:
   log_transport: file
   ## Enable local logging of events being recorded
   log_events_locally_enabled: false
+
+  ## Cache configuration
+  cache_max_byte_size: 10000000
 
 init:
   enabled: true

--- a/centralledger/chart-handler-transfer-prepare/Chart.yaml
+++ b/centralledger/chart-handler-transfer-prepare/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-prepare
-version: 8.7.1
-appVersion: "8.7.1"
+version: 8.8.0
+appVersion: "8.8.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-prepare/configs/default.json
+++ b/centralledger/chart-handler-transfer-prepare/configs/default.json
@@ -91,6 +91,9 @@
         ]
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+    "CACHE": {
+        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }},
+    },
     "KAFKA": {
         "TOPIC_TEMPLATES": {
             "PARTICIPANT_TOPIC_TEMPLATE": {

--- a/centralledger/chart-handler-transfer-prepare/configs/default.json
+++ b/centralledger/chart-handler-transfer-prepare/configs/default.json
@@ -92,7 +92,7 @@
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
     "CACHE": {
-        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }},
+        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }}
     },
     "KAFKA": {
         "TOPIC_TEMPLATES": {

--- a/centralledger/chart-handler-transfer-prepare/values.yaml
+++ b/centralledger/chart-handler-transfer-prepare/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v8.7.1
+      tag: v8.8.2
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
     service:
@@ -50,7 +50,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v8.7.1
+    tag: v8.7.3
     pullPolicy: Always
     command: '["npm", "run", "start"]'
   service:
@@ -134,6 +134,9 @@ config:
   log_transport: file
   ## Enable local logging of events being recorded
   log_events_locally_enabled: false
+
+  ## Cache configuration
+  cache_max_byte_size: 10000000
 
 init:
   enabled: true

--- a/centralledger/chart-service/Chart.yaml
+++ b/centralledger/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Service Helm chart for Kubernetes
 name: centralledger-service
-version: 8.7.1
-appVersion: "8.7.1"
+version: 8.8.0
+appVersion: "8.8.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-service/configs/default.json
+++ b/centralledger/chart-service/configs/default.json
@@ -91,6 +91,9 @@
         ]
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+    "CACHE": {
+        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }},
+    },
     "KAFKA": {
         "TOPIC_TEMPLATES": {
             "PARTICIPANT_TOPIC_TEMPLATE": {

--- a/centralledger/chart-service/configs/default.json
+++ b/centralledger/chart-service/configs/default.json
@@ -92,7 +92,7 @@
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
     "CACHE": {
-        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }},
+        "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }}
     },
     "KAFKA": {
         "TOPIC_TEMPLATES": {

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v8.7.1
+      tag: v8.8.2
       pullPolicy: Always
       command: '["node", "src/api/index.js"]'
     service:
@@ -50,7 +50,7 @@ sidecar:
   enabled: false
   image:
     repository: mojaloop/event-sidecar
-    tag: v8.7.1
+    tag: v8.7.3
     pullPolicy: Always
     command: '["npm", "run", "start"]'
   service:
@@ -135,6 +135,9 @@ config:
   log_events_locally_enabled: false
   
   log_transport: file
+
+  ## Cache configuration
+  cache_max_byte_size: 10000000
 
 init:
   enabled: true

--- a/centralledger/requirements.yaml
+++ b/centralledger/requirements.yaml
@@ -1,31 +1,31 @@
 # requirements.yaml
 dependencies:
 - name: centralledger-service
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://./chart-service"
   condition: centralledger-service.enabled
 - name: centralledger-handler-transfer-prepare
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://./chart-handler-transfer-prepare"
   condition: centralledger-handler-transfer-prepare.enabled
 - name: centralledger-handler-transfer-position
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://./chart-handler-transfer-position"
   condition: centralledger-handler-transfer-position.enabled
 - name: centralledger-handler-transfer-get
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://./chart-handler-transfer-get"
   condition: centralledger-handler-transfer-get.enabled
 - name: centralledger-handler-transfer-fulfil
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://./chart-handler-transfer-fulfil"
   condition: centralledger-handler-transfer-fulfil.enabled
 - name: centralledger-handler-timeout
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://./chart-handler-timeout"
   condition: centralledger-handler-timeout.enabled
 - name: centralledger-handler-admin-transfer
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://./chart-handler-admin-transfer"
   condition: centralledger-handler-transfer-get.enabled
 

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -30,7 +30,7 @@ centralledger-service:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v8.7.1
+        tag: v8.8.2
         pullPolicy: Always
         command: '["node", "src/api/index.js"]'
       service:
@@ -56,7 +56,7 @@ centralledger-service:
     enabled: false
     image:
       repository: mojaloop/event-sidecar
-      tag: v8.7.1
+      tag: v8.7.3
       pullPolicy: Always
     readinessProbe:
       enabled: true
@@ -191,7 +191,7 @@ centralledger-handler-transfer-prepare:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v8.7.1
+        tag: v8.8.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
       service:
@@ -217,7 +217,7 @@ centralledger-handler-transfer-prepare:
     enabled: true
     image:
       repository: mojaloop/event-sidecar
-      tag: v8.7.1
+      tag: v8.7.3
       pullPolicy: Always
     readinessProbe:
       enabled: true
@@ -359,7 +359,7 @@ centralledger-handler-transfer-position:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v8.7.1
+        tag: v8.8.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--position"]'
       service:
@@ -385,7 +385,7 @@ centralledger-handler-transfer-position:
     enabled: true
     image:
       repository: mojaloop/event-sidecar
-      tag: v8.7.1
+      tag: v8.7.3
       pullPolicy: Always
     readinessProbe:
       enabled: true
@@ -527,7 +527,7 @@ centralledger-handler-transfer-get:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v8.7.1
+        tag: v8.8.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--get"]'
       service:
@@ -553,7 +553,7 @@ centralledger-handler-transfer-get:
     enabled: false
     image:
       repository: mojaloop/event-sidecar
-      tag: v8.7.1
+      tag: v8.7.3
       pullPolicy: Always
     readinessProbe:
       enabled: true
@@ -695,7 +695,7 @@ centralledger-handler-transfer-fulfil:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v8.7.1
+        tag: v8.8.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
       service:
@@ -721,7 +721,7 @@ centralledger-handler-transfer-fulfil:
     enabled: true
     image:
       repository: mojaloop/event-sidecar
-      tag: v8.7.1
+      tag: v8.7.3
       pullPolicy: Always
     readinessProbe:
       enabled: true
@@ -863,7 +863,7 @@ centralledger-handler-timeout:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v8.7.1
+        tag: v8.8.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
       service:
@@ -889,7 +889,7 @@ centralledger-handler-timeout:
     enabled: true
     image:
       repository: mojaloop/event-sidecar
-      tag: v8.7.1
+      tag: v8.7.3
       pullPolicy: Always
     readinessProbe:
       enabled: true
@@ -1031,7 +1031,7 @@ centralledger-handler-admin-transfer:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v8.7.1
+        tag: v8.8.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--admin"]'
       service:
@@ -1057,7 +1057,7 @@ centralledger-handler-admin-transfer:
     enabled: false
     image:
       repository: mojaloop/event-sidecar
-      tag: v8.7.1
+      tag: v8.7.3
       pullPolicy: Always
     readinessProbe:
       enabled: true

--- a/centralsettlement/Chart.yaml
+++ b/centralsettlement/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Settlement Helm chart for Kubernetes
 name: centralsettlement
-version: 8.7.1
-appVersion: "8.6.0"
+version: 8.8.0
+appVersion: "8.8.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralsettlement/values.yaml
+++ b/centralsettlement/values.yaml
@@ -21,7 +21,7 @@ global:
 replicaCount: 1
 image:
   repository: mojaloop/central-settlement
-  tag: v8.6.0
+  tag: v8.8.0
   pullPolicy: Always
 
 readinessProbe:

--- a/emailnotifier/Chart.yaml
+++ b/emailnotifier/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Email Notifier For Mojaloop
 name: emailnotifier
-version: 8.7.1
-appVersion: "8.7.0"
+version: 8.8.0
+appVersion: "8.8.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/emailnotifier/values.yaml
+++ b/emailnotifier/values.yaml
@@ -22,7 +22,7 @@ global:
 replicaCount: 1
 image:
   repository: mojaloop/email-notifier
-  tag: v8.7.0
+  tag: v8.8.0
   pullPolicy: Always
 
 init:

--- a/eventstreamprocessor/Chart.yaml
+++ b/eventstreamprocessor/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Event Stream Processor for Mojaloop
 name: eventstreamprocessor
-version: 8.7.1
-appVersion: "8.7.2-snapshot"
+version: 8.8.0
+appVersion: "8.8.0-snapshot"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/eventstreamprocessor/values.yaml
+++ b/eventstreamprocessor/values.yaml
@@ -22,7 +22,7 @@ global:
 replicaCount: 1
 image:
   repository: mojaloop/event-stream-processor
-  tag: v8.7.2-snapshot
+  tag: v8.8.0-snapshot
   pullPolicy: Always
 
 init:
@@ -49,8 +49,8 @@ service:
 
   annotations: {}
 
-  # This allows one to point the service to an external backend. 
-  # This is useful for local development where one wishes to hijack 
+  # This allows one to point the service to an external backend.
+  # This is useful for local development where one wishes to hijack
   # the communication from the service to the node layer and point
   # to a specific endpoint (IP, Port, etc).
   external:
@@ -58,7 +58,7 @@ service:
     # 10.0.2.2 is the magic IP for the host on virtualbox's network
     ip: 10.0.2.2
     ports:
-      api: 
+      api:
         name: event-stream-processor
         externalPort: 3082
 
@@ -81,13 +81,13 @@ ingress:
   # Used to create an Ingress record.
   hosts:
     api: event-stream-processor.local
-  
+
   externalPath: /
-  
+
   annotations:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  
+
   tls:
     # Secrets must be manually created in the namespace.
     # - secretName: chart-example-tls

--- a/finance-portal-settlement-management/templates/configmap.yaml
+++ b/finance-portal-settlement-management/templates/configmap.yaml
@@ -1,3 +1,8 @@
+{{- $dbHost := (.Values.config.db_host | replace "$release_name" .Release.Name) }}
+{{- $centralLedger := (.Values.settlementManagement.config.CENTRAL_LEDGER_SERVICE_NAME | replace "$release_name" .Release.Name) }}
+{{- $settlements := (.Values.settlementManagement.config.SETTLEMENTS_SERVICE_NAME | replace "$release_name" .Release.Name) }}
+{{- $operatorSettlement := (.Values.settlementManagement.config.OPERATOR_SETTLEMENTS_SERVICE_NAME | replace "$release_name" .Release.Name) }}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,7 +14,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 data:
-  ADMIN_ENDPOINT: {{ (printf "%s%s-%s:%s" "http://" .Release.Name .Values.settlementManagement.config.CENTRAL_LEDGER_SERVICE_NAME .Values.settlementManagement.config.CENTRAL_LEDGER_SERVICE_ADMIN_PORT) | quote }}
+  ADMIN_ENDPOINT: {{ (printf "%s%s:%s" "http://"  $centralLedger .Values.settlementManagement.config.CENTRAL_LEDGER_SERVICE_ADMIN_PORT) | quote }}
   MIN_WINDOW_AGE_MS: {{ (printf "%s" .Values.settlementManagement.config.MIN_WINDOW_AGE_MS) | quote }}
-  SETTLEMENT_ENDPOINT: {{ (printf "%s%s-%s:%s/%s" "http://" .Release.Name .Values.settlementManagement.config.SETTLEMENTS_SERVICE_NAME .Values.settlementManagement.config.SETTLEMENTS_SERVICE_PORT "v1") | quote }}
-  OPERATOR_SETTLEMENT_ENDPOINT: {{ (printf "%s%s-%s:%s" "http://" .Release.Name .Values.settlementManagement.config.OPERATOR_SETTLEMENTS_SERVICE_NAME .Values.settlementManagement.config.OPERATOR_SETTLEMENTS_SERVICE_PORT) | quote }}
+  SETTLEMENT_ENDPOINT: {{ (printf "%s%s:%s/%s" "http://" $settlements .Values.settlementManagement.config.SETTLEMENTS_SERVICE_PORT "v1") | quote }}
+  OPERATOR_SETTLEMENT_ENDPOINT: {{ (printf "%s%s:%s" "http://" $operatorSettlement .Values.settlementManagement.config.OPERATOR_SETTLEMENTS_SERVICE_PORT) | quote }}

--- a/finance-portal-settlement-management/values.yaml
+++ b/finance-portal-settlement-management/values.yaml
@@ -34,7 +34,7 @@ operatorSettlement:
     command: mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database < /opt/operator-settlement/init.sql
 
   ingress:
-    enabled: true
+    enabled: false
     externalPath: /
     hosts:
       api: operator-settlement.local
@@ -72,7 +72,7 @@ settlementManagement:
     OPERATOR_SETTLEMENTS_SERVICE_PORT: '80'
 
   ingress:
-    enabled: true
+    enabled: false
     externalPath: /
     hosts:
       api: settlement-management.local

--- a/finance-portal-settlement-management/values.yaml
+++ b/finance-portal-settlement-management/values.yaml
@@ -67,7 +67,7 @@ settlementManagement:
 
   config:
     CENTRAL_LEDGER_SERVICE_NAME: '$release_name-centralledger-service'
-    CENTRAL_LEDGER_SERVICE_ADMIN_PORT: '3001'
+    CENTRAL_LEDGER_SERVICE_ADMIN_PORT: '80'
     SETTLEMENTS_SERVICE_NAME: '$release_name-centralsettlement'
     SETTLEMENTS_SERVICE_PORT: '80'
     MIN_WINDOW_AGE_MS: '5000'

--- a/finance-portal-settlement-management/values.yaml
+++ b/finance-portal-settlement-management/values.yaml
@@ -51,7 +51,7 @@ operatorSettlement:
 settlementManagement:
   image:
     repository: mojaloop/settlement-management
-    tag: v8.8.0
+    tag: v8.8.1
     pullPolicy: Always
 
   service:
@@ -66,12 +66,12 @@ settlementManagement:
     command: mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database < /opt/settlement-management/init.sql
 
   config:
-    CENTRAL_LEDGER_SERVICE_NAME: 'centralledger-service'
+    CENTRAL_LEDGER_SERVICE_NAME: '$release_name-centralledger-service'
     CENTRAL_LEDGER_SERVICE_ADMIN_PORT: '3001'
-    SETTLEMENTS_SERVICE_NAME: 'centralsettlement'
+    SETTLEMENTS_SERVICE_NAME: '$release_name-centralsettlement'
     SETTLEMENTS_SERVICE_PORT: '80'
     MIN_WINDOW_AGE_MS: '5000'
-    OPERATOR_SETTLEMENTS_SERVICE_NAME: 'settlement'
+    OPERATOR_SETTLEMENTS_SERVICE_NAME: '$release_name-finance-portal-settlement-management'
     OPERATOR_SETTLEMENTS_SERVICE_PORT: '80'
 
   ingress:

--- a/finance-portal-settlement-management/values.yaml
+++ b/finance-portal-settlement-management/values.yaml
@@ -29,7 +29,7 @@ operatorSettlement:
     enabled: true
     image:
       repository: mojaloop/operator-settlement
-      tag: latest
+      tag: v8.8.0
       pullPolicy: Always
     command: mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database < /opt/operator-settlement/init.sql
 

--- a/finance-portal-settlement-management/values.yaml
+++ b/finance-portal-settlement-management/values.yaml
@@ -39,8 +39,11 @@ operatorSettlement:
     hosts:
       api: operator-settlement.local
     annotations:
-      nginx.ingress.kubernetes.io/rewrite-target: '/'
-      # kubernetes.io/ingress.class: nginx
+      kubernetes.io/ingress.class: nginx
+      ## NGINX Ingres Control < v0.22-
+      nginx.ingress.kubernetes.io/rewrite-target: /
+      ## NGINX Ingres Control >= v0.22+
+      # nginx.ingress.kubernetes.io/rewrite-target: /$1
       # kubernetes.io/tls-acme: "true"
     tls:
 
@@ -77,8 +80,11 @@ settlementManagement:
     hosts:
       api: settlement-management.local
     annotations:  
-      nginx.ingress.kubernetes.io/rewrite-target: '/'
-      # kubernetes.io/ingress.class: nginx
+      kubernetes.io/ingress.class: nginx
+      ## NGINX Ingres Control < v0.22-
+      nginx.ingress.kubernetes.io/rewrite-target: /
+      ## NGINX Ingres Control >= v0.22+
+      # nginx.ingress.kubernetes.io/rewrite-target: /$1
       # kubernetes.io/tls-acme: "true"
     tls:
     # Secrets must be manually created in the namespace.

--- a/finance-portal/templates/configmap.yaml
+++ b/finance-portal/templates/configmap.yaml
@@ -1,3 +1,7 @@
+{{- $settlementsEndpoint := ( .Values.config.settlementsEndpoint | replace "$release_name" .Release.Name ) -}}
+{{- $centralLedgerEndpoint := ( .Values.config.centralLedgerEndpoint | replace "$release_name" .Release.Name) -}}
+{{- $settlementManagementEndpoint := ( .Values.config.settlementManagementEndpoint | replace "$release_name" .Release.Name) -}}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,11 +13,11 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 data:
-  SETTLEMENTS_ENDPOINT: {{ (printf "http://%s-%s" .Release.Name .Values.config.settlementsEndpoint) | quote }}
-  CENTRAL_LEDGER_ENDPOINT: {{ (printf "http://%s-%s" .Release.Name .Values.config.centralLedgerEndpoint) | quote }}
+  SETTLEMENTS_ENDPOINT: {{ (printf "http://%s" $settlementsEndpoint) | quote }}
+  CENTRAL_LEDGER_ENDPOINT: {{ (printf "http://%s" $centralLedgerEndpoint) | quote }}
   HUB_REPORT_URL_312: {{ (printf "http://%s-%s" .Release.Name .Values.config.report1) | quote }}
   HUB_REPORT_URL_644: {{ (printf "http://%s-%s" .Release.Name .Values.config.report2) | quote }}
-  SETTLEMENT_MANAGEMENT_ENDPOINT: {{ (printf "%s%s-%s:%s" "http://" .Release.Name .Values.config.settlementManagementEndpoint .Values.config.settlementManagementPort) | quote }}
+  SETTLEMENT_MANAGEMENT_ENDPOINT: {{ (printf "%s%s:%s" "http://" $settlementManagementEndpoint .Values.config.settlementManagementPort) | quote }}
   LISTEN_PORT: "3000"
   NODE_ENV: "production"
   BYPASS_AUTH:  {{ .Values.config.BypassAuth | quote }}

--- a/finance-portal/values.yaml
+++ b/finance-portal/values.yaml
@@ -109,7 +109,7 @@ frontend:
     externalPath: /(.*)
     hosts: 
       api: finance-portal.local
-    annotations: {}
+    annotations:
       kubernetes.io/ingress.class: nginx
       ## NGINX Ingres Control < v0.22-
       nginx.ingress.kubernetes.io/rewrite-target: /
@@ -136,7 +136,7 @@ backend:
     externalPath: /admin-portal-backend/
     hosts: 
       api: finance-portal.local
-    annotations: {}
+    annotations:
       kubernetes.io/ingress.class: nginx
       ## NGINX Ingres Control < v0.22-
       nginx.ingress.kubernetes.io/rewrite-target: /

--- a/finance-portal/values.yaml
+++ b/finance-portal/values.yaml
@@ -122,7 +122,7 @@ backend:
     port: 3000
   image:
     repository: mojaloop/finance-portal-backend-service
-    tag: v8.8.7
+    tag: v8.8.8
     pullPolicy: Always
     port: 3000
   init:

--- a/finance-portal/values.yaml
+++ b/finance-portal/values.yaml
@@ -66,9 +66,9 @@ config:
   db_user: 'central_ledger'
   db_password: 'oyMxgZChuu'
   db_database: 'central_ledger'
-  settlementsEndpoint: 'centralsettlement/v1'
-  centralLedgerEndpoint: 'centralledger-service'
-  settlementManagementEndpoint: 'finance-portal-settlement-management'
+  settlementsEndpoint: '$release_name-centralsettlement/v1'
+  centralLedgerEndpoint: '$release_name-centralledger-service'
+  settlementManagementEndpoint: '$release_name-finance-portal-settlement-management'
   settlementManagementPort: '5000'
   isOauthEnabled: false
   oauthServer: 'https://localhost'
@@ -121,7 +121,7 @@ backend:
     port: 3000
   image:
     repository: mojaloop/finance-portal-backend-service
-    tag: v8.8.0
+    tag: v8.8.3
     pullPolicy: Always
     port: 3000
   init:

--- a/finance-portal/values.yaml
+++ b/finance-portal/values.yaml
@@ -129,7 +129,7 @@ backend:
       pullPolicy: Always
   env: 'dev'
   ingress:
-    enabled: true
+    enabled: false
     externalPath: /admin-portal-backend/(.*)
     hosts: 
       api: finance-portal-backend.local

--- a/finance-portal/values.yaml
+++ b/finance-portal/values.yaml
@@ -68,7 +68,7 @@ config:
   db_database: 'central_ledger'
   settlementsEndpoint: 'centralsettlement/v1'
   centralLedgerEndpoint: 'centralledger-service'
-  settlementManagementEndpoint: 'settlement'
+  settlementManagementEndpoint: 'finance-portal-settlement-management'
   settlementManagementPort: '5000'
   isOauthEnabled: false
   oauthServer: 'https://localhost'

--- a/finance-portal/values.yaml
+++ b/finance-portal/values.yaml
@@ -66,6 +66,7 @@ config:
   db_user: 'central_ledger'
   db_password: 'oyMxgZChuu'
   db_database: 'central_ledger'
+  fxpEndpoint: '$release_name-fxp-server'
   settlementsEndpoint: '$release_name-centralsettlement/v1'
   centralLedgerEndpoint: '$release_name-centralledger-service'
   settlementManagementEndpoint: '$release_name-finance-portal-settlement-management'
@@ -121,7 +122,7 @@ backend:
     port: 3000
   image:
     repository: mojaloop/finance-portal-backend-service
-    tag: v8.8.5
+    tag: v8.8.7
     pullPolicy: Always
     port: 3000
   init:

--- a/finance-portal/values.yaml
+++ b/finance-portal/values.yaml
@@ -125,7 +125,7 @@ backend:
     enabled: false
     image:
       repository: mojaloop/finance-portal-backend-service
-      tag: v0.0.1
+      tag: v8.8.0
       pullPolicy: Always
   env: 'dev'
   ingress:

--- a/finance-portal/values.yaml
+++ b/finance-portal/values.yaml
@@ -129,7 +129,7 @@ backend:
     enabled: true
     image:
       repository: mojaloop/finance-portal-backend-service
-      tag: v8.8.0
+      tag: v8.8.8
       pullPolicy: Always
   env: 'dev'
   ingress:

--- a/finance-portal/values.yaml
+++ b/finance-portal/values.yaml
@@ -108,9 +108,12 @@ frontend:
     enabled: true
     externalPath: /(.*)
     hosts: 
-      api: finance-portal-frontend.local
+      api: finance-portal.local
     annotations: {}
-      # kubernetes.io/ingress.class: nginx
+      kubernetes.io/ingress.class: nginx
+      ## NGINX Ingres Control < v0.22-
+      nginx.ingress.kubernetes.io/rewrite-target: /
+      ## NGINX Ingres Control >= v0.22+
       # nginx.ingress.kubernetes.io/rewrite-target: /$1
       
 backend:
@@ -122,7 +125,7 @@ backend:
     pullPolicy: Always
     port: 3000
   init:
-    enabled: false
+    enabled: true
     image:
       repository: mojaloop/finance-portal-backend-service
       tag: v8.8.0
@@ -130,9 +133,12 @@ backend:
   env: 'dev'
   ingress:
     enabled: false
-    externalPath: /admin-portal-backend/(.*)
+    externalPath: /admin-portal-backend/
     hosts: 
-      api: finance-portal-backend.local
+      api: finance-portal.local
     annotations: {}
-      # kubernetes.io/ingress.class: nginx
+      kubernetes.io/ingress.class: nginx
+      ## NGINX Ingres Control < v0.22-
+      nginx.ingress.kubernetes.io/rewrite-target: /
+      ## NGINX Ingres Control >= v0.22+
       # nginx.ingress.kubernetes.io/rewrite-target: /$1

--- a/finance-portal/values.yaml
+++ b/finance-portal/values.yaml
@@ -115,13 +115,13 @@ frontend:
       nginx.ingress.kubernetes.io/rewrite-target: /
       ## NGINX Ingres Control >= v0.22+
       # nginx.ingress.kubernetes.io/rewrite-target: /$1
-      
+
 backend:
   service:
     port: 3000
   image:
     repository: mojaloop/finance-portal-backend-service
-    tag: v8.8.3
+    tag: v8.8.5
     pullPolicy: Always
     port: 3000
   init:

--- a/ml-api-adapter/Chart.yaml
+++ b/ml-api-adapter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Helm chart for Kubernetes
 name: ml-api-adapter
-version: 8.7.1
-appVersion: "8.7.2"
+version: 8.8.0
+appVersion: "8.8.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-handler-notification/Chart.yaml
+++ b/ml-api-adapter/chart-handler-notification/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: ml-api-adapter-handler-notification
-version: 8.7.1
-appVersion: "8.7.2"
+version: 8.8.0
+appVersion: "8.8.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v8.7.2
+  tag: v8.8.2
   command: '["node", "src/handlers/index.js", "handler", "--notification"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.
@@ -18,7 +18,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v8.7.1
+    tag: v8.7.3
     pullPolicy: Always
     command: '["npm", "run", "start"]'
   service:

--- a/ml-api-adapter/chart-service/Chart.yaml
+++ b/ml-api-adapter/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter API component Helm chart for Kubernetes
 name: ml-api-adapter-service
-version: 8.7.1
-appVersion: "8.7.2"
+version: 8.8.0
+appVersion: "8.8.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-service/values.yaml
+++ b/ml-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v8.7.2
+  tag: v8.8.2
   command: '["node", "src/api/index.js"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.
@@ -18,7 +18,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v8.7.1
+    tag: v8.7.3
     pullPolicy: Always
     command: '["npm", "run", "start"]'
   service:

--- a/ml-api-adapter/requirements.yaml
+++ b/ml-api-adapter/requirements.yaml
@@ -1,11 +1,11 @@
 # requirements.yaml
 dependencies:
 - name: ml-api-adapter-service
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://./chart-service"
   condition: ml-api-adapter-service.enabled
 - name: ml-api-adapter-handler-notification
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://./chart-handler-notification"
   condition: ml-api-adapter-handler-notification.enabled
 ## This is used for testing ml-api-adapter deployments

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -26,7 +26,7 @@ ml-api-adapter-service:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v8.7.2
+    tag: v8.8.2
     command: '["node", "src/api/index.js"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -40,7 +40,7 @@ ml-api-adapter-service:
     enabled: true
     image:
       repository: mojaloop/event-sidecar
-      tag: v8.7.1
+      tag: v8.7.3
       pullPolicy: Always
     readinessProbe:
       enabled: true
@@ -156,7 +156,7 @@ ml-api-adapter-handler-notification:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v8.7.2
+    tag: v8.8.2
     command: '["node", "src/handlers/index.js", "handler", "--notification"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -170,7 +170,7 @@ ml-api-adapter-handler-notification:
     enabled: true
     image:
       repository: mojaloop/event-sidecar
-      tag: v8.7.1
+      tag: v8.7.3
       pullPolicy: Always
     readinessProbe:
       enabled: true

--- a/mojaloop-bulk/Chart.yaml
+++ b/mojaloop-bulk/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Mojaloop Bulk Helm chart for Kubernetes
 name: mojaloop-bulk
-version: 8.7.1
-appVersion: "bulk-api-adapter: v8.7.0-snapshot; central-ledger: v8.7.1"
+version: 8.8.0
+appVersion: "bulk-api-adapter: v8.8.0-snapshot; central-ledger: v8.8.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop-bulk/requirements.yaml
+++ b/mojaloop-bulk/requirements.yaml
@@ -1,11 +1,11 @@
 # requirements.yaml
 dependencies:
 - name: bulk-api-adapter
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://../bulk-api-adapter"
   condition: bulk-api-adapter.enabled
 - name: bulk-centralledger
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://../bulk-centralledger"
   condition: bulk-centralledger.enabled
 - name: mongodb

--- a/mojaloop-bulk/values.yaml
+++ b/mojaloop-bulk/values.yaml
@@ -260,7 +260,7 @@ bulk-centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v8.7.1
+          tag: v8.8.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
         service:
@@ -426,7 +426,7 @@ bulk-centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v8.7.1
+          tag: v8.8.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
         service:
@@ -592,7 +592,7 @@ bulk-centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v8.7.1
+          tag: v8.8.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
         service:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 8.8.0
-appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.8.1; quoting-service: v8.8.1-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.7.0-snapshot; email-notifier: v8.7.0; simulator: v8.7.1; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.7.1; finance-portal: v8.8.0; finance-portal-settlement-management: v8.8.0"
+appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.8.1; quoting-service: v8.8.1-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.7.0-snapshot; email-notifier: v8.8.0; simulator: v8.7.1; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.7.1; finance-portal: v8.8.0; finance-portal-settlement-management: v8.8.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 8.8.0
-appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.7.0; quoting-service: v8.8.0-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.8.0-snapshot; email-notifier: v8.8.0; simulator: v8.8.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.7.1; finance-portal: v8.8.0; finance-portal-settlement-management: v8.8.0"
+appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.7.0; quoting-service: v8.7.0-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.8.0-snapshot; email-notifier: v8.8.0; simulator: v8.8.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.7.1; finance-portal: v8.8.0; finance-portal-settlement-management: v8.8.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 8.8.0
-appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.8.1; quoting-service: v8.7.0-snapshot; central-settlement: v8.6.0; central-event-processor: v8.7.0; bulk-api-adapter: v8.7.0-snapshot; email-notifier: v8.7.0; simulator: v8.7.1; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.7.1"
+appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.8.1; quoting-service: v8.8.1-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.7.0-snapshot; email-notifier: v8.7.0; simulator: v8.7.1; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.7.1; finance-portal: v8.8.0; finance-portal-settlement-management: v8.8.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 8.8.0
-appVersion: "ml-api-adapter: v8.7.2; central-ledger: v8.8.2; account-lookup-service: v8.7.0; quoting-service: v8.7.0-snapshot; central-settlement: v8.6.0; central-event-processor: v8.7.0; bulk-api-adapter: v8.7.0-snapshot; email-notifier: v8.7.0; simulator: v8.7.1; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.7.1"
+appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.7.0; quoting-service: v8.7.0-snapshot; central-settlement: v8.6.0; central-event-processor: v8.7.0; bulk-api-adapter: v8.7.0-snapshot; email-notifier: v8.7.0; simulator: v8.7.1; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.7.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 8.8.0
-appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.8.1; quoting-service: v8.8.1-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.7.0-snapshot; email-notifier: v8.8.0; simulator: v8.8.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.7.1; finance-portal: v8.8.0; finance-portal-settlement-management: v8.8.0"
+appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.8.1; quoting-service: v8.8.1-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.7.0-snapshot; email-notifier: v8.8.0; simulator: v8.8.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.8.0; finance-portal: v8.8.0; finance-portal-settlement-management: v8.8.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 8.8.0
-appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.7.0; quoting-service: v8.7.0-snapshot; central-settlement: v8.6.0; central-event-processor: v8.7.0; bulk-api-adapter: v8.7.0-snapshot; email-notifier: v8.7.0; simulator: v8.7.1; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.7.1"
+appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.8.1; quoting-service: v8.7.0-snapshot; central-settlement: v8.6.0; central-event-processor: v8.7.0; bulk-api-adapter: v8.7.0-snapshot; email-notifier: v8.7.0; simulator: v8.7.1; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.7.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 8.8.0
-appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.7.0; quoting-service: v8.7.0-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.8.0-snapshot; email-notifier: v8.8.0; simulator: v8.8.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.7.1; finance-portal: v8.8.0; finance-portal-settlement-management: v8.8.0"
+appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.7.0; quoting-service: v8.7.0-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.8.0-snapshot; email-notifier: v8.8.0; simulator: v8.8.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.8.1; finance-portal: v8.8.0; finance-portal-settlement-management: v8.8.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 8.8.0
-appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.8.1; quoting-service: v8.8.1-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.7.0-snapshot; email-notifier: v8.8.0; simulator: v8.8.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.8.0; finance-portal: v8.8.0; finance-portal-settlement-management: v8.8.0"
+appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.8.1; quoting-service: v8.8.1-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.8.0-snapshot; email-notifier: v8.8.0; simulator: v8.8.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.8.0; finance-portal: v8.8.0; finance-portal-settlement-management: v8.8.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
-version: 8.7.1
-appVersion: "ml-api-adapter: v8.7.2; central-ledger: v8.7.1; account-lookup-service: v8.7.0; quoting-service: v8.7.0-snapshot; central-settlement: v8.6.0; central-event-processor: v8.7.0; bulk-api-adapter: v8.7.0-snapshot; email-notifier: v8.7.0; simulator: v8.7.1; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.7.1"
+version: 8.8.0
+appVersion: "ml-api-adapter: v8.7.2; central-ledger: v8.8.2; account-lookup-service: v8.7.0; quoting-service: v8.7.0-snapshot; central-settlement: v8.6.0; central-event-processor: v8.7.0; bulk-api-adapter: v8.7.0-snapshot; email-notifier: v8.7.0; simulator: v8.7.1; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.7.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 8.8.0
-appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.8.1; quoting-service: v8.8.1-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.7.0-snapshot; email-notifier: v8.8.0; simulator: v8.7.1; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.7.1; finance-portal: v8.8.0; finance-portal-settlement-management: v8.8.0"
+appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.8.1; quoting-service: v8.8.1-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.7.0-snapshot; email-notifier: v8.8.0; simulator: v8.8.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.7.1; finance-portal: v8.8.0; finance-portal-settlement-management: v8.8.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 8.8.0
-appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.7.0; quoting-service: v8.7.0-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.8.0-snapshot; email-notifier: v8.8.0; simulator: v8.8.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.8.1; finance-portal: v8.8.0; finance-portal-settlement-management: v8.8.0"
+appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v9.2.0; quoting-service: v9.1.0-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.8.0-snapshot; email-notifier: v8.8.0; simulator: v9.1.1; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v9.1.0; finance-portal: v8.8.8; finance-portal-settlement-management: v8.8.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 8.8.0
-appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.8.1; quoting-service: v8.8.1-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.8.0-snapshot; email-notifier: v8.8.0; simulator: v8.8.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.8.0; finance-portal: v8.8.0; finance-portal-settlement-management: v8.8.0"
+appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.8.1; quoting-service: v8.8.1-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.8.0-snapshot; email-notifier: v8.8.0; simulator: v8.8.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.7.1; finance-portal: v8.8.0; finance-portal-settlement-management: v8.8.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 8.8.0
-appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.8.1; quoting-service: v8.8.1-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.8.0-snapshot; email-notifier: v8.8.0; simulator: v8.8.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.7.1; finance-portal: v8.8.0; finance-portal-settlement-management: v8.8.0"
+appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v8.7.0; quoting-service: v8.8.0-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.8.0-snapshot; email-notifier: v8.8.0; simulator: v8.8.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v8.7.1; finance-portal: v8.8.0; finance-portal-settlement-management: v8.8.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
   repository: "file://../central"
   condition: central.enabled
 - name: ml-api-adapter
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://../ml-api-adapter"
   condition: ml-api-adapter.enabled
 - name: emailnotifier

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -29,7 +29,7 @@ dependencies:
   repository: "file://../mojaloop-bulk"
   condition: mojaloop-bulk.enabled
 - name: transaction-requests-service
-  version: 8.8.0
+  version: 8.7.1
   repository: "file://../transaction-requests-service"
   condition: transaction-requests-service.enabled
 - name: finance-portal

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -13,7 +13,7 @@ dependencies:
   repository: "file://../emailnotifier"
   condition: emailnotifier.enabled
 - name: account-lookup-service
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://../account-lookup-service"
   condition: account-lookup-service.enabled
 - name: quoting-service

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -17,7 +17,7 @@ dependencies:
   repository: "file://../account-lookup-service"
   condition: account-lookup-service.enabled
 - name: quoting-service
-  version: 8.8.0
+  version: 8.7.0
   repository: "file://../quoting-service"
   condition: quoting-service.enabled
 - name: simulator

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: central
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://../central"
   condition: central.enabled
 - name: ml-api-adapter

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -13,11 +13,11 @@ dependencies:
   repository: "file://../emailnotifier"
   condition: emailnotifier.enabled
 - name: account-lookup-service
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://../account-lookup-service"
   condition: account-lookup-service.enabled
 - name: quoting-service
-  version: 8.7.0
+  version: 8.8.0
   repository: "file://../quoting-service"
   condition: quoting-service.enabled
 - name: simulator

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -29,7 +29,7 @@ dependencies:
   repository: "file://../mojaloop-bulk"
   condition: mojaloop-bulk.enabled
 - name: transaction-requests-service
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://../transaction-requests-service"
   condition: transaction-requests-service.enabled
 - name: finance-portal

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -25,7 +25,7 @@ dependencies:
   repository: "file://../simulator"
   condition: simulator.enabled
 - name: mojaloop-bulk
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://../mojaloop-bulk"
   condition: mojaloop-bulk.enabled
 - name: transaction-requests-service

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -21,7 +21,7 @@ dependencies:
   repository: "file://../quoting-service"
   condition: quoting-service.enabled
 - name: simulator
-  version: 8.7.0
+  version: 8.8.0
   repository: "file://../simulator"
   condition: simulator.enabled
 - name: mojaloop-bulk

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   repository: "file://../ml-api-adapter"
   condition: ml-api-adapter.enabled
 - name: emailnotifier
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://../emailnotifier"
   condition: emailnotifier.enabled
 - name: account-lookup-service

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -13,7 +13,7 @@ dependencies:
   repository: "file://../emailnotifier"
   condition: emailnotifier.enabled
 - name: account-lookup-service
-  version: 8.8.0
+  version: 8.7.1
   repository: "file://../account-lookup-service"
   condition: account-lookup-service.enabled
 - name: quoting-service

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -17,7 +17,7 @@ dependencies:
   repository: "file://../account-lookup-service"
   condition: account-lookup-service.enabled
 - name: quoting-service
-  version: 8.7.1
+  version: 8.8.0
   repository: "file://../quoting-service"
   condition: quoting-service.enabled
 - name: simulator

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2491,7 +2491,7 @@ account-lookup-service:
       api:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v8.8.1
+          tag: v8.7.0
           pullPolicy: Always
           command: '["node", "src/index.js", "server", "--api"]'
         service:
@@ -2502,7 +2502,7 @@ account-lookup-service:
       admin:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v8.8.1
+          tag: v8.7.0
           pullPolicy: Always
           command: '["node", "src/index.js", "server", "--admin"]'
         service:
@@ -2621,7 +2621,7 @@ account-lookup-service:
       api:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v8.8.1
+          tag: v8.7.0
           pullPolicy: Always
           command: '["node", "src/index.js", "server", "--api"]'
         service:
@@ -2632,7 +2632,7 @@ account-lookup-service:
       admin:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v8.8.1
+          tag: v8.7.0
           pullPolicy: Always
           command: '["node", "src/index.js", "server", "--admin"]'
         service:
@@ -3091,7 +3091,7 @@ quoting-service:
   replicaCount: 1
   image:
     repository: mojaloop/quoting-service
-    tag: v8.8.1-snapshot
+    tag: v8.8.0-snapshot
     pullPolicy: Always
 
   readinessProbe:
@@ -3149,7 +3149,7 @@ quoting-service:
     enabled: true
     image:
       repository: mojaloop/event-sidecar
-      tag: v8.7.1
+      tag: v8.7.3
       pullPolicy: Always
     readinessProbe:
       enabled: true

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -37,7 +37,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v8.7.1
+            tag: v8.8.2
             pullPolicy: Always
             command: '["node", "src/api/index.js"]'
           service:
@@ -63,7 +63,7 @@ central:
         enabled: false
         image:
           repository: mojaloop/event-sidecar
-          tag: v8.7.1
+          tag: v8.7.3
           pullPolicy: Always
         readinessProbe:
           enabled: true
@@ -202,7 +202,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v8.7.1
+            tag: v8.8.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
           service:
@@ -228,7 +228,7 @@ central:
         enabled: true
         image:
           repository: mojaloop/event-sidecar
-          tag: v8.7.1
+          tag: v8.7.3
           pullPolicy: Always
         readinessProbe:
           enabled: true
@@ -374,7 +374,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v8.7.1
+            tag: v8.8.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--admin"]'
           service:
@@ -400,7 +400,7 @@ central:
         enabled: false
         image:
           repository: mojaloop/event-sidecar
-          tag: v8.7.1
+          tag: v8.7.3
           pullPolicy: Always
         readinessProbe:
           enabled: true
@@ -546,7 +546,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v8.7.1
+            tag: v8.8.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--position"]'
           service:
@@ -572,7 +572,7 @@ central:
         enabled: true
         image:
           repository: mojaloop/event-sidecar
-          tag: v8.7.1
+          tag: v8.7.3
           pullPolicy: Always
         readinessProbe:
           enabled: true
@@ -718,7 +718,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v8.7.1
+            tag: v8.8.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--get"]'
           service:
@@ -744,7 +744,7 @@ central:
         enabled: false
         image:
           repository: mojaloop/event-sidecar
-          tag: v8.7.1
+          tag: v8.7.3
           pullPolicy: Always
         readinessProbe:
           enabled: true
@@ -890,7 +890,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v8.7.1
+            tag: v8.8.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
           service:
@@ -916,7 +916,7 @@ central:
         enabled: true
         image:
           repository: mojaloop/event-sidecar
-          tag: v8.7.1
+          tag: v8.7.3
           pullPolicy: Always
         readinessProbe:
           enabled: true
@@ -1062,7 +1062,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v8.7.1
+            tag: v8.8.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
           service:
@@ -1088,7 +1088,7 @@ central:
         enabled: true
         image:
           repository: mojaloop/event-sidecar
-          tag: v8.7.1
+          tag: v8.7.3
           pullPolicy: Always
         readinessProbe:
           enabled: true

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3540,7 +3540,7 @@ finance-portal:
         pullPolicy: Always
     env: 'dev'
     ingress:
-      enabled: true
+      enabled: false
       externalPath: /admin-portal-backend/(.*)
       hosts: 
         api: finance-portal-backend.local
@@ -3586,7 +3586,7 @@ finance-portal-settlement-management:
       command: mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database < /opt/operator-settlement/init.sql
 
     ingress:
-      enabled: true
+      enabled: false
       externalPath: /
       hosts:
         api: operator-settlement.local
@@ -3624,7 +3624,7 @@ finance-portal-settlement-management:
       OPERATOR_SETTLEMENTS_SERVICE_PORT: '80'
 
     ingress:
-      enabled: true
+      enabled: false
       externalPath: /
       hosts:
         api: settlement-management.local

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2491,7 +2491,7 @@ account-lookup-service:
       api:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v8.7.0
+          tag: v9.2.0
           pullPolicy: Always
           command: '["node", "src/index.js", "server", "--api"]'
         service:
@@ -2502,7 +2502,7 @@ account-lookup-service:
       admin:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v8.7.0
+          tag: v9.2.0
           pullPolicy: Always
           command: '["node", "src/index.js", "server", "--admin"]'
         service:
@@ -2621,7 +2621,7 @@ account-lookup-service:
       api:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v8.7.0
+          tag: v9.2.0
           pullPolicy: Always
           command: '["node", "src/index.js", "server", "--api"]'
         service:
@@ -2632,7 +2632,7 @@ account-lookup-service:
       admin:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v8.7.0
+          tag: v9.2.0
           pullPolicy: Always
           command: '["node", "src/index.js", "server", "--admin"]'
         service:
@@ -3228,7 +3228,7 @@ transaction-requests-service:
   replicaCount: 1
   image:
     repository: mojaloop/transaction-requests-service
-    tag: v8.8.1
+    tag: v9.1.0
     pullPolicy: Always
 
   readinessProbe:
@@ -3323,7 +3323,7 @@ simulator:
 
   image:
     repository: mojaloop/simulator
-    tag: v8.8.1
+    tag: v9.1.1
     pullPolicy: Always
 
   imagePullSecrets: []

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2377,7 +2377,7 @@ emailnotifier:
 
   image:
     repository: mojaloop/email-notifier
-    tag: v8.7.0
+    tag: v8.8.0
     pullPolicy: Always
 
   init:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3091,7 +3091,7 @@ quoting-service:
   replicaCount: 1
   image:
     repository: mojaloop/quoting-service
-    tag: v8.7.0-snapshot
+    tag: v8.8.1-snapshot
     pullPolicy: Always
 
   readinessProbe:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -1669,7 +1669,7 @@ central:
     replicaCount: 1
     image:
       repository: mojaloop/central-settlement
-      tag: v8.6.0
+      tag: v8.8.0
       pullPolicy: Always
 
     readinessProbe:
@@ -1783,7 +1783,7 @@ central:
     replicaCount: 1
     image:
       repository: mojaloop/central-event-processor
-      tag: v8.6.0
+      tag: v8.8.0
       pullPolicy: Always
     init:
       enabled: true

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3091,7 +3091,7 @@ quoting-service:
   replicaCount: 1
   image:
     repository: mojaloop/quoting-service
-    tag: v8.8.0-snapshot
+    tag: v8.7.0-snapshot
     pullPolicy: Always
 
   readinessProbe:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3519,9 +3519,12 @@ finance-portal:
       enabled: true
       externalPath: /(.*)
       hosts: 
-        api: finance-portal-frontend.local
-      annotations: {}
-        # kubernetes.io/ingress.class: nginx
+        api: finance-portal.local
+      annotations:
+        kubernetes.io/ingress.class: nginx
+        ## NGINX Ingres Control < v0.22-
+        nginx.ingress.kubernetes.io/rewrite-target: /
+        ## NGINX Ingres Control >= v0.22+
         # nginx.ingress.kubernetes.io/rewrite-target: /$1
         
   backend:
@@ -3543,9 +3546,12 @@ finance-portal:
       enabled: false
       externalPath: /admin-portal-backend/(.*)
       hosts: 
-        api: finance-portal-backend.local
-      annotations: {}
-        # kubernetes.io/ingress.class: nginx
+        api: finance-portal.local
+      annotations:
+        kubernetes.io/ingress.class: nginx
+        ## NGINX Ingres Control < v0.22-
+        nginx.ingress.kubernetes.io/rewrite-target: /
+        ## NGINX Ingres Control >= v0.22+
         # nginx.ingress.kubernetes.io/rewrite-target: /$1
 
 finance-portal-settlement-management:
@@ -3591,8 +3597,11 @@ finance-portal-settlement-management:
       hosts:
         api: operator-settlement.local
       annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: '/'
-        # kubernetes.io/ingress.class: nginx
+        kubernetes.io/ingress.class: nginx
+        ## NGINX Ingres Control < v0.22-
+        nginx.ingress.kubernetes.io/rewrite-target: /
+        ## NGINX Ingres Control >= v0.22+
+        # nginx.ingress.kubernetes.io/rewrite-target: /$1
         # kubernetes.io/tls-acme: "true"
       tls:
 
@@ -3629,8 +3638,11 @@ finance-portal-settlement-management:
       hosts:
         api: settlement-management.local
       annotations:  
-        nginx.ingress.kubernetes.io/rewrite-target: '/'
-        # kubernetes.io/ingress.class: nginx
+        kubernetes.io/ingress.class: nginx
+        ## NGINX Ingres Control < v0.22-
+        nginx.ingress.kubernetes.io/rewrite-target: /
+        ## NGINX Ingres Control >= v0.22+
+        # nginx.ingress.kubernetes.io/rewrite-target: /$1
         # kubernetes.io/tls-acme: "true"
       tls:
       # Secrets must be manually created in the namespace.

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3512,7 +3512,7 @@ finance-portal:
       port: 80
     image:
       repository: mojaloop/finance-portal-ui
-      tag: v8.8.0
+      tag: v8.8.1
       pullPolicy: Always
       port: 80
     ingress:
@@ -3532,7 +3532,7 @@ finance-portal:
       port: 3000
     image:
       repository: mojaloop/finance-portal-backend-service
-      tag: v8.8.3
+      tag: v8.8.4
       pullPolicy: Always
       port: 3000
     init:
@@ -3625,7 +3625,7 @@ finance-portal-settlement-management:
 
     config:
       CENTRAL_LEDGER_SERVICE_NAME: '$release_name-centralledger-service'
-      CENTRAL_LEDGER_SERVICE_ADMIN_PORT: '3001'
+      CENTRAL_LEDGER_SERVICE_ADMIN_PORT: '80'
       SETTLEMENTS_SERVICE_NAME: '$release_name-centralsettlement'
       SETTLEMENTS_SERVICE_PORT: '80'
       MIN_WINDOW_AGE_MS: '5000'

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3091,7 +3091,7 @@ quoting-service:
   replicaCount: 1
   image:
     repository: mojaloop/quoting-service
-    tag: v8.7.0-snapshot
+    tag: v9.1.0-snapshot
     pullPolicy: Always
 
   readinessProbe:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3344,6 +3344,7 @@ simulator:
     PARTIES_SERVICE_ENDPOINT: 'http://$release_name-account-lookup-service'
     QUOTES_SERVICE_ENDPOINT: 'http://$release_name-quoting-service'
     TRANSFERS_SERVICE_ENDPOINT: 'http://$release_name-ml-api-adapter-service'
+    TRANSACTION_REQUESTS_SERVICE_ENDPOINT: 'http://$release_name-transaction-requests-service'
     ## Disable the fulfil response callback
     TRANSFERS_FULFIL_RESPONSE_DISABLED: false
     ## Set the fulfil response response information

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3228,7 +3228,7 @@ transaction-requests-service:
   replicaCount: 1
   image:
     repository: mojaloop/transaction-requests-service
-    tag: v8.8.0
+    tag: v8.7.1
     pullPolicy: Always
 
   readinessProbe:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3323,7 +3323,7 @@ simulator:
 
   image:
     repository: mojaloop/simulator
-    tag: v8.7.1
+    tag: v8.8.0
     pullPolicy: Always
 
   imagePullSecrets: []

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2491,7 +2491,7 @@ account-lookup-service:
       api:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v8.7.0
+          tag: v8.8.1
           pullPolicy: Always
           command: '["node", "src/index.js", "server", "--api"]'
         service:
@@ -2502,7 +2502,7 @@ account-lookup-service:
       admin:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v8.7.0
+          tag: v8.8.1
           pullPolicy: Always
           command: '["node", "src/index.js", "server", "--admin"]'
         service:
@@ -2621,7 +2621,7 @@ account-lookup-service:
       api:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v8.7.0
+          tag: v8.8.1
           pullPolicy: Always
           command: '["node", "src/index.js", "server", "--api"]'
         service:
@@ -2632,7 +2632,7 @@ account-lookup-service:
       admin:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v8.7.0
+          tag: v8.8.1
           pullPolicy: Always
           command: '["node", "src/index.js", "server", "--admin"]'
         service:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2171,7 +2171,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v8.7.2
+      tag: v8.8.2
       command: '["node", "src/api/index.js"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -2185,7 +2185,7 @@ ml-api-adapter:
       enabled: true
       image:
         repository: mojaloop/event-sidecar
-        tag: v8.7.1
+        tag: v8.7.3
         pullPolicy: Always
       readinessProbe:
         enabled: true
@@ -2281,7 +2281,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v8.7.2
+      tag: v8.8.2
       command: '["node", "src/handlers/index.js", "handler", "--notification"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -2295,7 +2295,7 @@ ml-api-adapter:
       enabled: true
       image:
         repository: mojaloop/event-sidecar
-        tag: v8.7.1
+        tag: v8.7.3
         pullPolicy: Always
       readinessProbe:
         enabled: true

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3533,14 +3533,14 @@ finance-portal:
       port: 3000
     image:
       repository: mojaloop/finance-portal-backend-service
-      tag: v8.8.7
+      tag: v8.8.8
       pullPolicy: Always
       port: 3000
     init:
       enabled: false
       image:
         repository: mojaloop/finance-portal-backend-service
-        tag: v8.8.0
+        tag: v8.8.8
         pullPolicy: Always
     env: 'dev'
     ingress:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3526,13 +3526,13 @@ finance-portal:
         nginx.ingress.kubernetes.io/rewrite-target: /
         ## NGINX Ingres Control >= v0.22+
         # nginx.ingress.kubernetes.io/rewrite-target: /$1
-        
+
   backend:
     service:
       port: 3000
     image:
       repository: mojaloop/finance-portal-backend-service
-      tag: v8.8.4
+      tag: v8.8.5
       pullPolicy: Always
       port: 3000
     init:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3407,8 +3407,236 @@ simulator:
 
   affinity: {}
 
+finance-portal:
+  enabled: true
+  service:
+    type: ClusterIP
+
+  imageCredentials:
+      enabled: false
+      name: pull-secrets
+
+  JWTKeys:
+    # These are example keys, please get valid keys for your deployment
+    # The name you assign to each variable will be used as the file name. Using the following examples, three key files will be created:
+    # - /opt/finance-portal-backend-service/secrets/first_key.key
+    # - /opt/finance-portal-backend-service/secrets/second_key.key
+    # - /opt/finance-portal-backend-service/secrets/third_key.key
+    first_key.key: |-
+      -----BEGIN RSA PUBLIC KEY-----
+      MIICXQIBAAKBgQCyQ80uaA1DKxjwuGgetuHiXoZxpQ/Twyj/9a5zeMCfZlAvreCs
+      8MhCm17OuQkYkiIpoEwn3DUDXAO03kUg9Hg5pd5ObnTZdWoBKWR1t/U2R4xU6v2w
+      KLn9KyK/cA/79wzaiMZS+H+j+pt9ZjgdpKOcn3XK8bOURIVEsSNu8+yZ/wIDAQAB
+      AoGAULdvj9wwaSH6DIFLL+EaHYA0ev/Ez1tWVLN/NqzN9z8B/tzJ1zS9UJ9+Sbcx
+      3azJiDSbVw8X9/nxebOM9JONXbcCMeJX5MqsBzrR89vTHo9ir91u7LDVBEo+bsrS
+      ufTQdT1etUOggwWssU4JLoQB7L7QoFhBTndAc6AwmB1t6pECQQDHBe01qgTQwF4H
+      zjnpBKPUlYX5Ma+6VDvSG/yFdJeA58TrF3oBBnET9ZTmy4mDLQaO88wsAx0kduaB
+      H8tuoCUvAkEA5UyIpG2djRCyCRkENJLn9qpCaSOwaO43D189KqGzW9nHihMNczha
+      akAIa3ULp8AoqPFKOFk+v2jGYwPHSatEMQJBAK9vr/wAFSKWj8y9oxqetnPsIh7a
+      B5duLRU3Ck/xyKMeqty44xkIPqFjd5BClsME66UTj0S0sfm0vdfQ2Rh5Ho0CQAaz
+      PM7pMRBdK4aeh4Ptwv9vLC+cTlxSkaNOWiAzx2TosS70rZDvVZ0DL/vL2MJXGBkP
+      q+aHnRDEw/9CrgEWExECQQCT7jFthoPs29A981euHfZ+bXMFEI48PFgw13cmyWnM
+      HijF+4E/XtD11WJkIuDCmHal/oRtcbIO/cCk15xbWZkD
+      -----END RSA PUBLIC KEY-----
+    second_key.key: |-
+      -----BEGIN RSA PUBLIC KEY-----
+      MIICXQIBAAKBgQCyQ80uaA1DKxjwuGgetuHiXoZxpQ/Twyj/9a5zeMCfZlAvreCs
+      8MhCm17OuQkYkiIpoEwn3DUDXAO03kUg9Hg5pd5ObnTZdWoBKWR1t/U2R4xU6v2w
+      KLn9KyK/cA/79wzaiMZS+H+j+pt9ZjgdpKOcn3XK8bOURIVEsSNu8+yZ/wIDAQAB
+      AoGAULdvj9wwaSH6DIFLL+EaHYA0ev/Ez1tWVLN/NqzN9z8B/tzJ1zS9UJ9+Sbcx
+      3azJiDSbVw8X9/nxebOM9JONXbcCMeJX5MqsBzrR89vTHo9ir91u7LDVBEo+bsrS
+      ufTQdT1etUOggwWssU4JLoQB7L7QoFhBTndAc6AwmB1t6pECQQDHBe01qgTQwF4H
+      zjnpBKPUlYX5Ma+6VDvSG/yFdJeA58TrF3oBBnET9ZTmy4mDLQaO88wsAx0kduaB
+      H8tuoCUvAkEA5UyIpG2djRCyCRkENJLn9qpCaSOwaO43D189KqGzW9nHihMNczha
+      akAIa3ULp8AoqPFKOFk+v2jGYwPHSatEMQJBAK9vr/wAFSKWj8y9oxqetnPsIh7a
+      B5duLRU3Ck/xyKMeqty44xkIPqFjd5BClsME66UTj0S0sfm0vdfQ2Rh5Ho0CQAaz
+      PM7pMRBdK4aeh4Ptwv9vLC+cTlxSkaNOWiAzx2TosS70rZDvVZ0DL/vL2MJXGBkP
+      q+aHnRDEw/9CrgEWExECQQCT7jFthoPs29A981euHfZ+bXMFEI48PFgw13cmyWnM
+      HijF+4E/XtD11WJkIuDCmHal/oRtcbIO/cCk15xbWZkD
+      -----END RSA PUBLIC KEY-----
+    third_key.key: |-
+      -----BEGIN RSA PUBLIC KEY-----
+      MIICXQIBAAKBgQCyQ80uaA1DKxjwuGgetuHiXoZxpQ/Twyj/9a5zeMCfZlAvreCs
+      8MhCm17OuQkYkiIpoEwn3DUDXAO03kUg9Hg5pd5ObnTZdWoBKWR1t/U2R4xU6v2w
+      KLn9KyK/cA/79wzaiMZS+H+j+pt9ZjgdpKOcn3XK8bOURIVEsSNu8+yZ/wIDAQAB
+      AoGAULdvj9wwaSH6DIFLL+EaHYA0ev/Ez1tWVLN/NqzN9z8B/tzJ1zS9UJ9+Sbcx
+      3azJiDSbVw8X9/nxebOM9JONXbcCMeJX5MqsBzrR89vTHo9ir91u7LDVBEo+bsrS
+      ufTQdT1etUOggwWssU4JLoQB7L7QoFhBTndAc6AwmB1t6pECQQDHBe01qgTQwF4H
+      zjnpBKPUlYX5Ma+6VDvSG/yFdJeA58TrF3oBBnET9ZTmy4mDLQaO88wsAx0kduaB
+      H8tuoCUvAkEA5UyIpG2djRCyCRkENJLn9qpCaSOwaO43D189KqGzW9nHihMNczha
+      akAIa3ULp8AoqPFKOFk+v2jGYwPHSatEMQJBAK9vr/wAFSKWj8y9oxqetnPsIh7a
+      B5duLRU3Ck/xyKMeqty44xkIPqFjd5BClsME66UTj0S0sfm0vdfQ2Rh5Ho0CQAaz
+      PM7pMRBdK4aeh4Ptwv9vLC+cTlxSkaNOWiAzx2TosS70rZDvVZ0DL/vL2MJXGBkP
+      q+aHnRDEw/9CrgEWExECQQCT7jFthoPs29A981euHfZ+bXMFEI48PFgw13cmyWnM
+      HijF+4E/XtD11WJkIuDCmHal/oRtcbIO/cCk15xbWZkD
+      -----END RSA PUBLIC KEY-----
+
+  config:
+    db_host: '$release_name-centralledger-mysql'
+    db_port: '3306'
+    db_user: 'central_ledger'
+    db_password: 'oyMxgZChuu'
+    db_database: 'central_ledger'
+    settlementsEndpoint: 'centralsettlement/v1'
+    centralLedgerEndpoint: 'centralledger-service'
+    settlementManagementEndpoint: 'settlement'
+    settlementManagementPort: '5000'
+    isOauthEnabled: false
+    oauthServer: 'https://localhost'
+    oauthPort: 9443
+    oauthLoginPath: '/oauth2/token'
+    oauthTokenValidationPath: '/oauth2/introspect'
+    oauthUserInfo: '/oauth2/userinfo'
+    oauthTokenRevoke: '/oauth2/revoke'
+    oauthClientKey: 'testkey'
+    oauthClientSecret: 'testsecret'
+    BypassAuth: 'true'
+    InsecureCookie: 'false'
+    is_populate:
+      name: ispopulate
+      http:
+        endpoint: 'something'
+        timeout: 30000
+      authentication:
+        type: 'basic'
+        credentials:
+          username: 'admin'
+          password: 'admin'
+    jasperUser: 'user'
+    jasperPassword: 'password'
+    report1: "something"
+    report2: "something"
+
+  frontend:
+    service:
+      port: 80
+    image:
+      repository: mojaloop/finance-portal-ui
+      tag: v8.8.0
+      pullPolicy: Always
+      port: 80
+    ingress:
+      enabled: true
+      externalPath: /(.*)
+      hosts: 
+        api: finance-portal-frontend.local
+      annotations: {}
+        # kubernetes.io/ingress.class: nginx
+        # nginx.ingress.kubernetes.io/rewrite-target: /$1
+        
+  backend:
+    service:
+      port: 3000
+    image:
+      repository: mojaloop/finance-portal-backend-service
+      tag: v8.8.0
+      pullPolicy: Always
+      port: 3000
+    init:
+      enabled: false
+      image:
+        repository: mojaloop/finance-portal-backend-service
+        tag: v8.8.0
+        pullPolicy: Always
+    env: 'dev'
+    ingress:
+      enabled: true
+      externalPath: /admin-portal-backend/(.*)
+      hosts: 
+        api: finance-portal-backend.local
+      annotations: {}
+        # kubernetes.io/ingress.class: nginx
+        # nginx.ingress.kubernetes.io/rewrite-target: /$1
+
 finance-portal-settlement-management:
   enabled: true
+  # This is a YAML-formatted file.
+  # Declare variables to be passed into your templates.
+  # Default values shared by all containers
+  config:
+    db_protocol: 'mysql'
+    db_host: '$release_name-centralledger-mysql'
+    db_port: '3306'
+    db_user: 'central_ledger'
+    db_password: 'oyMxgZChuu'
+    db_database: 'central_ledger'
+
+  service:
+    type: ClusterIP
+
+  imageCredentials:
+    name: pull-secrets
+
+  # Default values for operator-settlement
+  operatorSettlement:
+    image:
+      repository: mojaloop/operator-settlement
+      tag: v8.8.0
+      pullPolicy: Always
+
+    service:
+      port: 80
+
+    init:
+      enabled: true
+      image:
+        repository: mojaloop/operator-settlement
+        tag: v8.8.0
+        pullPolicy: Always
+      command: mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database < /opt/operator-settlement/init.sql
+
+    ingress:
+      enabled: true
+      externalPath: /
+      hosts:
+        api: operator-settlement.local
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: '/'
+        # kubernetes.io/ingress.class: nginx
+        # kubernetes.io/tls-acme: "true"
+      tls:
+
+  # Default values for settlement-management
+  settlementManagement:
+    image:
+      repository: mojaloop/settlement-management
+      tag: v8.8.0
+      pullPolicy: Always
+
+    service:
+      port: 5000
+
+    init:
+      enabled: true
+      image:
+        repository: mojaloop/settlement-management
+        tag: latest
+        pullPolicy: Always
+      command: mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database < /opt/settlement-management/init.sql
+
+    config:
+      CENTRAL_LEDGER_SERVICE_NAME: 'centralledger-service'
+      CENTRAL_LEDGER_SERVICE_ADMIN_PORT: '3001'
+      SETTLEMENTS_SERVICE_NAME: 'centralsettlement'
+      SETTLEMENTS_SERVICE_PORT: '80'
+      MIN_WINDOW_AGE_MS: '5000'
+      OPERATOR_SETTLEMENTS_SERVICE_NAME: 'settlement'
+      OPERATOR_SETTLEMENTS_SERVICE_PORT: '80'
+
+    ingress:
+      enabled: true
+      externalPath: /
+      hosts:
+        api: settlement-management.local
+      annotations:  
+        nginx.ingress.kubernetes.io/rewrite-target: '/'
+        # kubernetes.io/ingress.class: nginx
+        # kubernetes.io/tls-acme: "true"
+      tls:
+      # Secrets must be manually created in the namespace.
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local
 
 mojaloop-bulk:
   enabled: false

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3228,7 +3228,7 @@ transaction-requests-service:
   replicaCount: 1
   image:
     repository: mojaloop/transaction-requests-service
-    tag: v8.7.0
+    tag: v8.8.0
     pullPolicy: Always
 
   readinessProbe:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3228,7 +3228,7 @@ transaction-requests-service:
   replicaCount: 1
   image:
     repository: mojaloop/transaction-requests-service
-    tag: v8.7.1
+    tag: v8.7.0
     pullPolicy: Always
 
   readinessProbe:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3228,7 +3228,7 @@ transaction-requests-service:
   replicaCount: 1
   image:
     repository: mojaloop/transaction-requests-service
-    tag: v8.7.0
+    tag: v8.8.1
     pullPolicy: Always
 
   readinessProbe:
@@ -3323,7 +3323,7 @@ simulator:
 
   image:
     repository: mojaloop/simulator
-    tag: v8.8.0
+    tag: v8.8.1
     pullPolicy: Always
 
   imagePullSecrets: []

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3477,6 +3477,7 @@ finance-portal:
     db_user: 'central_ledger'
     db_password: 'oyMxgZChuu'
     db_database: 'central_ledger'
+    fxpEndpoint: '$release_name-fxp-server'
     settlementsEndpoint: '$release_name-centralsettlement/v1'
     centralLedgerEndpoint: '$release_name-centralledger-service'
     settlementManagementEndpoint: '$release_name-finance-portal-settlement-management'
@@ -3532,7 +3533,7 @@ finance-portal:
       port: 3000
     image:
       repository: mojaloop/finance-portal-backend-service
-      tag: v8.8.5
+      tag: v8.8.7
       pullPolicy: Always
       port: 3000
     init:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3423,7 +3423,7 @@ mojaloop-bulk:
       replicaCount: 1
       image:
         repository: mojaloop/bulk-api-adapter
-        tag: v8.7.0-snapshot
+        tag: v8.8.0-snapshot
         command: '["node", "src/api/index.js"]'
         ## Optionally specify an array of imagePullSecrets.
         ## Secrets must be manually created in the namespace.
@@ -3533,7 +3533,7 @@ mojaloop-bulk:
       replicaCount: 1
       image:
         repository: mojaloop/bulk-api-adapter
-        tag: v8.7.0-snapshot
+        tag: v8.8.0-snapshot
         command: '["node", "src/handlers/index.js", "handler", "--notification"]'
         ## Optionally specify an array of imagePullSecrets.
         ## Secrets must be manually created in the namespace.
@@ -3647,7 +3647,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v8.7.1
+            tag: v8.8.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
           service:
@@ -3812,7 +3812,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v8.7.1
+            tag: v8.8.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
           service:
@@ -3977,7 +3977,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v8.7.1
+            tag: v8.8.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
           service:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3479,7 +3479,7 @@ finance-portal:
     db_database: 'central_ledger'
     settlementsEndpoint: 'centralsettlement/v1'
     centralLedgerEndpoint: 'centralledger-service'
-    settlementManagementEndpoint: 'settlement'
+    settlementManagementEndpoint: 'finance-portal-settlement-management'
     settlementManagementPort: '5000'
     isOauthEnabled: false
     oauthServer: 'https://localhost'

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3477,9 +3477,9 @@ finance-portal:
     db_user: 'central_ledger'
     db_password: 'oyMxgZChuu'
     db_database: 'central_ledger'
-    settlementsEndpoint: 'centralsettlement/v1'
-    centralLedgerEndpoint: 'centralledger-service'
-    settlementManagementEndpoint: 'finance-portal-settlement-management'
+    settlementsEndpoint: '$release_name-centralsettlement/v1'
+    centralLedgerEndpoint: '$release_name-centralledger-service'
+    settlementManagementEndpoint: '$release_name-finance-portal-settlement-management'
     settlementManagementPort: '5000'
     isOauthEnabled: false
     oauthServer: 'https://localhost'
@@ -3532,7 +3532,7 @@ finance-portal:
       port: 3000
     image:
       repository: mojaloop/finance-portal-backend-service
-      tag: v8.8.0
+      tag: v8.8.3
       pullPolicy: Always
       port: 3000
     init:
@@ -3609,7 +3609,7 @@ finance-portal-settlement-management:
   settlementManagement:
     image:
       repository: mojaloop/settlement-management
-      tag: v8.8.0
+      tag: v8.8.1
       pullPolicy: Always
 
     service:
@@ -3624,14 +3624,13 @@ finance-portal-settlement-management:
       command: mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database < /opt/settlement-management/init.sql
 
     config:
-      CENTRAL_LEDGER_SERVICE_NAME: 'centralledger-service'
+      CENTRAL_LEDGER_SERVICE_NAME: '$release_name-centralledger-service'
       CENTRAL_LEDGER_SERVICE_ADMIN_PORT: '3001'
-      SETTLEMENTS_SERVICE_NAME: 'centralsettlement'
+      SETTLEMENTS_SERVICE_NAME: '$release_name-centralsettlement'
       SETTLEMENTS_SERVICE_PORT: '80'
       MIN_WINDOW_AGE_MS: '5000'
-      OPERATOR_SETTLEMENTS_SERVICE_NAME: 'settlement'
+      OPERATOR_SETTLEMENTS_SERVICE_NAME: '$release_name-finance-portal-settlement-management'
       OPERATOR_SETTLEMENTS_SERVICE_PORT: '80'
-
     ingress:
       enabled: false
       externalPath: /

--- a/quoting-service/Chart.yaml
+++ b/quoting-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Quoting-Service Helm chart for Kubernetes
 name: quoting-service
-version: 8.7.1
-appVersion: "8.7.0-snapshot"
+version: 8.8.0
+appVersion: "8.8.1-snapshot"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/quoting-service/Chart.yaml
+++ b/quoting-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Quoting-Service Helm chart for Kubernetes
 name: quoting-service
-version: 8.8.0
-appVersion: "8.8.0-snapshot"
+version: 8.7.0
+appVersion: "8.7.0-snapshot"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/quoting-service/Chart.yaml
+++ b/quoting-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Quoting-Service Helm chart for Kubernetes
 name: quoting-service
 version: 8.8.0
-appVersion: "8.8.1-snapshot"
+appVersion: "8.8.0-snapshot"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/quoting-service/Chart.yaml
+++ b/quoting-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Quoting-Service Helm chart for Kubernetes
 name: quoting-service
-version: 8.7.0
-appVersion: "8.7.0-snapshot"
+version: 8.8.0
+appVersion: "9.1.0-snapshot"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/quoting-service/values.yaml
+++ b/quoting-service/values.yaml
@@ -21,7 +21,7 @@ global:
 replicaCount: 1
 image:
   repository: mojaloop/quoting-service
-  tag: v8.7.0-snapshot
+  tag: v8.8.1-snapshot
   pullPolicy: Always
 
 readinessProbe:

--- a/quoting-service/values.yaml
+++ b/quoting-service/values.yaml
@@ -21,7 +21,7 @@ global:
 replicaCount: 1
 image:
   repository: mojaloop/quoting-service
-  tag: v8.8.1-snapshot
+  tag: v8.8.0-snapshot
   pullPolicy: Always
 
 readinessProbe:
@@ -82,7 +82,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v8.7.0
+    tag: v8.7.3
     pullPolicy: Always
     command: '["npm", "run", "start"]'
   service:

--- a/quoting-service/values.yaml
+++ b/quoting-service/values.yaml
@@ -21,7 +21,7 @@ global:
 replicaCount: 1
 image:
   repository: mojaloop/quoting-service
-  tag: v8.8.0-snapshot
+  tag: v8.7.0-snapshot
   pullPolicy: Always
 
 readinessProbe:

--- a/quoting-service/values.yaml
+++ b/quoting-service/values.yaml
@@ -21,7 +21,7 @@ global:
 replicaCount: 1
 image:
   repository: mojaloop/quoting-service
-  tag: v8.7.0-snapshot
+  tag: v9.1.0-snapshot
   pullPolicy: Always
 
 readinessProbe:

--- a/simulator/Chart.yaml
+++ b/simulator/Chart.yaml
@@ -1,4 +1,4 @@
 description: Simulators Helm Chart for Simultors
 name: simulator
-version: 8.7.0
-appVersion: "8.7.1"
+version: 8.8.0
+appVersion: "8.8.0"

--- a/simulator/templates/config.yaml
+++ b/simulator/templates/config.yaml
@@ -13,6 +13,7 @@ data:
   PARTIES_ENDPOINT: {{ (.Values.config.PARTIES_SERVICE_ENDPOINT | replace "$release_name" .Release.Name) }}
   QUOTES_ENDPOINT: {{ (.Values.config.QUOTES_SERVICE_ENDPOINT | replace "$release_name" .Release.Name) }}
   TRANSFERS_ENDPOINT: {{ (.Values.config.TRANSFERS_SERVICE_ENDPOINT | replace "$release_name" .Release.Name) }}
+  TRANSACTION_REQUESTS_ENDPOINT: {{ (.Values.config.TRANSACTION_REQUESTS_SERVICE_ENDPOINT | replace "$release_name" .Release.Name) }}
   TRANSFERS_FULFIL_RESPONSE_DISABLED: {{ .Values.config.TRANSFERS_FULFIL_RESPONSE_DISABLED | quote }}
   TRANSFERS_FULFILMENT: {{ .Values.config.TRANSFERS_FULFILMENT | quote }}
   TRANSFERS_CONDITION: {{ .Values.config.TRANSFERS_CONDITION | quote }}

--- a/simulator/templates/deployment.yaml
+++ b/simulator/templates/deployment.yaml
@@ -73,6 +73,11 @@ spec:
                 configMapKeyRef:
                   name: {{ template "simulators.fullname" . }}-config
                   key: TRANSFERS_ENDPOINT
+            - name: TRANSACTION_REQUESTS_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "simulators.fullname" . }}-config
+                  key: TRANSACTION_REQUESTS_ENDPOINT
             - name: TRANSFERS_FULFIL_RESPONSE_DISABLED
               valueFrom:
                 configMapKeyRef:

--- a/simulator/values.yaml
+++ b/simulator/values.yaml
@@ -27,6 +27,7 @@ config:
   PARTIES_SERVICE_ENDPOINT: 'http://localhost:8088'
   QUOTES_SERVICE_ENDPOINT: 'http://localhost:8088'
   TRANSFERS_SERVICE_ENDPOINT: 'http://localhost:8088'
+  TRANSACTION_REQUESTS_SERVICE_ENDPOINT: 'http://localhost:8088'
   ## Disable the fulfil response callback
   TRANSFERS_FULFIL_RESPONSE_DISABLED: false
   ## Set the fulfil response response information

--- a/simulator/values.yaml
+++ b/simulator/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: mojaloop/simulator
-  tag: v8.7.1
+  tag: v8.8.0
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/transaction-requests-service/Chart.yaml
+++ b/transaction-requests-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Transaction-Requests-Service Helm chart for Kubernetes
 name: transaction-requests-service
-version: 8.8.0
-appVersion: "8.8.0"
+version: 8.7.1
+appVersion: "8.7.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/transaction-requests-service/Chart.yaml
+++ b/transaction-requests-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Transaction-Requests-Service Helm chart for Kubernetes
 name: transaction-requests-service
-version: 8.7.1
-appVersion: "8.7.1"
+version: 8.8.0
+appVersion: "8.8.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/transaction-requests-service/Chart.yaml
+++ b/transaction-requests-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Transaction-Requests-Service Helm chart for Kubernetes
 name: transaction-requests-service
 version: 8.7.1
-appVersion: "8.7.1"
+appVersion: "8.7.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/transaction-requests-service/Chart.yaml
+++ b/transaction-requests-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Transaction-Requests-Service Helm chart for Kubernetes
 name: transaction-requests-service
-version: 8.7.1
-appVersion: "8.7.0"
+version: 8.8.0
+appVersion: "8.8.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/transaction-requests-service/configs/default.json
+++ b/transaction-requests-service/configs/default.json
@@ -5,7 +5,7 @@
     "expiresIn": 180000,
     "generateTimeout": 30000
   },
-  "SWITCH_ENDPOINT": "http://{{ .Values.config.central_services_host }}:{{ .Values.config.central_services_port }}",
+  "SWITCH_ENDPOINT": "http://{{ (default .Values.config.central_services_host $centralServicesHost) }}:{{ .Values.config.central_services_port }}",
   "INSTRUMENTATION": {
   "METRICS": {
     "DISABLED": {{ not .Values.metrics.enabled }},

--- a/transaction-requests-service/configs/default.json
+++ b/transaction-requests-service/configs/default.json
@@ -5,7 +5,7 @@
     "expiresIn": 180000,
     "generateTimeout": 30000
   },
-  "SWITCH_ENDPOINT": "http://{{ $centralServicesHost }}:{{ .Values.config.central_services_port }}",
+  "SWITCH_ENDPOINT": "http://{{ .Values.config.central_services_host }}:{{ .Values.config.central_services_port }}",
   "INSTRUMENTATION": {
   "METRICS": {
     "DISABLED": {{ not .Values.metrics.enabled }},

--- a/transaction-requests-service/templates/deployment.yaml
+++ b/transaction-requests-service/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
               value: {{ .Values.config.log_transport }}
           volumeMounts:
             - name: {{ template "transactionrequestsservice.fullname" . }}-config-volume
-              mountPath: /opt/transaction-request-service/config
+              mountPath: /opt/transaction-requests-service/config
       volumes:
         - name: {{ template "transactionrequestsservice.fullname" . }}-config-volume
           configMap:

--- a/transaction-requests-service/values.yaml
+++ b/transaction-requests-service/values.yaml
@@ -21,7 +21,7 @@ global:
 replicaCount: 1
 image:
   repository: mojaloop/transaction-requests-service
-  tag: v8.8.0
+  tag: v8.7.1
   pullPolicy: Always
 
 readinessProbe:

--- a/transaction-requests-service/values.yaml
+++ b/transaction-requests-service/values.yaml
@@ -21,7 +21,7 @@ global:
 replicaCount: 1
 image:
   repository: mojaloop/transaction-requests-service
-  tag: v8.7.1
+  tag: v8.7.0
   pullPolicy: Always
 
 readinessProbe:

--- a/transaction-requests-service/values.yaml
+++ b/transaction-requests-service/values.yaml
@@ -21,7 +21,7 @@ global:
 replicaCount: 1
 image:
   repository: mojaloop/transaction-requests-service
-  tag: v8.7.0
+  tag: v8.8.0
   pullPolicy: Always
 
 readinessProbe:

--- a/transaction-requests-service/values.yaml
+++ b/transaction-requests-service/values.yaml
@@ -21,7 +21,7 @@ global:
 replicaCount: 1
 image:
   repository: mojaloop/transaction-requests-service
-  tag: v8.7.0
+  tag: v8.8.1
   pullPolicy: Always
 
 readinessProbe:


### PR DESCRIPTION
Upgraded Helm charts to support the following releases:
- ml-api-adapter: v8.8.2
- central-ledger: v8.8.2
   - Added new config var `cache_max_byte_size`
- account-lookup-service: v9.2.0
- quoting-service: v9.1.0-snapshot
- central-settlement: v8.8.0
- central-event-processor: v8.8.0
- bulk-api-adapter: v8.8.0-snapshot
- email-notifier: v8.8.0
- simulator: v9.1.1
- als-oracle-pathfinder: v8.7.1 (no change)
- transaction-requests-service: v9.1.0
- finance-portal: v8.8.8