### PR TITLE
 Bump to finance-portal-backend v9.1.0

### DIFF
--- a/finance-portal/templates/configmap.yaml
+++ b/finance-portal/templates/configmap.yaml
@@ -1,4 +1,6 @@
-{{- $settlementsEndpoint := ( .Values.config.settlementsEndpoint | replace "$release_name" .Release.Name ) -}}
+{{- $fxpEndpoint := ( .Values.config.fxpEndpoint | replace "$release_name" .Release.Name ) -}}
+{{- $externalSettlementsEndpoint := ( .Values.config.externalSettlementsEndpoint | replace "$release_name" .Release.Name ) -}}
+{{- $centralSettlementsEndpoint := ( .Values.config.centralSettlementsEndpoint | replace "$release_name" .Release.Name ) -}}
 {{- $centralLedgerEndpoint := ( .Values.config.centralLedgerEndpoint | replace "$release_name" .Release.Name) -}}
 {{- $settlementManagementEndpoint := ( .Values.config.settlementManagementEndpoint | replace "$release_name" .Release.Name) -}}
 
@@ -13,7 +15,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 data:
-  SETTLEMENTS_ENDPOINT: {{ (printf "http://%s" $settlementsEndpoint) | quote }}
+  FXP_ENDPOINT: {{ (printf "http://%s" $settlementsEndpoint) | quote }}
+  EXTERNAL_SETTLEMENTS_ENDPOINT: {{ (printf "http://%s" $settlementsEndpoint) | quote }}
+  CENTRAL_SETTLEMENTS_ENDPOINT: {{ (printf "http://%s" $settlementsEndpoint) | quote }}
   CENTRAL_LEDGER_ENDPOINT: {{ (printf "http://%s" $centralLedgerEndpoint) | quote }}
   HUB_REPORT_URL_312: {{ (printf "http://%s-%s" .Release.Name .Values.config.report1) | quote }}
   HUB_REPORT_URL_644: {{ (printf "http://%s-%s" .Release.Name .Values.config.report2) | quote }}

--- a/finance-portal/templates/configmap.yaml
+++ b/finance-portal/templates/configmap.yaml
@@ -15,9 +15,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 data:
-  FXP_ENDPOINT: {{ (printf "http://%s" $settlementsEndpoint) | quote }}
-  EXTERNAL_SETTLEMENTS_ENDPOINT: {{ (printf "http://%s" $settlementsEndpoint) | quote }}
-  CENTRAL_SETTLEMENTS_ENDPOINT: {{ (printf "http://%s" $settlementsEndpoint) | quote }}
+  FXP_ENDPOINT: {{ (printf "http://%s" $fxpEndpoint) | quote }}
+  EXTERNAL_SETTLEMENTS_ENDPOINT: {{ (printf "http://%s" $externalSettlementsEndpoint) | quote }}
+  CENTRAL_SETTLEMENTS_ENDPOINT: {{ (printf "http://%s" $centralSettlementsEndpoint) | quote }}
   CENTRAL_LEDGER_ENDPOINT: {{ (printf "http://%s" $centralLedgerEndpoint) | quote }}
   HUB_REPORT_URL_312: {{ (printf "http://%s-%s" .Release.Name .Values.config.report1) | quote }}
   HUB_REPORT_URL_644: {{ (printf "http://%s-%s" .Release.Name .Values.config.report2) | quote }}

--- a/finance-portal/values.yaml
+++ b/finance-portal/values.yaml
@@ -67,7 +67,8 @@ config:
   db_password: 'oyMxgZChuu'
   db_database: 'central_ledger'
   fxpEndpoint: '$release_name-fxp-server'
-  settlementsEndpoint: '$release_name-centralsettlement/v1'
+  externalSettlementsEndpoint: '$release_name-external-settlement-server'
+  centralSettlementsEndpoint: '$release_name-centralsettlement/v1'
   centralLedgerEndpoint: '$release_name-centralledger-service'
   settlementManagementEndpoint: '$release_name-finance-portal-settlement-management'
   settlementManagementPort: '5000'
@@ -126,14 +127,14 @@ backend:
     port: 3000
   image:
     repository: mojaloop/finance-portal-backend-service
-    tag: v8.8.8
+    tag: v9.1.0
     pullPolicy: Always
     port: 3000
   init:
     enabled: true
     image:
       repository: mojaloop/finance-portal-backend-service
-      tag: v8.8.8
+      tag: v9.1.0
       pullPolicy: Always
   env: 'dev'
   ingress:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3479,7 +3479,8 @@ finance-portal:
     db_password: 'oyMxgZChuu'
     db_database: 'central_ledger'
     fxpEndpoint: '$release_name-fxp-server'
-    settlementsEndpoint: '$release_name-centralsettlement/v1'
+    externalSettlementsEndpoint: '$release_name-external-settlement-server'
+    centralSettlementsEndpoint: '$release_name-centralsettlement/v1'
     centralLedgerEndpoint: '$release_name-centralledger-service'
     settlementManagementEndpoint: '$release_name-finance-portal-settlement-management'
     settlementManagementPort: '5000'
@@ -3538,14 +3539,14 @@ finance-portal:
       port: 3000
     image:
       repository: mojaloop/finance-portal-backend-service
-      tag: v8.8.8
+      tag: v9.1.0
       pullPolicy: Always
       port: 3000
     init:
       enabled: false
       image:
         repository: mojaloop/finance-portal-backend-service
-        tag: v8.8.8
+        tag: v9.1.0
         pullPolicy: Always
     env: 'dev'
     ingress:


### PR DESCRIPTION
Covers the changes in finance-portal-backend-service that were applied through these PRs mojaloop/finance-portal-backend-service#27
mojaloop/finance-portal-backend-service#28
and have been released as v9.1.0
https://github.com/mojaloop/finance-portal-backend-service/releases/tag/v9.1.0