### PR TITLE
Release/v10.4.0 upgraded core services

### DIFF
--- a/account-lookup-service/Chart.yaml
+++ b/account-lookup-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 10.3.0
-appVersion: "account-lookup-service: v10.3.1; als-oracle-pathfinder: v9.4.0"
+version: 10.4.0
+appVersion: "account-lookup-service: v10.4.2; als-oracle-pathfinder: v9.4.0"
 description: Account Lookup Service Helm Chart for Mojaloop
 name: account-lookup-service

--- a/account-lookup-service/chart-admin/Chart.yaml
+++ b/account-lookup-service/chart-admin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 10.3.0
-appVersion: "10.3.1"
+version: 10.4.0
+appVersion: "10.4.2"
 description: A Helm chart for Kubernetes
 name: account-lookup-service-admin

--- a/account-lookup-service/chart-admin/values.yaml
+++ b/account-lookup-service/chart-admin/values.yaml
@@ -7,7 +7,7 @@ containers:
   api:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v10.3.1
+      tag: v10.4.2
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--api"]'
     service:
@@ -18,7 +18,7 @@ containers:
   admin:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v10.3.1
+      tag: v10.4.2
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--admin"]'
     service:

--- a/account-lookup-service/chart-service/Chart.yaml
+++ b/account-lookup-service/chart-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 10.3.0
-appVersion: "10.3.1"
+version: 10.4.0
+appVersion: "10.4.2"
 description: A Helm chart for Kubernetes
 name: account-lookup-service

--- a/account-lookup-service/chart-service/values.yaml
+++ b/account-lookup-service/chart-service/values.yaml
@@ -8,7 +8,7 @@ containers:
   api:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v10.3.1
+      tag: v10.4.2
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--api"]'
     service:
@@ -19,7 +19,7 @@ containers:
   admin:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v10.3.1
+      tag: v10.4.2
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--admin"]'
     service:

--- a/account-lookup-service/requirements.yaml
+++ b/account-lookup-service/requirements.yaml
@@ -1,11 +1,11 @@
 # requirements.yaml
 dependencies:
 - name: account-lookup-service
-  version: 10.3.0
+  version: 10.4.0
   repository: "file://./chart-service"
   condition: account-lookup-service.enabled
 - name: account-lookup-service-admin
-  version: 10.3.0
+  version: 10.4.0
   repository: "file://./chart-admin"
   condition: account-lookup-service-admin.enabled
 - name: als-oracle-pathfinder

--- a/account-lookup-service/values.yaml
+++ b/account-lookup-service/values.yaml
@@ -9,7 +9,7 @@ account-lookup-service:
     api:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v10.3.1
+        tag: v10.4.2
         pullPolicy: Always
         command: '["node", "src/index.js", "server", "--api"]'
       service:
@@ -20,7 +20,7 @@ account-lookup-service:
     admin:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v10.3.1
+        tag: v10.4.2
         pullPolicy: Always
         command: '["node", "src/index.js", "server", "--admin"]'
       service:
@@ -159,7 +159,7 @@ account-lookup-service-admin:
     api:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v10.3.1
+        tag: v10.4.2
         pullPolicy: IfNotPresent
         command: '["node", "src/index.js", "server", "--api"]'
       service:
@@ -170,7 +170,7 @@ account-lookup-service-admin:
     admin:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v10.3.1
+        tag: v10.4.2
         pullPolicy: IfNotPresent
         command: '["node", "src/index.js", "server", "--admin"]'
       service:

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Bulk Transfer Fulfil Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-fulfil
 version: 10.4.0
-appVersion: "10.4.2"
+appVersion: "10.4.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v10.4.2
+      tag: v10.4.5
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
     service:

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Bulk Transfer Prepare Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-prepare
 version: 10.4.0
-appVersion: "10.4.2"
+appVersion: "10.4.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v10.4.2
+      tag: v10.4.5
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
     service:

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Bulk Transfer Processing Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-processing
 version: 10.4.0
-appVersion: "10.4.2"
+appVersion: "10.4.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v10.4.2
+      tag: v10.4.5
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
     service:

--- a/bulk-centralledger/values.yaml
+++ b/bulk-centralledger/values.yaml
@@ -14,7 +14,7 @@ cl-handler-bulk-transfer-prepare:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v10.4.2
+        tag: v10.4.5
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
       service:
@@ -195,7 +195,7 @@ cl-handler-bulk-transfer-fulfil:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v10.4.2
+        tag: v10.4.5
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
       service:
@@ -373,7 +373,7 @@ cl-handler-bulk-transfer-processing:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v10.4.2
+        tag: v10.4.5
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
       service:

--- a/central/Chart.yaml
+++ b/central/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central Helm chart for Kubernetes
 name: central
 version: 10.4.0
-appVersion: "central-ledger: v10.4.2; central-settlement: v9.5.0; central-event-processor: v9.5.0"
+appVersion: "central-ledger: v10.4.5; central-settlement: v9.5.0; central-event-processor: v9.5.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -22,7 +22,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v10.4.2
+          tag: v10.4.5
           pullPolicy: Always
           command: '["node", "src/api/index.js"]'
         service:
@@ -196,7 +196,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v10.4.2
+          tag: v10.4.5
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
         service:
@@ -380,7 +380,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v10.4.2
+          tag: v10.4.5
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--position"]'
         service:
@@ -561,7 +561,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v10.4.2
+          tag: v10.4.5
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--get"]'
         service:
@@ -742,7 +742,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v10.4.2
+          tag: v10.4.5
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
         service:
@@ -923,7 +923,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v10.4.2
+          tag: v10.4.5
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
         service:
@@ -1104,7 +1104,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v10.4.2
+          tag: v10.4.5
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--admin"]'
         service:

--- a/centralledger/Chart.yaml
+++ b/centralledger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Helm chart for Kubernetes
 name: centralledger
 version: 10.4.0
-appVersion: "10.4.2"
+appVersion: "10.4.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-admin-transfer/Chart.yaml
+++ b/centralledger/chart-handler-admin-transfer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-admin-transfer
 version: 10.4.0
-appVersion: "10.4.2"
+appVersion: "10.4.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-admin-transfer/values.yaml
+++ b/centralledger/chart-handler-admin-transfer/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v10.4.2
+      tag: v10.4.5
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--admin"]'
     service:

--- a/centralledger/chart-handler-timeout/Chart.yaml
+++ b/centralledger/chart-handler-timeout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Timeout Handler Helm chart for Kubernetes
 name: centralledger-handler-timeout
 version: 10.4.0
-appVersion: "10.4.2"
+appVersion: "10.4.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-timeout/values.yaml
+++ b/centralledger/chart-handler-timeout/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v10.4.2
+      tag: v10.4.5
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
     service:

--- a/centralledger/chart-handler-transfer-fulfil/Chart.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Transfer Fulfil Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-fulfil
 version: 10.4.0
-appVersion: "10.4.2"
+appVersion: "10.4.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-fulfil/values.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v10.4.2
+      tag: v10.4.5
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
     service:

--- a/centralledger/chart-handler-transfer-get/Chart.yaml
+++ b/centralledger/chart-handler-transfer-get/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Get Transfer Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-get
 version: 10.4.0
-appVersion: "10.4.2"
+appVersion: "10.4.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-get/values.yaml
+++ b/centralledger/chart-handler-transfer-get/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v10.4.2
+      tag: v10.4.5
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--get"]'
     service:

--- a/centralledger/chart-handler-transfer-position/Chart.yaml
+++ b/centralledger/chart-handler-transfer-position/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Transfer Position Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-position
 version: 10.4.0
-appVersion: "10.4.2"
+appVersion: "10.4.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-position/values.yaml
+++ b/centralledger/chart-handler-transfer-position/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v10.4.2
+      tag: v10.4.5
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--position"]'
     service:

--- a/centralledger/chart-handler-transfer-prepare/Chart.yaml
+++ b/centralledger/chart-handler-transfer-prepare/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-prepare
 version: 10.4.0
-appVersion: "10.4.2"
+appVersion: "10.4.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-prepare/values.yaml
+++ b/centralledger/chart-handler-transfer-prepare/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v10.4.2
+      tag: v10.4.5
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
     service:

--- a/centralledger/chart-service/Chart.yaml
+++ b/centralledger/chart-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Service Helm chart for Kubernetes
 name: centralledger-service
 version: 10.4.0
-appVersion: "10.4.2"
+appVersion: "10.4.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v10.4.2
+      tag: v10.4.5
       pullPolicy: Always
       command: '["node", "src/api/index.js"]'
     service:

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -17,7 +17,7 @@ centralledger-service:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v10.4.2
+        tag: v10.4.5
         pullPolicy: Always
         command: '["node", "src/api/index.js"]'
       service:
@@ -192,7 +192,7 @@ centralledger-handler-transfer-prepare:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v10.4.2
+        tag: v10.4.5
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
       service:
@@ -377,7 +377,7 @@ centralledger-handler-transfer-position:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v10.4.2
+        tag: v10.4.5
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--position"]'
       service:
@@ -559,7 +559,7 @@ centralledger-handler-transfer-get:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v10.4.2
+        tag: v10.4.5
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--get"]'
       service:
@@ -741,7 +741,7 @@ centralledger-handler-transfer-fulfil:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v10.4.2
+        tag: v10.4.5
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
       service:
@@ -923,7 +923,7 @@ centralledger-handler-timeout:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v10.4.2
+        tag: v10.4.5
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
       service:
@@ -1105,7 +1105,7 @@ centralledger-handler-admin-transfer:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v10.4.2
+        tag: v10.4.5
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--admin"]'
       service:

--- a/ml-api-adapter/Chart.yaml
+++ b/ml-api-adapter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Helm chart for Kubernetes
 name: ml-api-adapter
-version: 10.3.0
-appVersion: "10.3.1"
+version: 10.4.0
+appVersion: "10.4.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-handler-notification/Chart.yaml
+++ b/ml-api-adapter/chart-handler-notification/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: ml-api-adapter-handler-notification
-version: 10.3.0
-appVersion: "10.3.1"
+version: 10.4.0
+appVersion: "10.4.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v10.3.1
+  tag: v10.4.2
   command: '["node", "src/handlers/index.js", "handler", "--notification"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/chart-service/Chart.yaml
+++ b/ml-api-adapter/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: ml-api-adapter API component Helm chart for Kubernetes
 name: ml-api-adapter-service
-version: 10.3.0
-appVersion: "10.3.0"
+version: 10.4.0
+appVersion: "10.4.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-service/values.yaml
+++ b/ml-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v10.3.1
+  tag: v10.4.2
   command: '["node", "src/api/index.js"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/requirements.yaml
+++ b/ml-api-adapter/requirements.yaml
@@ -1,11 +1,11 @@
 # requirements.yaml
 dependencies:
 - name: ml-api-adapter-service
-  version: 10.3.0
+  version: 10.4.0
   repository: "file://./chart-service"
   condition: ml-api-adapter-service.enabled
 - name: ml-api-adapter-handler-notification
-  version: 10.3.0
+  version: 10.4.0
   repository: "file://./chart-handler-notification"
   condition: ml-api-adapter-handler-notification.enabled
 ## This is used for testing ml-api-adapter deployments

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -13,7 +13,7 @@ ml-api-adapter-service:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v10.3.1
+    tag: v10.4.2
     command: '["node", "src/api/index.js"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -167,7 +167,7 @@ ml-api-adapter-handler-notification:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v10.3.1
+    tag: v10.4.2
     command: '["node", "src/handlers/index.js", "handler", "--notification"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.

--- a/mojaloop-bulk/Chart.yaml
+++ b/mojaloop-bulk/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Bulk Helm chart for Kubernetes
 name: mojaloop-bulk
 version: 10.4.0
-appVersion: "bulk-api-adapter: v9.5.0-snapshot; central-ledger: v10.4.2"
+appVersion: "bulk-api-adapter: v9.5.0-snapshot; central-ledger: v10.4.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop-bulk/values.yaml
+++ b/mojaloop-bulk/values.yaml
@@ -247,7 +247,7 @@ bulk-centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v10.4.2
+          tag: v10.4.5
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
         service:
@@ -416,7 +416,7 @@ bulk-centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v10.4.2
+          tag: v10.4.5
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
         service:
@@ -582,7 +582,7 @@ bulk-centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v10.4.2
+          tag: v10.4.5
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
         service:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 10.4.0
-appVersion: "ml-api-adapter: v10.3.1; central-ledger: v10.4.2; account-lookup-service: v10.3.1; quoting-service: v10.4.1; central-settlement: v9.5.0; central-event-processor: v9.5.0; bulk-api-adapter: v9.5.0-snapshot; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v10.1.2; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v9.5.0; mojaloop-simulator: v9.4.1; sdk-scheme-adapter: v10.1.0"
+appVersion: "ml-api-adapter: v10.3.1; central-ledger: v10.4.2; account-lookup-service: v10.4.2; quoting-service: v10.4.1; central-settlement: v9.5.0; central-event-processor: v9.5.0; bulk-api-adapter: v9.5.0-snapshot; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v10.1.2; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v9.5.0; mojaloop-simulator: v9.4.1; sdk-scheme-adapter: v10.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 10.4.0
-appVersion: "ml-api-adapter: v10.3.1; central-ledger: v10.4.2; account-lookup-service: v10.3.1; quoting-service: v10.2.0; central-settlement: v9.5.0; central-event-processor: v9.5.0; bulk-api-adapter: v9.5.0-snapshot; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v10.1.2; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v9.5.0; mojaloop-simulator: v9.4.1; sdk-scheme-adapter: v10.1.0"
+appVersion: "ml-api-adapter: v10.3.1; central-ledger: v10.4.2; account-lookup-service: v10.3.1; quoting-service: v10.4.1; central-settlement: v9.5.0; central-event-processor: v9.5.0; bulk-api-adapter: v9.5.0-snapshot; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v10.1.2; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v9.5.0; mojaloop-simulator: v9.4.1; sdk-scheme-adapter: v10.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 10.4.0
-appVersion: "ml-api-adapter: v10.3.1; central-ledger: v10.4.2; account-lookup-service: v10.4.2; quoting-service: v10.4.1; central-settlement: v9.5.0; central-event-processor: v9.5.0; bulk-api-adapter: v9.5.0-snapshot; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v10.1.2; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v10.4.1; mojaloop-simulator: v9.4.1; sdk-scheme-adapter: v10.1.0"
+appVersion: "ml-api-adapter: v10.4.2; central-ledger: v10.4.2; account-lookup-service: v10.4.2; quoting-service: v10.4.1; central-settlement: v9.5.0; central-event-processor: v9.5.0; bulk-api-adapter: v9.5.0-snapshot; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v10.1.2; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v10.4.1; mojaloop-simulator: v9.4.1; sdk-scheme-adapter: v10.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 10.4.0
-appVersion: "ml-api-adapter: v10.4.2; central-ledger: v10.4.2; account-lookup-service: v10.4.2; quoting-service: v10.4.1; central-settlement: v9.5.0; central-event-processor: v9.5.0; bulk-api-adapter: v9.5.0-snapshot; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v10.4.0; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v10.4.1; mojaloop-simulator: v9.4.1; sdk-scheme-adapter: v10.1.0"
+appVersion: "ml-api-adapter: v10.4.2; central-ledger: v10.4.5; account-lookup-service: v10.4.2; quoting-service: v10.4.1; central-settlement: v9.5.0; central-event-processor: v9.5.0; bulk-api-adapter: v9.5.0-snapshot; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v10.4.0; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v10.4.1; mojaloop-simulator: v9.4.1; sdk-scheme-adapter: v10.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 10.4.0
-appVersion: "ml-api-adapter: v10.3.1; central-ledger: v10.4.2; account-lookup-service: v10.4.2; quoting-service: v10.4.1; central-settlement: v9.5.0; central-event-processor: v9.5.0; bulk-api-adapter: v9.5.0-snapshot; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v10.1.2; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v9.5.0; mojaloop-simulator: v9.4.1; sdk-scheme-adapter: v10.1.0"
+appVersion: "ml-api-adapter: v10.3.1; central-ledger: v10.4.2; account-lookup-service: v10.4.2; quoting-service: v10.4.1; central-settlement: v9.5.0; central-event-processor: v9.5.0; bulk-api-adapter: v9.5.0-snapshot; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v10.1.2; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v10.4.1; mojaloop-simulator: v9.4.1; sdk-scheme-adapter: v10.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 10.4.0
-appVersion: "ml-api-adapter: v10.4.2; central-ledger: v10.4.2; account-lookup-service: v10.4.2; quoting-service: v10.4.1; central-settlement: v9.5.0; central-event-processor: v9.5.0; bulk-api-adapter: v9.5.0-snapshot; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v10.1.2; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v10.4.1; mojaloop-simulator: v9.4.1; sdk-scheme-adapter: v10.1.0"
+appVersion: "ml-api-adapter: v10.4.2; central-ledger: v10.4.2; account-lookup-service: v10.4.2; quoting-service: v10.4.1; central-settlement: v9.5.0; central-event-processor: v9.5.0; bulk-api-adapter: v9.5.0-snapshot; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v10.4.0; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v10.4.1; mojaloop-simulator: v9.4.1; sdk-scheme-adapter: v10.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -17,7 +17,7 @@ dependencies:
   repository: "file://../account-lookup-service"
   condition: account-lookup-service.enabled
 - name: quoting-service
-  version: 10.2.0
+  version: 10.4.0
   repository: "file://../quoting-service"
   condition: quoting-service.enabled
 - name: simulator

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
   repository: "file://../central"
   condition: central.enabled
 - name: ml-api-adapter
-  version: 10.3.0
+  version: 10.4.0
   repository: "file://../ml-api-adapter"
   condition: ml-api-adapter.enabled
 - name: emailnotifier

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -13,7 +13,7 @@ dependencies:
   repository: "file://../emailnotifier"
   condition: emailnotifier.enabled
 - name: account-lookup-service
-  version: 10.3.0
+  version: 10.4.0
   repository: "file://../account-lookup-service"
   condition: account-lookup-service.enabled
 - name: quoting-service

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -21,7 +21,7 @@ dependencies:
   repository: "file://../quoting-service"
   condition: quoting-service.enabled
 - name: simulator
-  version: 9.5.0
+  version: 10.4.0
   repository: "file://../simulator"
   condition: simulator.enabled
 - name: mojaloop-simulator

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -33,7 +33,7 @@ dependencies:
   repository: "file://../mojaloop-bulk"
   condition: mojaloop-bulk.enabled
 - name: transaction-requests-service
-  version: 10.1.0
+  version: 10.4.0
   repository: "file://../transaction-requests-service"
   condition: transaction-requests-service.enabled
 - name: finance-portal

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3426,7 +3426,7 @@ quoting-service:
   replicaCount: 1
   image:
     repository: mojaloop/quoting-service
-    tag: v10.2.0
+    tag: v10.4.1
     pullPolicy: Always
 
   readinessProbe:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3710,7 +3710,7 @@ simulator:
 
   image:
     repository: mojaloop/simulator
-    tag: v9.5.0
+    tag: v10.4.1
     pullPolicy: Always
 
   imagePullSecrets: []

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2733,7 +2733,7 @@ account-lookup-service:
       api:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v10.3.1
+          tag: v10.4.2
           pullPolicy: Always
           command: '["node", "src/index.js", "server", "--api"]'
         service:
@@ -2744,7 +2744,7 @@ account-lookup-service:
       admin:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v10.3.1
+          tag: v10.4.2
           pullPolicy: Always
           command: '["node", "src/index.js", "server", "--admin"]'
         service:
@@ -2907,7 +2907,7 @@ account-lookup-service:
       api:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v10.3.1
+          tag: v10.4.2
           pullPolicy: Always
           command: '["node", "src/index.js", "server", "--api"]'
         service:
@@ -2918,7 +2918,7 @@ account-lookup-service:
       admin:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v10.3.1
+          tag: v10.4.2
           pullPolicy: Always
           command: '["node", "src/index.js", "server", "--admin"]'
         service:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2345,7 +2345,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v10.3.1
+      tag: v10.4.2
       command: '["node", "src/api/index.js"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -2477,7 +2477,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v10.3.1
+      tag: v10.4.2
       command: '["node", "src/handlers/index.js", "handler", "--notification"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3580,7 +3580,7 @@ transaction-requests-service:
   replicaCount: 1
   image:
     repository: mojaloop/transaction-requests-service
-    tag: v10.1.2
+    tag: v10.4.0
     pullPolicy: Always
     command: '["node", "src/index.js", "api"]'
 

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -24,7 +24,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v10.4.2
+            tag: v10.4.5
             pullPolicy: Always
             command: '["node", "src/api/index.js"]'
           service:
@@ -207,7 +207,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v10.4.2
+            tag: v10.4.5
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
           service:
@@ -400,7 +400,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v10.4.2
+            tag: v10.4.5
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--admin"]'
           service:
@@ -590,7 +590,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v10.4.2
+            tag: v10.4.5
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--position"]'
           service:
@@ -780,7 +780,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v10.4.2
+            tag: v10.4.5
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--get"]'
           service:
@@ -970,7 +970,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v10.4.2
+            tag: v10.4.5
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
           service:
@@ -1160,7 +1160,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v10.4.2
+            tag: v10.4.5
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
           service:
@@ -4963,7 +4963,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v10.4.2
+            tag: v10.4.5
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
           service:
@@ -5128,7 +5128,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v10.4.2
+            tag: v10.4.5
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
           service:

--- a/quoting-service/Chart.yaml
+++ b/quoting-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Quoting-Service Helm chart for Kubernetes
 name: quoting-service
-version: 10.2.0
-appVersion: "10.2.0"
+version: 10.4.0
+appVersion: "10.4.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/quoting-service/values.yaml
+++ b/quoting-service/values.yaml
@@ -8,7 +8,7 @@ global: {}
 replicaCount: 1
 image:
   repository: mojaloop/quoting-service
-  tag: v10.2.0
+  tag: v10.4.1
   pullPolicy: Always
 
 readinessProbe:

--- a/simulator/Chart.yaml
+++ b/simulator/Chart.yaml
@@ -1,4 +1,4 @@
 description: Simulator Helm Chart for Simultors
 name: simulator
-version: 9.5.0
-appVersion: "9.5.0"
+version: 10.4.0
+appVersion: "10.4.1"

--- a/simulator/values.yaml
+++ b/simulator/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: mojaloop/simulator
-  tag: v9.5.0
+  tag: v10.4.1
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/transaction-requests-service/Chart.yaml
+++ b/transaction-requests-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Transaction-Requests-Service Helm chart for Kubernetes
 name: transaction-requests-service
-version: 10.1.0
-appVersion: "10.1.2"
+version: 10.4.0
+appVersion: "10.4.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/transaction-requests-service/values.yaml
+++ b/transaction-requests-service/values.yaml
@@ -8,7 +8,7 @@ global: {}
 replicaCount: 1
 image:
   repository: mojaloop/transaction-requests-service
-  tag: v10.1.2
+  tag: v10.4.0
   pullPolicy: Always
   command: '["node", "src/index.js", "api"]'
 


### PR DESCRIPTION
Initial version, upgraded the following services
GP tests 695 passed, 6 failed on local deployment. Attached the postman report

- Central Ledger - 10.4.5
- Transaction request service - 10.4.0
- ml-api-adapter - 10.4.2
- Simulator - 10.4.1
- Account lookup service - 10.4.2
- Quoting service - 10.4.1

<img width="1279" alt="Screenshot 2020-06-20 at 12 27 11 AM" src="https://user-images.githubusercontent.com/33152110/85171521-cb0cca00-b28c-11ea-8f47-d0ef5d54f8e7.png">