### PR TITLE
Detecting merge conflicts in helm chart publish script

### DIFF
--- a/.circleci/publish_helm_charts.sh
+++ b/.circleci/publish_helm_charts.sh
@@ -15,6 +15,9 @@ git checkout -b $GITHUB_TARGET_BRANCH $GITHUB_PROJECT_USERNAME/$GITHUB_TARGET_BR
 echo "Merging tagged release code from $GITHUB_TAG..."
 git merge --no-commit $GITHUB_TAG &> git.log
 
+echo "Checking for merge conflicts"
+[[ $(git ls-files -u | wc -l) == 0 ]] || { echo "Merge conflict detected" | tee git.log && exit 1; }
+
 echo "Package helm charts..."
 sh package.sh
 


### PR DESCRIPTION
Motivated by:
https://github.com/casablanca-project/helm/blob/gh-pages/mojaloop/Chart.yaml

It's possible to have a merge conflict arise but the modified script will simply commit the merge conflict to the repo. This change will cause said script to fail if there is a merge conflict.