### PR TITLE
update release-name in values and bump up versions

### DIFF
--- a/finance-portal-settlement-management/templates/configmap.yaml
+++ b/finance-portal-settlement-management/templates/configmap.yaml
@@ -1,3 +1,8 @@
+{{- $dbHost := (.Values.config.db_host | replace "$release_name" .Release.Name) }}
+{{- $centralLedger := (.Values.settlementManagement.config.CENTRAL_LEDGER_SERVICE_NAME | replace "$release_name" .Release.Name) }}
+{{- $settlements := (.Values.settlementManagement.config.SETTLEMENTS_SERVICE_NAME | replace "$release_name" .Release.Name) }}
+{{- $operatorSettlement := (.Values.settlementManagement.config.OPERATOR_SETTLEMENTS_SERVICE_NAME | replace "$release_name" .Release.Name) }}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,7 +14,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 data:
-  ADMIN_ENDPOINT: {{ (printf "%s%s-%s:%s" "http://" .Release.Name .Values.settlementManagement.config.CENTRAL_LEDGER_SERVICE_NAME .Values.settlementManagement.config.CENTRAL_LEDGER_SERVICE_ADMIN_PORT) | quote }}
+  ADMIN_ENDPOINT: {{ (printf "%s%s:%s" "http://"  $centralLedger .Values.settlementManagement.config.CENTRAL_LEDGER_SERVICE_ADMIN_PORT) | quote }}
   MIN_WINDOW_AGE_MS: {{ (printf "%s" .Values.settlementManagement.config.MIN_WINDOW_AGE_MS) | quote }}
-  SETTLEMENT_ENDPOINT: {{ (printf "%s%s-%s:%s/%s" "http://" .Release.Name .Values.settlementManagement.config.SETTLEMENTS_SERVICE_NAME .Values.settlementManagement.config.SETTLEMENTS_SERVICE_PORT "v1") | quote }}
-  OPERATOR_SETTLEMENT_ENDPOINT: {{ (printf "%s%s-%s:%s" "http://" .Release.Name .Values.settlementManagement.config.OPERATOR_SETTLEMENTS_SERVICE_NAME .Values.settlementManagement.config.OPERATOR_SETTLEMENTS_SERVICE_PORT) | quote }}
+  SETTLEMENT_ENDPOINT: {{ (printf "%s%s:%s/%s" "http://" $settlements .Values.settlementManagement.config.SETTLEMENTS_SERVICE_PORT "v1") | quote }}
+  OPERATOR_SETTLEMENT_ENDPOINT: {{ (printf "%s%s:%s" "http://" $operatorSettlement .Values.settlementManagement.config.OPERATOR_SETTLEMENTS_SERVICE_PORT) | quote }}

--- a/finance-portal-settlement-management/values.yaml
+++ b/finance-portal-settlement-management/values.yaml
@@ -48,7 +48,7 @@ operatorSettlement:
 settlementManagement:
   image:
     repository: mojaloop/settlement-management
-    tag: v8.8.0
+    tag: v8.8.1
     pullPolicy: Always
 
   service:
@@ -63,12 +63,12 @@ settlementManagement:
     command: mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database < /opt/settlement-management/init.sql
 
   config:
-    CENTRAL_LEDGER_SERVICE_NAME: 'centralledger-service'
+    CENTRAL_LEDGER_SERVICE_NAME: '$release_name-centralledger-service'
     CENTRAL_LEDGER_SERVICE_ADMIN_PORT: '3001'
-    SETTLEMENTS_SERVICE_NAME: 'centralsettlement'
+    SETTLEMENTS_SERVICE_NAME: '$release_name-centralsettlement'
     SETTLEMENTS_SERVICE_PORT: '80'
     MIN_WINDOW_AGE_MS: '5000'
-    OPERATOR_SETTLEMENTS_SERVICE_NAME: 'settlement'
+    OPERATOR_SETTLEMENTS_SERVICE_NAME: '$release_name-finance-portal-settlement-management'
     OPERATOR_SETTLEMENTS_SERVICE_PORT: '80'
 
   ingress:

--- a/finance-portal/templates/configmap.yaml
+++ b/finance-portal/templates/configmap.yaml
@@ -1,3 +1,7 @@
+{{- $settlementsEndpoint := ( .Values.config.settlementsEndpoint | replace "$release_name" .Release.Name ) -}}
+{{- $centralLedgerEndpoint := ( .Values.config.centralLedgerEndpoint | replace "$release_name" .Release.Name) -}}
+{{- $settlementManagementEndpoint := ( .Values.config.settlementManagementEndpoint | replace "$release_name" .Release.Name) -}}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,11 +13,11 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 data:
-  SETTLEMENTS_ENDPOINT: {{ (printf "http://%s-%s" .Release.Name .Values.config.settlementsEndpoint) | quote }}
-  CENTRAL_LEDGER_ENDPOINT: {{ (printf "http://%s-%s" .Release.Name .Values.config.centralLedgerEndpoint) | quote }}
+  SETTLEMENTS_ENDPOINT: {{ (printf "http://%s" $settlementsEndpoint) | quote }}
+  CENTRAL_LEDGER_ENDPOINT: {{ (printf "http://%s" $centralLedgerEndpoint) | quote }}
   HUB_REPORT_URL_312: {{ (printf "http://%s-%s" .Release.Name .Values.config.report1) | quote }}
   HUB_REPORT_URL_644: {{ (printf "http://%s-%s" .Release.Name .Values.config.report2) | quote }}
-  SETTLEMENT_MANAGEMENT_ENDPOINT: {{ (printf "%s%s-%s:%s" "http://" .Release.Name .Values.config.settlementManagementEndpoint .Values.config.settlementManagementPort) | quote }}
+  SETTLEMENT_MANAGEMENT_ENDPOINT: {{ (printf "%s%s:%s" "http://" $settlementManagementEndpoint .Values.config.settlementManagementPort) | quote }}
   LISTEN_PORT: "3000"
   NODE_ENV: "production"
   BYPASS_AUTH:  {{ .Values.config.BypassAuth | quote }}

--- a/finance-portal/values.yaml
+++ b/finance-portal/values.yaml
@@ -66,9 +66,9 @@ config:
   db_user: 'central_ledger'
   db_password: 'oyMxgZChuu'
   db_database: 'central_ledger'
-  settlementsEndpoint: 'centralsettlement/v1'
-  centralLedgerEndpoint: 'centralledger-service'
-  settlementManagementEndpoint: 'settlement'
+  settlementsEndpoint: '$release_name-centralsettlement/v1'
+  centralLedgerEndpoint: '$release_name-centralledger-service'
+  settlementManagementEndpoint: '$release_name-finance-portal-settlement-management'
   settlementManagementPort: '5000'
   isOauthEnabled: false
   oauthServer: 'https://localhost'
@@ -118,7 +118,7 @@ backend:
     port: 3000
   image:
     repository: mojaloop/finance-portal-backend-service
-    tag: v8.8.0
+    tag: v8.8.3
     pullPolicy: Always
     port: 3000
   init:


### PR DESCRIPTION
This changes updates the finance portal helm charts so it follows the same `$release_name` convention. It also updates the version for the finance portal that fixes some SQL queries and containers versions.