### PR TITLE
Added some more intuitive ingress defaults

### DIFF
--- a/mojaloop-simulator/templates/ingress.yaml
+++ b/mojaloop-simulator/templates/ingress.yaml
@@ -20,7 +20,8 @@ spec:
   {{- $fullName := printf "%s%s" (include "mojaloop-simulator.prefix" $) $name -}}
   {{- $config := merge $customConfig $.Values.defaults }}
   {{- if $config.ingress.enabled -}}
-    {{- range $host := $config.ingress.hosts }}
+    {{ $hosts := default (list nil) $config.ingress.hosts }}
+    {{- range $host := $hosts }}
       - host: {{ $host }}
         http:
           paths:

--- a/mojaloop-simulator/values.yaml
+++ b/mojaloop-simulator/values.yaml
@@ -149,6 +149,9 @@ sharedJWSPubKeys:
 defaults: &defaults
   # Changes to this object in the parent chart, for example 'mojaloop-simulator.defaults' will be
   # applied to all simulators deployed by this child chart.
+  ingress:
+    enabled: false
+
   config:
     imagePullSecretName: dock-casa-secret
 


### PR DESCRIPTION
With these defaults
- ingress is disabled by default
- if a user enables ingress but doesn't specify a host, they'll automatically receive a wildcard host