### PR TITLE
bugfix GET /transfers JWS issue

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @mdebarros, @elnyry and @rmothilal will be requested for
+# @mdebarros, @elynry-sam-k and @rmothilal will be requested for
 # review when someone opens a pull request.
-*       @mdebarros @elnyry @rmothilal
+*       @mdebarros @elynry-sam-k @rmothilal

--- a/ml-api-adapter/Chart.yaml
+++ b/ml-api-adapter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: ml-api-adapter Helm chart for Kubernetes
 name: ml-api-adapter
 version: 10.3.0
-appVersion: "10.3.0"
+appVersion: "10.3.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/Chart.yaml
+++ b/ml-api-adapter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Helm chart for Kubernetes
 name: ml-api-adapter
-version: 10.2.0
-appVersion: "10.2.0"
+version: 10.3.0
+appVersion: "10.3.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-handler-notification/Chart.yaml
+++ b/ml-api-adapter/chart-handler-notification/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: ml-api-adapter-handler-notification
-version: 10.2.0
-appVersion: "10.2.0"
+version: 10.3.0
+appVersion: "10.3.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-handler-notification/Chart.yaml
+++ b/ml-api-adapter/chart-handler-notification/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: ml-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: ml-api-adapter-handler-notification
 version: 10.3.0
-appVersion: "10.3.0"
+appVersion: "10.3.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v10.2.0
+  tag: v10.3.1
   command: '["node", "src/handlers/index.js", "handler", "--notification"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/chart-service/Chart.yaml
+++ b/ml-api-adapter/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter API component Helm chart for Kubernetes
 name: ml-api-adapter-service
-version: 10.2.0
-appVersion: "10.2.0"
+version: 10.3.0
+appVersion: "10.3.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-service/values.yaml
+++ b/ml-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v10.2.0
+  tag: v10.3.1
   command: '["node", "src/api/index.js"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/requirements.yaml
+++ b/ml-api-adapter/requirements.yaml
@@ -1,11 +1,11 @@
 # requirements.yaml
 dependencies:
 - name: ml-api-adapter-service
-  version: 10.2.0
+  version: 10.3.0
   repository: "file://./chart-service"
   condition: ml-api-adapter-service.enabled
 - name: ml-api-adapter-handler-notification
-  version: 10.2.0
+  version: 10.3.0
   repository: "file://./chart-handler-notification"
   condition: ml-api-adapter-handler-notification.enabled
 ## This is used for testing ml-api-adapter deployments

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -167,7 +167,7 @@ ml-api-adapter-handler-notification:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v10.2.0
+    tag: v10.3.1
     command: '["node", "src/handlers/index.js", "handler", "--notification"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -13,7 +13,7 @@ ml-api-adapter-service:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v10.2.0
+    tag: v10.3.1
     command: '["node", "src/api/index.js"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 10.1.0
-appVersion: "ml-api-adapter: v10.1.1; central-ledger: v10.1.1; account-lookup-service: v10.1.1; quoting-service: v10.2.0; central-settlement: v9.5.0; central-event-processor: v9.5.0; bulk-api-adapter: v9.5.0-snapshot; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v10.1.2; finance-portal-ui: v10.3.0; finance-portal-backend-service: v10.3.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v9.5.0; mojaloop-simulator: v9.4.1; sdk-scheme-adapter: v10.1.0"
+appVersion: "ml-api-adapter: v10.3.1; central-ledger: v10.1.1; account-lookup-service: v10.1.1; quoting-service: v10.2.0; central-settlement: v9.5.0; central-event-processor: v9.5.0; bulk-api-adapter: v9.5.0-snapshot; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v10.1.2; finance-portal-ui: v10.3.0; finance-portal-backend-service: v10.3.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v9.5.0; mojaloop-simulator: v9.4.1; sdk-scheme-adapter: v10.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
   repository: "file://../central"
   condition: central.enabled
 - name: ml-api-adapter
-  version: 10.2.0
+  version: 10.3.0
   repository: "file://../ml-api-adapter"
   condition: ml-api-adapter.enabled
 - name: emailnotifier

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2342,7 +2342,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v10.2.0
+      tag: v10.3.1
       command: '["node", "src/api/index.js"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -2474,7 +2474,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v10.2.0
+      tag: v10.3.1
       command: '["node", "src/handlers/index.js", "handler", "--notification"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Summary:**
Upgraded the version of ml-api-adapter to `v10.3.1`. This includes a bugfix where `GET /transfers` notification was not signed by the switch
