### PR TITLE
Allow the user to supply their own TLS creds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,7 @@ jobs:
       - run:
           name: Update Helm Charts
           command: |
+            trap 'echo "Dep update failed...exiting. Please fix me!"'
             sh update-charts-dep.sh
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
       - run:
           name: Update Helm Charts
           command: |
-            trap 'echo "Dep update failed...exiting. Please fix me!"'
+            trap 'echo "Dep update failed...exiting. Please fix me!"' ERR
             sh update-charts-dep.sh
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,8 +144,7 @@ jobs:
       - run:
           name: Update Helm Charts
           command: |
-            trap 'echo "Dep update failed...exiting. Please fix me!"' ERR
-            sh update-charts-dep.sh
+            bash update-charts-dep.sh
 
   deploy:
     <<: *defaults_working_directory

--- a/mojaloop-simulator/Chart.yaml
+++ b/mojaloop-simulator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: "Helm Chart for the Mojaloop (SDK based) Simulator - mojaloop-simulator: v9.4.1; sdk-scheme-adapter: v10.1.0"
 name: mojaloop-simulator
-version: 10.1.0
+version: 10.4.0
 appVersion: "9.4.1"

--- a/mojaloop-simulator/templates/deployment.yaml
+++ b/mojaloop-simulator/templates/deployment.yaml
@@ -99,23 +99,23 @@ spec:
         - name: DFSP_ID
           value: {{ $name | quote }}
         - name: IN_CA_CERT_PATH
-          value: "./secrets/cacert.pem"
+          value: "./secrets/inbound-cacert.pem"
         - name: IN_SERVER_CERT_PATH
-          value: "./secrets/servercert.pem"
+          value: "./secrets/inbound-cert.pem"
         - name: IN_SERVER_KEY_PATH
-          value: "./secrets/serverkey.pem"
+          value: "./secrets/inbound-key.pem"
         - name: OUT_CA_CERT_PATH
-          value: "./secrets/cacert.pem"
+          value: "./secrets/outbound-cacert.pem"
         - name: OUT_CLIENT_CERT_PATH
-          value: "./secrets/servercert.pem"
+          value: "./secrets/outbound-cert.pem"
         - name: OUT_CLIENT_KEY_PATH
-          value: "./secrets/serverkey.pem"
+          value: "./secrets/outbound-key.pem"
         - name: TEST_CA_CERT_PATH
-          value: "./secrets/cacert.pem"
+          value: "./secrets/test-cacert.pem"
         - name: TEST_CLIENT_CERT_PATH
-          value: "./secrets/servercert.pem"
+          value: "./secrets/test-cert.pem"
         - name: TEST_CLIENT_KEY_PATH
-          value: "./secrets/serverkey.pem"
+          value: "./secrets/test-key.pem"
         {{- range $k, $v := $config.config.schemeAdapter.env }}
         - name: {{ $k }}
           value: {{ $v | quote }}

--- a/mojaloop-simulator/templates/ingress.yaml
+++ b/mojaloop-simulator/templates/ingress.yaml
@@ -44,7 +44,8 @@ spec:
     {{- end }}
   {{- end }}
   {{- end }}
-    # This dummy rule means that installs do not fail for being noncompliant with the manifest spec
+    # This dummy rule means that installs with no ingress do not fail for being noncompliant with
+    # the manifest spec
     - host: null
 ---
 {{ end }}

--- a/mojaloop-simulator/templates/ingress.yaml
+++ b/mojaloop-simulator/templates/ingress.yaml
@@ -44,5 +44,7 @@ spec:
     {{- end }}
   {{- end }}
   {{- end }}
+    # This dummy rule means that installs do not fail for being noncompliant with the manifest spec
+    - host: null
 ---
 {{ end }}

--- a/mojaloop-simulator/templates/secret.yaml
+++ b/mojaloop-simulator/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- $ca := genCA "mojaloop-simulator" 3650 }}
 {{- range $name, $customConfig := .Values.simulators }}
 {{- $config := merge $customConfig $.Values.defaults }}
 {{- $fullName := printf "%s%s" (include "mojaloop-simulator.prefix" $) $name -}}
@@ -33,11 +34,17 @@ metadata:
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
 data:
-  {{- $ca := genCA (printf "%s-scheme-adapter" $fullName) 3650 }}
+  {{- if $config.config.schemeAdapter.secrets.tls }}
+  {{- $requiredMessage := "When supplying TLS configuration you must supply all of tls.cacert, tls.cert and tls.key for each simulator." }}
+  "cacert.pem": {{ $config.config.schemeAdapter.secrets.tls.cacert | required $requiredMessage | b64enc }}
+  "servercert.pem": {{ $config.config.schemeAdapter.secrets.tls.cert | required $requiredMessage | b64enc }}
+  "serverkey.pem": {{ $config.config.schemeAdapter.secrets.tls.key | required $requiredMessage | b64enc }}
+  {{- else }}
   {{- $cert := genSignedCert (printf "%s-scheme-adapter" $fullName) nil nil 3650 $ca }}
   "cacert.pem": {{ $ca.Cert | b64enc }}
   "servercert.pem": {{ $cert.Cert | b64enc }}
   "serverkey.pem": {{ $cert.Key | b64enc }}
+  {{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/mojaloop-simulator/templates/secret.yaml
+++ b/mojaloop-simulator/templates/secret.yaml
@@ -34,16 +34,36 @@ metadata:
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
 data:
-  {{- if $config.config.schemeAdapter.secrets.tls }}
-  {{- $requiredMessage := "When supplying TLS configuration you must supply all of tls.cacert, tls.cert and tls.key for each simulator." }}
-  "cacert.pem": {{ $config.config.schemeAdapter.secrets.tls.cacert | required $requiredMessage | b64enc }}
-  "servercert.pem": {{ $config.config.schemeAdapter.secrets.tls.cert | required $requiredMessage | b64enc }}
-  "serverkey.pem": {{ $config.config.schemeAdapter.secrets.tls.key | required $requiredMessage | b64enc }}
+  {{- $defaultCert := genSignedCert (printf "%s-scheme-adapter" $fullName) nil nil 3650 $ca }}
+  {{- if (and $config.config.schemeAdapter.env.INBOUND_MUTUAL_TLS_ENABLED $config.config.schemeAdapter.secrets.tls.inbound) }}
+  {{- $requiredMessage := "When supplying TLS configuration you must supply all of tls.inbound.cacert, tls.inbound.cert and tls.inbound.key for each simulator." }}
+  "inbound-cacert.pem": {{ $config.config.schemeAdapter.secrets.tls.inbound.cacert | required $requiredMessage | b64enc }}
+  "inbound-cert.pem":   {{ $config.config.schemeAdapter.secrets.tls.inbound.cert   | required $requiredMessage | b64enc }}
+  "inbound-key.pem":    {{ $config.config.schemeAdapter.secrets.tls.inbound.key    | required $requiredMessage | b64enc }}
   {{- else }}
-  {{- $cert := genSignedCert (printf "%s-scheme-adapter" $fullName) nil nil 3650 $ca }}
-  "cacert.pem": {{ $ca.Cert | b64enc }}
-  "servercert.pem": {{ $cert.Cert | b64enc }}
-  "serverkey.pem": {{ $cert.Key | b64enc }}
+  "inbound-cacert.pem": {{ $ca.Cert | b64enc }}
+  "inbound-cert.pem": {{ $defaultCert.Cert | b64enc }}
+  "inbound-key.pem": {{ $defaultCert.Key | b64enc }}
+  {{- end }}
+  {{- if (and $config.config.schemeAdapter.env.OUTBOUND_MUTUAL_TLS_ENABLED $config.config.schemeAdapter.secrets.tls.outbound) }}
+  {{- $requiredMessage := "When supplying TLS configuration you must supply all of tls.outbound.cacert, tls.outbound.cert and tls.outbound.key for each simulator." }}
+  "outbound-cacert.pem": {{ $config.config.schemeAdapter.secrets.tls.outbound.cacert | required $requiredMessage | b64enc }}
+  "outbound-cert.pem":   {{ $config.config.schemeAdapter.secrets.tls.outbound.cert   | required $requiredMessage | b64enc }}
+  "outbound-key.pem":    {{ $config.config.schemeAdapter.secrets.tls.outbound.key    | required $requiredMessage | b64enc }}
+  {{- else }}
+  "outbound-cacert.pem": {{ $ca.Cert | b64enc }}
+  "outbound-cert.pem": {{ $defaultCert.Cert | b64enc }}
+  "outbound-key.pem": {{ $defaultCert.Key | b64enc }}
+  {{- end }}
+  {{- if (and $config.config.schemeAdapter.env.TEST_MUTUAL_TLS_ENABLED $config.config.schemeAdapter.secrets.tls.test) }}
+  {{- $requiredMessage := "When supplying TLS configuration you must supply all of tls.test.cacert, tls.test.cert and tls.test.key for each simulator." }}
+  "test-cacert.pem": {{ $config.config.schemeAdapter.secrets.tls.test.cacert | required $requiredMessage | b64enc }}
+  "test-cert.pem":   {{ $config.config.schemeAdapter.secrets.tls.test.cert   | required $requiredMessage | b64enc }}
+  "test-key.pem":    {{ $config.config.schemeAdapter.secrets.tls.test.key    | required $requiredMessage | b64enc }}
+  {{- else }}
+  "test-cacert.pem": {{ $ca.Cert | b64enc }}
+  "test-cert.pem": {{ $defaultCert.Cert | b64enc }}
+  "test-key.pem": {{ $defaultCert.Key | b64enc }}
   {{- end }}
 ---
 {{- end }}

--- a/mojaloop-simulator/values.yaml
+++ b/mojaloop-simulator/values.yaml
@@ -88,6 +88,8 @@
 #   payeefsp) "sim-component" (e.g. backend, scheme-adapter, cache)
 # * can _probably_ remove port numbers from services to simplify chart (although perhaps not? try
 #   to port-forward with a named port instead of a numbered port?)
+# * It is likely possible to have the user supply a CA cert + key and use those to generate and
+#   sign automatically generated per-simulator keys.
 
 
 simulators: {}
@@ -185,7 +187,8 @@ defaults: &defaults
       secrets:
         tls:
           # In order to enable TLS with your supplied credentials, you will need to:
-          # 1. set all three of the `cert`, `key`, `cacert` fields appropriately
+          # 1. set all three of the `cert`, `key`, `cacert` fields appropriately for each of
+          # `inbound`, `outbound` and `test` as per your preference.
           # 2. optionally specify `schemeAdapter.env.INBOUND_MUTUAL_TLS_ENABLED: true`
           # 3. optionally specify `schemeAdapter.env.OUTBOUND_MUTUAL_TLS_ENABLED: true`
           # 4. optionally specify `schemeAdapter.env.TEST_MUTUAL_TLS_ENABLED: true`
@@ -193,18 +196,35 @@ defaults: &defaults
           # the CA, cert and key will be generated for you by this chart. To use this functionality
           # you only need specify the config documented in steps (2, 3, 4) a few lines up.
           #
-          # key: |
-          #   -----BEGIN CERTIFICATE-----
-          #   ...
-          #   -----END CERTIFICATE-----
-          # cacert:
-          #   -----BEGIN CERTIFICATE-----
-          #   ...
-          #   -----END CERTIFICATE-----
-          # cert:
-          #   -----BEGIN RSA PRIVATE KEY-----
-          #   ...
-          #   -----END RSA PRIVATE KEY-----
+          # inbound:
+          #   key: |
+          #     -----BEGIN CERTIFICATE-----
+          #     ...
+          #     -----END CERTIFICATE-----
+          #   cacert: |
+          #     -----BEGIN CERTIFICATE-----
+          #     ...
+          #     -----END CERTIFICATE-----
+          #   cert: |
+          #     -----BEGIN RSA PRIVATE KEY-----
+          #     ...
+          #     -----END RSA PRIVATE KEY-----
+          #
+          # To set the same values for each of inbound, outbound and test, specify the values for
+          # inbound as above, then the values for outbound and test using yaml anchors:
+          #
+          # inbound: &inbound
+          #   key: |
+          #     ..
+          #   cacert: |
+          #     ..
+          #   cert: |
+          #     ..
+          # outbound: *inbound
+          # test: *inbound
+          inbound: &inbound
+          outbound: *inbound
+          test: *inbound
         jws:
           # Use the privKeySecretName field if you would like to supply a JWS private key external
           # to this chart.
@@ -288,7 +308,8 @@ defaults: &defaults
         JWS_VERIFICATION_KEYS_DIRECTORY: "/jwsVerificationKeys"
 
         # Location of certs and key required for TLS. It is possible to configure these- however,
-        # at the time of writing, it's not supported by this chart.
+        # at the time of writing, it's not supported by this chart and will likely cause breakage.
+        # You should probably not do it unless you know what you're doing.
         # IN_CA_CERT_PATH: "./secrets/cacert.pem"
         # IN_SERVER_CERT_PATH: "./secrets/servercert.pem"
         # IN_SERVER_KEY_PATH: "./secrets/serverkey.pem"

--- a/mojaloop-simulator/values.yaml
+++ b/mojaloop-simulator/values.yaml
@@ -189,6 +189,9 @@ defaults: &defaults
           # 2. optionally specify `schemeAdapter.env.INBOUND_MUTUAL_TLS_ENABLED: true`
           # 3. optionally specify `schemeAdapter.env.OUTBOUND_MUTUAL_TLS_ENABLED: true`
           # 4. optionally specify `schemeAdapter.env.TEST_MUTUAL_TLS_ENABLED: true`
+          # It probably makes sense to set your CA cert in defaults. Note that the default is that
+          # the CA, cert and key will be generated for you by this chart. To use this functionality
+          # you only need specify the config documented in steps (2, 3, 4) a few lines up.
           #
           # key: |
           #   -----BEGIN CERTIFICATE-----

--- a/mojaloop-simulator/values.yaml
+++ b/mojaloop-simulator/values.yaml
@@ -183,6 +183,25 @@ defaults: &defaults
 
     schemeAdapter:
       secrets:
+        tls:
+          # In order to enable TLS with your supplied credentials, you will need to:
+          # 1. set all three of the `cert`, `key`, `cacert` fields appropriately
+          # 2. optionally specify `schemeAdapter.env.INBOUND_MUTUAL_TLS_ENABLED: true`
+          # 3. optionally specify `schemeAdapter.env.OUTBOUND_MUTUAL_TLS_ENABLED: true`
+          # 4. optionally specify `schemeAdapter.env.TEST_MUTUAL_TLS_ENABLED: true`
+          #
+          # key: |
+          #   -----BEGIN CERTIFICATE-----
+          #   ...
+          #   -----END CERTIFICATE-----
+          # cacert:
+          #   -----BEGIN CERTIFICATE-----
+          #   ...
+          #   -----END CERTIFICATE-----
+          # cert:
+          #   -----BEGIN RSA PRIVATE KEY-----
+          #   ...
+          #   -----END RSA PRIVATE KEY-----
         jws:
           # Use the privKeySecretName field if you would like to supply a JWS private key external
           # to this chart.

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -25,7 +25,7 @@ dependencies:
   repository: "file://../simulator"
   condition: simulator.enabled
 - name: mojaloop-simulator
-  version: 10.1.0
+  version: 10.4.0
   repository: "file://../mojaloop-simulator"
   condition: mojaloop-simulator.enabled
 - name: mojaloop-bulk

--- a/update-charts-dep.sh
+++ b/update-charts-dep.sh
@@ -1,121 +1,49 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 #
 # Script to update all Helm Chart Dependencies
 #
 
-echo "Updating all Charts..."
+set -e
 
-# Function to check the last command's result exited with a value of 0, otherwise the script will exit with a 1
-function checkCommandResult () {
-    if [ $? -eq 0 ]; then
-        echo ""
-    else
-        echo "Dep update failed...exiting. Please fix me!";
-        exit 1
-    fi
-}
+trap 'echo "Dep update failed...exiting. Please fix me!"' ERR
 
 echo "Removing old charts..."
 find ./ -name "charts"| xargs rm -Rf
 find ./ -name "tmpcharts"| xargs rm -Rf
 
-## Disabled as Simulator has no requirements at this time
-#echo "Updating Simulator..."
-#helm dep up ./simulator
-#checkCommandResult
+echo "Updating all Charts..."
+declare -a arr=(
+    eventstreamprocessor
+    monitoring/promfana
+    monitoring/efk
+    account-lookup-service
+    als-oracle-pathfinder
+    centralkms
+    forensicloggingsidecar
+    centralledger
+    centralenduserregistry
+    centralsettlement
+    ml-api-adapter
+    quoting-service
+    finance-portal
+    finance-portal-settlement-management
+    transaction-requests-service
+    emailnotifier
+    centraleventprocessor
+    central
+    bulk-centralledger
+    bulk-api-adapter
+    mojaloop-bulk
+    mojaloop-simulator
+    mojaloop
+)
 
-echo "Updating Event Stream Processor..."
-helm dep up ./eventstreamprocessor
-checkCommandResult
-
-echo "Updating Promfana..."
-helm dep up ./monitoring/promfana
-checkCommandResult
-
-echo "Updating EFK..."
-helm dep up ./monitoring/efk
-checkCommandResult
-
-echo "Updating Account Lookup Service..."
-helm dep up ./account-lookup-service
-checkCommandResult
-
-echo "Updating ALS Oracle Pathfinder..."
-helm dep up ./als-oracle-pathfinder
-checkCommandResult
-
-echo "Updating Central-KMS..."
-helm dep up ./centralkms
-checkCommandResult
-
-echo "Updating Forensic Logging Sidecar..."
-helm dep up ./forensicloggingsidecar
-checkCommandResult
-
-echo "Updating Central-Ledger..."
-helm dep up ./centralledger
-checkCommandResult
-
-echo "Updating Central-End-User-Registry..."
-helm dep up ./centralenduserregistry
-checkCommandResult
-
-echo "Updating Central-Settlement..."
-helm dep up ./centralsettlement
-checkCommandResult
-
-echo "Updating ml-api-adapter..."
-helm dep up ./ml-api-adapter
-checkCommandResult
-
-echo "Updating quoting-service..."
-helm dep up ./quoting-service
-checkCommandResult
-
-echo "Updating finance-portal..."
-helm dep up ./finance-portal
-checkCommandResult
-
-echo "Updating finance-portal-settlement-management..."
-helm dep up ./finance-portal-settlement-management
-checkCommandResult
-
-echo "Updating transaction-request-service..."
-helm dep up ./transaction-requests-service
-checkCommandResult
-
-echo "Updating Email Notifier..."
-helm dep up ./emailnotifier
-checkCommandResult
-
-echo "Central Event Processor..."
-helm dep up ./centraleventprocessor
-checkCommandResult
-
-echo "Updating Central..."
-helm dep up ./central
-checkCommandResult
-
-echo "Updating bulk-centralledger..."
-helm dep up ./bulk-centralledger/
-checkCommandResult
-
-echo "Updating bulk-api-adapter..."
-helm dep up ./bulk-api-adapter/
-checkCommandResult
-
-echo "Updating Mojaloop Bulk..."
-helm dep up ./mojaloop-bulk
-checkCommandResult
-
-echo "Updating Mojaloop..."
-helm dep up ./mojaloop
-checkCommandResult
-
-echo "Updating Mojaloop Simulator..."
-helm dep up ./mojaloop-simulator
-checkCommandResult
+for chart in "${arr[@]}"
+do
+    echo "Updating $chart"
+    helm dep up "$chart"
+done
 
 echo "\
 Chart updates completed.\n \

--- a/update-charts-dep.sh
+++ b/update-charts-dep.sh
@@ -1,10 +1,12 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 #
 # Script to update all Helm Chart Dependencies
 #
 
 set -e
+
+trap 'echo "Dep update failed...exiting. Please fix me!"' ERR
 
 echo "Removing old charts..."
 find ./ -name "charts"| xargs rm -Rf

--- a/update-charts-dep.sh
+++ b/update-charts-dep.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 #
 # Script to update all Helm Chart Dependencies
@@ -13,7 +13,7 @@ find ./ -name "charts"| xargs rm -Rf
 find ./ -name "tmpcharts"| xargs rm -Rf
 
 echo "Updating all Charts..."
-declare -a arr=(
+declare -a charts=(
     eventstreamprocessor
     monitoring/promfana
     monitoring/efk
@@ -39,7 +39,7 @@ declare -a arr=(
     mojaloop
 )
 
-for chart in "${arr[@]}"
+for chart in "${charts[@]}"
 do
     echo "Updating $chart"
     helm dep up "$chart"

--- a/update-charts-dep.sh
+++ b/update-charts-dep.sh
@@ -1,13 +1,10 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 #
 # Script to update all Helm Chart Dependencies
 #
 
 set -e
-
-message() { echo "Dep update failed...exiting. Please fix me!"; }
-trap message ERR
 
 echo "Removing old charts..."
 find ./ -name "charts"| xargs rm -Rf

--- a/update-charts-dep.sh
+++ b/update-charts-dep.sh
@@ -6,7 +6,8 @@
 
 set -e
 
-trap 'echo "Dep update failed...exiting. Please fix me!"' ERR
+message() { echo "Dep update failed...exiting. Please fix me!"; }
+trap message ERR
 
 echo "Removing old charts..."
 find ./ -name "charts"| xargs rm -Rf


### PR DESCRIPTION
Also generating only a single CA for automatic credential generation. Makes much more sense that all generated keys + certs should be signed by the same CA.

`update-chart-deps.sh`
- Modified to trap non-zero return codes and print the existing error message. The loop could be considered a matter of taste and if someone prefers the existing sequence of commands to the loop I wouldn't fight them to the death over it.
- Called by `bash` to support `trap ERR`.