### PR TITLE
Fixes helm3 deployment issue

### DIFF
--- a/finance-portal-settlement-management/templates/deployment.yaml
+++ b/finance-portal-settlement-management/templates/deployment.yaml
@@ -21,6 +21,18 @@ spec:
         app.kubernetes.io/name: {{ include "finance-portal-settlement-management.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+    {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}
       initContainers:
         {{- if .Values.operatorSettlement.init.enabled }}
         - name: operator-settlement-init
@@ -62,17 +74,6 @@ spec:
         - secretRef:
             name: {{ template "finance-portal-settlement-management.fullname" . }}
         resources: {}
-        ## Pod scheduling preferences.
-        ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-        affinity: {}
-
-        ## Node labels for pod assignment
-        ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-        nodeSelector: {}
-
-        ## Set toleration for scheduler
-        ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-        tolerations: []
       - name: settlement-management
         image: "{{ .Values.settlementManagement.image.repository }}:{{ .Values.settlementManagement.image.tag }}"
         imagePullPolicy: {{ .Values.settlementManagement.image.pullPolicy }}
@@ -93,16 +94,5 @@ spec:
               name: {{ template "finance-portal-settlement-management.fullname" . }}
           - secretRef:
               name: {{ template "finance-portal-settlement-management.fullname" . }}
-        ## Pod scheduling preferences.
-        ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-        affinity: {}
-
-        ## Node labels for pod assignment
-        ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-        nodeSelector: {}
-
-        ## Set toleration for scheduler
-        ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-        tolerations: []
       imagePullSecrets:
         - name: {{ .Values.imageCredentials.name }}

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3732,10 +3732,6 @@ simulator:
     #  memory: 128Mi
 
 
-  tolerations: []
-
-  affinity: {}
-
 mojaloop-simulator:
   enabled: false
   # Default values for mojaloop-simulator.


### PR DESCRIPTION
New Mojaloop installations and upgrades will work with Helm2 and Helm3 with these PR changes:
- Fixed bad affinity, nodeSelector and toleration configs in the deployment template for settlement-management
- Maintenance: Removed duplicate keys (tolerations, affinity) from mojaloop values config
