### PR TITLE
making fluentd optional to support multi cluster deploys

### DIFF
--- a/monitoring/efk/requirements.yaml
+++ b/monitoring/efk/requirements.yaml
@@ -3,6 +3,7 @@ dependencies:
 - name: fluentd-elasticsearch
   version: 4.3.2
   repository: "https://kiwigrid.github.io"
+  condition: fluentd-elasticsearch.enabled
 - name: elasticsearch
   version: 7.2.1-0
   repository: "https://helm.elastic.co"

--- a/monitoring/efk/values.yaml
+++ b/monitoring/efk/values.yaml
@@ -19,6 +19,7 @@ global:
 
 # Declare variables to be passed into your templates.
 fluentd-elasticsearch:
+  enabled: true
   image:
     repository: quay.io/fluentd_elasticsearch/fluentd
     ## Specify an imagePullPolicy (Required)


### PR DESCRIPTION
making fluentd optional to support multi cluster deploys, for example to install a different log collector in mojaloop cluster and elasticsearch and kibana in a monitoring cluster