### PR TITLE
JWS signing key default was broken.

### DIFF
--- a/mojaloop-simulator/templates/deployment.yaml
+++ b/mojaloop-simulator/templates/deployment.yaml
@@ -116,6 +116,8 @@ spec:
           value: "/secrets/test-cert.pem"
         - name: TEST_CLIENT_KEY_PATH
           value: "/secrets/test-key.pem"
+        - name: JWS_SIGNING_KEY_PATH
+          value: "/jwsSigningKey/private.key"
         {{- range $k, $v := $config.config.schemeAdapter.env }}
         - name: {{ $k }}
           value: {{ $v | quote }}

--- a/mojaloop-simulator/values.yaml
+++ b/mojaloop-simulator/values.yaml
@@ -304,7 +304,7 @@ defaults: &defaults
         JWS_SIGN_PUT_PARTIES: true
 
         # Path to JWS signing key (private key of THIS DFSP)
-        JWS_SIGNING_KEY_PATH: "/jwsSigningKey.key" # TODO: do not configure- will break the chart
+        # JWS_SIGNING_KEY_PATH: "/jwsSigningKey.key" # do not configure- will break the chart
         JWS_VERIFICATION_KEYS_DIRECTORY: "/jwsVerificationKeys"
 
         # Location of certs and key required for TLS. It is possible to configure these- however,


### PR DESCRIPTION
The default value was broken.

As can be seen here:
https://github.com/mojaloop/helm/blob/4afd91b4d4c976e1f8d60495c677f1ba48b30192/mojaloop-simulator/templates/deployment.yaml#L90

and here:
https://github.com/mojaloop/helm/blob/4afd91b4d4c976e1f8d60495c677f1ba48b30192/mojaloop-simulator/templates/secret.yaml#L22

the key is being placed at `/jwsSigningKey/private.key`. It is not possible to volume mount to root. The existing configuration may have appeared to be working because there's a key packaged in the image for testing purposes (I'm not certain of this, I haven't checked). I'm not convinced configuration of this option adds any value, so I commented it out. It is in fact still configurable, as values set in the `values.yaml` file will take precedence over those in `templates/deployment.yaml`.

I think it's probably preferable for the image to fail with a message than to have insecure defaults (a very public "private key").