### PR TITLE
Exposing the portal backend CORS reflect origin option to make local testing easier

### DIFF
--- a/finance-portal/Chart.yaml
+++ b/finance-portal/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: Finance portal service
 name: finance-portal
-version: 8.8.0
-appVersion: "8.8.0"
+version: 8.8.1
+appVersion: "8.8.1"

--- a/finance-portal/Chart.yaml
+++ b/finance-portal/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: Finance portal service
 name: finance-portal
-version: 8.8.1
-appVersion: "8.8.1"
+version: 9.1.0
+appVersion: "9.1.0"

--- a/finance-portal/templates/configmap.yaml
+++ b/finance-portal/templates/configmap.yaml
@@ -21,6 +21,7 @@ data:
   LISTEN_PORT: "3000"
   NODE_ENV: "production"
   BYPASS_AUTH:  {{ .Values.config.BypassAuth | quote }}
+  CORS_ACCESS_CONTROL_REFLECT_ORIGIN: {{ .Values.config.corsReflectOrigin | quote }}
   INSECURE_COOKIE: {{ .Values.config.InsecureCookie | quote }}
   AUTH_SERVER: {{ .Values.config.oauthServer | quote }}
   AUTH_SERVER_PORT: {{ .Values.config.oauthPort | quote }}

--- a/finance-portal/values.yaml
+++ b/finance-portal/values.yaml
@@ -80,7 +80,11 @@ config:
   oauthTokenRevoke: '/oauth2/revoke'
   oauthClientKey: 'testkey'
   oauthClientSecret: 'testsecret'
+  # Do not set to true in production
+  corsReflectOrigin: 'false'
+  # Do not set to true in production
   BypassAuth: 'true'
+  # Do not set to true in production
   InsecureCookie: 'false'
   is_populate:
     name: ispopulate

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
-version: 8.8.0
-appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v9.2.0; quoting-service: v9.1.0-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.8.0-snapshot; email-notifier: v8.8.0; simulator: v9.1.1; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v9.1.0; finance-portal: v8.8.8; finance-portal-settlement-management: v8.8.1"
+version: 9.1.0
+appVersion: "ml-api-adapter: v8.8.2; central-ledger: v8.8.2; account-lookup-service: v9.2.0; quoting-service: v9.1.0-snapshot; central-settlement: v8.8.0; central-event-processor: v8.8.0; bulk-api-adapter: v8.8.0-snapshot; email-notifier: v8.8.0; simulator: v9.1.1; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v9.1.0; finance-portal: v9.1.0; finance-portal-settlement-management: v8.8.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -33,7 +33,7 @@ dependencies:
   repository: "file://../transaction-requests-service"
   condition: transaction-requests-service.enabled
 - name: finance-portal
-  version: 8.8.1
+  version: 9.1.0
   repository: "file://../finance-portal"
   condtion: finance-portal.enabled
 - name: finance-portal-settlement-management

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -33,7 +33,7 @@ dependencies:
   repository: "file://../transaction-requests-service"
   condition: transaction-requests-service.enabled
 - name: finance-portal
-  version: 8.8.0
+  version: 8.8.1
   repository: "file://../finance-portal"
   condtion: finance-portal.enabled
 - name: finance-portal-settlement-management

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3492,7 +3492,11 @@ finance-portal:
     oauthTokenRevoke: '/oauth2/revoke'
     oauthClientKey: 'testkey'
     oauthClientSecret: 'testsecret'
+    # Do not set to true in production
+    corsReflectOrigin: 'false'
+    # Do not set to true in production
     BypassAuth: 'true'
+    # Do not set to true in production
     InsecureCookie: 'false'
     is_populate:
       name: ispopulate

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2533,7 +2533,7 @@ account-lookup-service:
       end_point_cache:
         expiresIn: 180000
         generateTimeout: 30000
-      
+
       error_handling:
           include_cause_extension: false
           truncate_extensions: true
@@ -2559,7 +2559,7 @@ account-lookup-service:
       db_debug: false
       display_routes: true
       run_migrations: false
-      
+
       # Log config
       log_level: 'info'
       log_transport: 'file'
@@ -3131,16 +3131,16 @@ quoting-service:
     simple_routing_mode_enabled: true
     log_level: 'info'
     log_transport: 'file'
-    
+
     # A comma-separated list of events that should return immediately instead of waiting for the event promises to resolve
     # Any combination of: `log,audit,trace`
     event_async_override: ''
-    
+
     ## Kafka Configuration (used for sidecar)
     # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
     kafka_host: '$release_name-kafka'
     kafka_port: 9092
-    
+
     error_handling:
       include_cause_extension: false
       truncate_extensions: true
@@ -3524,7 +3524,7 @@ finance-portal:
     ingress:
       enabled: true
       externalPath: /(.*)
-      hosts: 
+      hosts:
         api: finance-portal.local
       annotations:
         kubernetes.io/ingress.class: nginx
@@ -3551,7 +3551,7 @@ finance-portal:
     ingress:
       enabled: false
       externalPath: /admin-portal-backend/(.*)
-      hosts: 
+      hosts:
         api: finance-portal.local
       annotations:
         kubernetes.io/ingress.class: nginx
@@ -3642,7 +3642,7 @@ finance-portal-settlement-management:
       externalPath: /
       hosts:
         api: settlement-management.local
-      annotations:  
+      annotations:
         kubernetes.io/ingress.class: nginx
         ## NGINX Ingres Control < v0.22-
         nginx.ingress.kubernetes.io/rewrite-target: /


### PR DESCRIPTION
Exposing this already existing-config:
https://github.com/mojaloop/finance-portal-backend-service/blob/master/src/config/config.js#L38
to the chart. That controls whether the service responds with an `Access-Control-Allow-Origin` header that mirrors the `Origin` header in the request. When it does so, it means a UI served to the browser from any hostname can make requests to the backend- not just one served from the same hostname as the backend. It's standard browser security functionality- nothing implementation-specific.

The specific use-case I'm trying to enable in this case is hosting a frontend on a developer machine and a backend in a cluster somewhere. I.e. frontend on localhost, backend on some other hostname.