### PR TITLE
Feature/#1463 update helmchartstosupport kubernetesdeployments1.15andlaterversions

### DIFF
--- a/account-lookup-service/chart-admin/templates/_helpers.tpl
+++ b/account-lookup-service/chart-admin/templates/_helpers.tpl
@@ -30,3 +30,19 @@ Create chart name and version as used by the chart label.
 {{- define "account-lookup-service-admin.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "account-lookup-service-admin.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "account-lookup-service-admin.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/account-lookup-service/chart-admin/templates/deployment.yaml
+++ b/account-lookup-service/chart-admin/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
-apiVersion: apps/v1beta2
+apiVersion: {{ template "account-lookup-service-admin.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ include "account-lookup-service-admin.fullname" . }}

--- a/account-lookup-service/chart-admin/templates/ingress.yaml
+++ b/account-lookup-service/chart-admin/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "account-lookup-service-admin.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "account-lookup-service-admin.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/account-lookup-service/chart-service/templates/_helpers.tpl
+++ b/account-lookup-service/chart-service/templates/_helpers.tpl
@@ -30,3 +30,19 @@ Create chart name and version as used by the chart label.
 {{- define "account-lookup-service-api.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "account-lookup-service-api.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "account-lookup-service-api.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/account-lookup-service/chart-service/templates/deployment.yaml
+++ b/account-lookup-service/chart-service/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
-apiVersion: apps/v1beta2
+apiVersion: {{ template "account-lookup-service-api.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ include "account-lookup-service-api.fullname" . }}

--- a/account-lookup-service/chart-service/templates/ingress.yaml
+++ b/account-lookup-service/chart-service/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "account-lookup-service-api.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "account-lookup-service-api.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/account-lookup-service/requirements.yaml
+++ b/account-lookup-service/requirements.yaml
@@ -13,7 +13,7 @@ dependencies:
   repository: "file://../als-oracle-pathfinder"
   condition: als-oracle-pathfinder.enabled
 - name: percona-xtradb-cluster
-  version: 1.0.1
+  version: 1.0.4
   repository: https://kubernetes-charts.storage.googleapis.com
   alias: mysql
   condition: mysql.enabled

--- a/account-lookup-service/values.yaml
+++ b/account-lookup-service/values.yaml
@@ -641,6 +641,8 @@ mysql:
   metricsExporter:
     enabled: true
     tag: v0.11.0
+    commandOverrides: []
+    argsOverrides: []
 
   ## When set to true will create sidecar to tail mysql log
   logTail: true

--- a/als-oracle-pathfinder/templates/_helpers.tpl
+++ b/als-oracle-pathfinder/templates/_helpers.tpl
@@ -30,3 +30,19 @@ Create chart name and version as used by the chart label.
 {{- define "als-oracle-pathfinder.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "als-oracle-pathfinder.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "als-oracle-pathfinder.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/als-oracle-pathfinder/templates/deployment.yaml
+++ b/als-oracle-pathfinder/templates/deployment.yaml
@@ -1,7 +1,7 @@
 {{- $dbHostCentralLedger := ( .Values.config.db.central_ledger.host | replace "$release_name" .Release.Name ) -}}
 {{- $dbHostAccountLookup := ( .Values.config.db.account_lookup.host | replace "$release_name" .Release.Name ) -}}
 {{- $serviceName :=  (include "als-oracle-pathfinder.fullname" .) -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "als-oracle-pathfinder.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "als-oracle-pathfinder.fullname" . }}

--- a/als-oracle-pathfinder/templates/ingress.yaml
+++ b/als-oracle-pathfinder/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "als-oracle-pathfinder.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $servicePath := .Values.ingress.externalPath -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "als-oracle-pathfinder.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "als-oracle-pathfinder.fullname" . }}

--- a/bulk-api-adapter/chart-handler-notification/templates/_helpers.tpl
+++ b/bulk-api-adapter/chart-handler-notification/templates/_helpers.tpl
@@ -14,3 +14,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "bulk-api-adapter-handler-notification.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "bulk-api-adapter-handler-notification.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/bulk-api-adapter/chart-handler-notification/templates/deployment.yaml
+++ b/bulk-api-adapter/chart-handler-notification/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
 {{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "bulk-api-adapter-handler-notification.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "bulk-api-adapter-handler-notification.fullname" . }}

--- a/bulk-api-adapter/chart-handler-notification/templates/ingress.yaml
+++ b/bulk-api-adapter/chart-handler-notification/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "bulk-api-adapter-handler-notification.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $servicePath := .Values.ingress.externalPath -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "bulk-api-adapter-handler-notification.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "bulk-api-adapter-handler-notification.fullname" . }}

--- a/bulk-api-adapter/chart-service/templates/_helpers.tpl
+++ b/bulk-api-adapter/chart-service/templates/_helpers.tpl
@@ -14,3 +14,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "bulk-api-adapter-service.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "bulk-api-adapter-service.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/bulk-api-adapter/chart-service/templates/deployment.yaml
+++ b/bulk-api-adapter/chart-service/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
 {{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "bulk-api-adapter-service.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "bulk-api-adapter-service.fullname" . }}

--- a/bulk-api-adapter/chart-service/templates/ingress.yaml
+++ b/bulk-api-adapter/chart-service/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "bulk-api-adapter-service.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $servicePath := .Values.ingress.externalPath -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "bulk-api-adapter-service.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "bulk-api-adapter-service.fullname" . }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/_helpers.tpl
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/_helpers.tpl
@@ -14,3 +14,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "centralledger-handler-bulk-transfer-fulfil.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "centralledger-handler-bulk-transfer-fulfil.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/deployment.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/deployment.yaml
@@ -1,7 +1,7 @@
 {{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
 {{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "centralledger-handler-bulk-transfer-fulfil.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}
@@ -15,7 +15,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "centralledger-handler-admin-transfer.name" . }}
+      app.kubernetes.io/name: {{ include "centralledger-handler-bulk-transfer-fulfil.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/ingress.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/ingress.yaml
@@ -1,11 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "centralledger-handler-bulk-transfer-fulfil.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "centralledger-handler-bulk-transfer-fulfil.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "centralledger-handler-admin-transfer.name" . }}
+    app.kubernetes.io/name: {{ include "centralledger-handler-bulk-transfer-fulfil.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/secret.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/secret.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   name: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "centralledger-handler-admin-transfer.name" . }}
+    app.kubernetes.io/name: {{ include "centralledger-handler-bulk-transfer-fulfil.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/service.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ template "centralledger-handler-bulk-transfer-fulfil.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "centralledger-handler-admin-transfer.name" . }}
+    app.kubernetes.io/name: {{ include "centralledger-handler-bulk-transfer-fulfil.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/_helpers.tpl
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/_helpers.tpl
@@ -14,3 +14,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "centralledger-handler-bulk-transfer-prepare.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "centralledger-handler-bulk-transfer-prepare.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/deployment.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/deployment.yaml
@@ -1,7 +1,7 @@
 {{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
 {{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "centralledger-handler-bulk-transfer-prepare.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/ingress.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "centralledger-handler-bulk-transfer-prepare.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "centralledger-handler-bulk-transfer-prepare.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "centralledger-handler-bulk-transfer-prepare.fullname" . }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/_helpers.tpl
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/_helpers.tpl
@@ -14,3 +14,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "centralledger-handler-bulk-transfer-processing.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "centralledger-handler-bulk-transfer-processing.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/deployment.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/deployment.yaml
@@ -1,7 +1,7 @@
 {{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
 {{- $objStoreUri := ( .Values.config.objstore_uri | replace "$release_name" .Release.Name ) -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "centralledger-handler-bulk-transfer-processing.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/ingress.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "centralledger-handler-bulk-transfer-processing.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "centralledger-handler-bulk-transfer-processing.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "centralledger-handler-bulk-transfer-processing.fullname" . }}

--- a/centralenduserregistry/templates/_helpers.tpl
+++ b/centralenduserregistry/templates/_helpers.tpl
@@ -14,3 +14,20 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+
+{{- define "centralenduserregistry.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "centralenduserregistry.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/centralenduserregistry/templates/deployment.yaml
+++ b/centralenduserregistry/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $dbHost := printf "%s-%s" .Release.Name .Values.postgresql.nameOverride -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "centralenduserregistry.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "centralenduserregistry.fullname" . }}

--- a/centralenduserregistry/templates/ingress.yaml
+++ b/centralenduserregistry/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "centralenduserregistry.fullname" . -}}
 {{- $servicePort := .Values.service.ports.api.externalPort -}}
 {{- $servicePath := .Values.ingress.externalPath -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "centralenduserregistry.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "centralenduserregistry.fullname" . }}

--- a/centraleventprocessor/requirements.yaml
+++ b/centraleventprocessor/requirements.yaml
@@ -1,12 +1,12 @@
 # requirements.yaml
 dependencies:
 # - name: kafka
-#   version: 0.7.2
+#   version: 0.21.2
 #   repository: http://storage.googleapis.com/kubernetes-charts-incubator
 #   alias: kafka
 #   condition: kafka.enabled
 - name: mongodb
-  version: 4.9.0
+  version: 7.8.10
   repository: https://kubernetes-charts.storage.googleapis.com/
   alias: mongodb
   condition: mongodb.enabled

--- a/centraleventprocessor/templates/_helpers.tpl
+++ b/centraleventprocessor/templates/_helpers.tpl
@@ -14,3 +14,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "centraleventprocessor.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "centraleventprocessor.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/centraleventprocessor/templates/deployment.yaml
+++ b/centraleventprocessor/templates/deployment.yaml
@@ -1,7 +1,6 @@
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
 {{- $mongodbHost := ( .Values.config.mongo_host | replace "$release_name" .Release.Name ) -}}
-
-apiVersion: apps/v1beta2
+apiVersion: {{ template "centraleventprocessor.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ include "centraleventprocessor.fullname" . }}

--- a/centraleventprocessor/templates/ingress.yaml
+++ b/centraleventprocessor/templates/ingress.yaml
@@ -4,8 +4,7 @@
 {{- $serviceName := include "centraleventprocessor.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $servicePath := .Values.ingress.externalPath -}}
-
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "centraleventprocessor.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/centraleventprocessor/values.yaml
+++ b/centraleventprocessor/values.yaml
@@ -143,8 +143,9 @@ config:
 #   ## The kafka image repository
 #   image: "confluentinc/cp-kafka"
 
+
 #   ## The kafka image tag
-#   imageTag: "4.0.1-1"
+#   imageTag: "5.0.1"
 
 #   ## Specify a imagePullPolicy
 #   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -475,7 +476,7 @@ mongodb:
     ## Bitnami MongoDB image tag
     ## ref: https://hub.docker.com/r/bitnami/mongodb/tags/
     ##
-    tag: 4.0.3
+    tag: 4.2.4-debian-10-r0
 
     ## Specify a imagePullPolicy
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/centralkms/templates/_helpers.tpl
+++ b/centralkms/templates/_helpers.tpl
@@ -25,3 +25,18 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "centralkms.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "centralkms.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/centralkms/templates/deployment.yaml
+++ b/centralkms/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $dbHost := printf "%s-%s" .Release.Name .Values.postgresql.nameOverride -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "centralkms.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "centralkms.fullname" . }}

--- a/centralkms/templates/ingress.yaml
+++ b/centralkms/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "centralkms.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $servicePath := .Values.ingress.externalPath -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "centralkms.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "centralkms.fullname" . }}

--- a/centralledger/chart-handler-admin-transfer/templates/_helpers.tpl
+++ b/centralledger/chart-handler-admin-transfer/templates/_helpers.tpl
@@ -14,3 +14,20 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+
+{{- define "centralledger-handler-admin-transfer.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "centralledger-handler-admin-transfer.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/centralledger/chart-handler-admin-transfer/templates/deployment.yaml
+++ b/centralledger/chart-handler-admin-transfer/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
-apiVersion: apps/v1
+apiVersion: {{ template "centralledger-handler-admin-transfer.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "centralledger-handler-admin-transfer.fullname" . }}

--- a/centralledger/chart-handler-admin-transfer/templates/ingress.yaml
+++ b/centralledger/chart-handler-admin-transfer/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "centralledger-handler-admin-transfer.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "centralledger-handler-admin-transfer.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "centralledger-handler-admin-transfer.fullname" . }}

--- a/centralledger/chart-handler-timeout/templates/_helpers.tpl
+++ b/centralledger/chart-handler-timeout/templates/_helpers.tpl
@@ -14,3 +14,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "centralledger-handler-timeout.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "centralledger-handler-timeout.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/centralledger/chart-handler-timeout/templates/deployment.yaml
+++ b/centralledger/chart-handler-timeout/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
-apiVersion: apps/v1
+apiVersion: {{ template "centralledger-handler-timeout.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "centralledger-handler-timeout.fullname" . }}

--- a/centralledger/chart-handler-timeout/templates/ingress.yaml
+++ b/centralledger/chart-handler-timeout/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "centralledger-handler-timeout.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "centralledger-handler-timeout.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "centralledger-handler-timeout.fullname" . }}

--- a/centralledger/chart-handler-transfer-fulfil/templates/_helpers.tpl
+++ b/centralledger/chart-handler-transfer-fulfil/templates/_helpers.tpl
@@ -14,3 +14,20 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+
+{{- define "centralledger-handler-transfer-fulfil.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "centralledger-handler-transfer-fulfil.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/centralledger/chart-handler-transfer-fulfil/templates/deployment.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
-apiVersion: apps/v1
+apiVersion: {{ template "centralledger-handler-transfer-fulfil.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "centralledger-handler-transfer-fulfil.fullname" . }}

--- a/centralledger/chart-handler-transfer-fulfil/templates/ingress.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "centralledger-handler-transfer-fulfil.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "centralledger-handler-transfer-fulfil.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "centralledger-handler-transfer-fulfil.fullname" . }}

--- a/centralledger/chart-handler-transfer-get/templates/_helpers.tpl
+++ b/centralledger/chart-handler-transfer-get/templates/_helpers.tpl
@@ -14,3 +14,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "centralledger-handler-transfer-get.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "centralledger-handler-transfer-get.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/centralledger/chart-handler-transfer-get/templates/deployment.yaml
+++ b/centralledger/chart-handler-transfer-get/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
-apiVersion: apps/v1
+apiVersion: {{ template "centralledger-handler-transfer-get.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "centralledger-handler-transfer-get.fullname" . }}

--- a/centralledger/chart-handler-transfer-get/templates/ingress.yaml
+++ b/centralledger/chart-handler-transfer-get/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "centralledger-handler-transfer-get.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "centralledger-handler-transfer-get.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "centralledger-handler-transfer-get.fullname" . }}

--- a/centralledger/chart-handler-transfer-position/templates/_helpers.tpl
+++ b/centralledger/chart-handler-transfer-position/templates/_helpers.tpl
@@ -14,3 +14,20 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+
+{{- define "centralledger-handler-transfer-position.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "centralledger-handler-transfer-position.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/centralledger/chart-handler-transfer-position/templates/deployment.yaml
+++ b/centralledger/chart-handler-transfer-position/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
-apiVersion: apps/v1
+apiVersion: {{ template "centralledger-handler-transfer-position.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "centralledger-handler-transfer-position.fullname" . }}

--- a/centralledger/chart-handler-transfer-position/templates/ingress.yaml
+++ b/centralledger/chart-handler-transfer-position/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "centralledger-handler-transfer-position.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "centralledger-handler-transfer-position.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "centralledger-handler-transfer-position.fullname" . }}

--- a/centralledger/chart-handler-transfer-prepare/templates/_helpers.tpl
+++ b/centralledger/chart-handler-transfer-prepare/templates/_helpers.tpl
@@ -14,3 +14,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "centralledger-handler-transfer-prepare.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "centralledger-handler-transfer-prepare.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/centralledger/chart-handler-transfer-prepare/templates/deployment.yaml
+++ b/centralledger/chart-handler-transfer-prepare/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
-apiVersion: apps/v1
+apiVersion: {{ template "centralledger-handler-transfer-prepare.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "centralledger-handler-transfer-prepare.fullname" . }}

--- a/centralledger/chart-handler-transfer-prepare/templates/ingress.yaml
+++ b/centralledger/chart-handler-transfer-prepare/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "centralledger-handler-transfer-prepare.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "centralledger-handler-transfer-prepare.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "centralledger-handler-transfer-prepare.fullname" . }}

--- a/centralledger/chart-service/templates/_helpers.tpl
+++ b/centralledger/chart-service/templates/_helpers.tpl
@@ -14,3 +14,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "centralledger-service.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "centralledger-service.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/centralledger/chart-service/templates/deployment.yaml
+++ b/centralledger/chart-service/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
-apiVersion: apps/v1
+apiVersion: {{ template "centralledger-service.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "centralledger-service.fullname" . }}

--- a/centralledger/chart-service/templates/ingress.yaml
+++ b/centralledger/chart-service/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "centralledger-service.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "centralledger-service.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "centralledger-service.fullname" . }}

--- a/centralledger/requirements.yaml
+++ b/centralledger/requirements.yaml
@@ -28,7 +28,6 @@ dependencies:
   version: 10.4.0
   repository: "file://./chart-handler-admin-transfer"
   condition: centralledger-handler-transfer-get.enabled
-
 #- name: forensicloggingsidecar
 #  version: 2.4.0
 #  repository: "file://../forensicloggingsidecar"
@@ -38,12 +37,12 @@ dependencies:
 #  repository: https://kubernetes-charts.storage.googleapis.com/
 #  condition: postgresql.enabled
 - name: percona-xtradb-cluster
-  version: 1.0.1
+  version: 1.0.4
   repository: https://kubernetes-charts.storage.googleapis.com
   alias: mysql
   condition: mysql.enabled
 - name: kafka
-  version: 0.13.11
+  version: 0.21.2
   repository: http://storage.googleapis.com/kubernetes-charts-incubator
   alias: kafka
   condition: kafka.enabled

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -1553,6 +1553,8 @@ mysql:
   metricsExporter:
     enabled: true
     tag: v0.11.0
+    commandOverrides: []
+    argsOverrides: []
 
   ## When set to true will create sidecar to tail mysql log
   logTail: true

--- a/centralsettlement/templates/_helpers.tpl
+++ b/centralsettlement/templates/_helpers.tpl
@@ -14,3 +14,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "centralsettlement.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "centralsettlement.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/centralsettlement/templates/deployment.yaml
+++ b/centralsettlement/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "centralsettlement.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "centralsettlement.fullname" . }}

--- a/centralsettlement/templates/ingress.yaml
+++ b/centralsettlement/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "centralsettlement.fullname" . -}}
 {{- $servicePort := .Values.service.ports.api.externalPort -}}
 {{- $servicePath := .Values.ingress.externalPath -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "centralsettlement.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "centralsettlement.fullname" . }}

--- a/emailnotifier/templates/_helpers.tpl
+++ b/emailnotifier/templates/_helpers.tpl
@@ -14,3 +14,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "emailnotifier.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "emailnotifier.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/emailnotifier/templates/deployment.yaml
+++ b/emailnotifier/templates/deployment.yaml
@@ -1,6 +1,5 @@
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
-
-apiVersion: apps/v1beta2
+apiVersion: {{ template "emailnotifier.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ include "emailnotifier.fullname" . }}

--- a/emailnotifier/templates/ingress.yaml
+++ b/emailnotifier/templates/ingress.yaml
@@ -4,8 +4,7 @@
 {{- $serviceName := include "emailnotifier.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $servicePath := .Values.ingress.externalPath -}}
-
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "emailnotifier.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/eventstreamprocessor/templates/_helpers.tpl
+++ b/eventstreamprocessor/templates/_helpers.tpl
@@ -14,3 +14,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "eventstreamprocessor.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "eventstreamprocessor.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/eventstreamprocessor/templates/deployment.yaml
+++ b/eventstreamprocessor/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
-apiVersion: apps/v1beta2
+apiVersion: {{ template "eventstreamprocessor.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ include "eventstreamprocessor.fullname" . }}

--- a/eventstreamprocessor/templates/ingress.yaml
+++ b/eventstreamprocessor/templates/ingress.yaml
@@ -4,8 +4,7 @@
 {{- $serviceName := include "eventstreamprocessor.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $servicePath := .Values.ingress.externalPath -}}
-
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "eventstreamprocessor.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/finance-portal-settlement-management/templates/_helpers.tpl
+++ b/finance-portal-settlement-management/templates/_helpers.tpl
@@ -30,3 +30,19 @@ Create chart name and version as used by the chart label.
 {{- define "finance-portal-settlement-management.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "finance-portal-settlement-management.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "finance-portal-settlement-management.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/finance-portal-settlement-management/templates/deployment.yaml
+++ b/finance-portal-settlement-management/templates/deployment.yaml
@@ -1,6 +1,5 @@
 {{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
-
-apiVersion: apps/v1beta1
+apiVersion: {{ template "finance-portal-settlement-management.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "finance-portal-settlement-management.fullname" . }}

--- a/finance-portal-settlement-management/templates/operator-settlement-ingress.yaml
+++ b/finance-portal-settlement-management/templates/operator-settlement-ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "finance-portal-settlement-management.fullname" . -}}
 {{- $operatorSettlementPort := .Values.operatorSettlement.service.port -}}
 {{- $operatorSettlementPath := .Values.operatorSettlement.ingress.externalPath -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "finance-portal-settlement-management.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "finance-portal-settlement-management.fullname" . }}-operator-settlement

--- a/finance-portal-settlement-management/templates/settlement-management-ingress.yaml
+++ b/finance-portal-settlement-management/templates/settlement-management-ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "finance-portal-settlement-management.fullname" . -}}
 {{- $settlementManagementPort := .Values.settlementManagement.service.port -}}
 {{- $settlementManagementPath := .Values.settlementManagement.ingress.externalPath -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "finance-portal-settlement-management.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "finance-portal-settlement-management.fullname" . }}-settlement-management

--- a/finance-portal/templates/_helpers.tpl
+++ b/finance-portal/templates/_helpers.tpl
@@ -30,3 +30,19 @@ Create chart name and version as used by the chart label.
 {{- define "finance-portal.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "finance-portal.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "finance-portal.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/finance-portal/templates/backend-ingress.yaml
+++ b/finance-portal/templates/backend-ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "finance-portal.fullname" . -}}
 {{- $backendPort := .Values.backend.service.port -}}
 {{- $backendPath := .Values.backend.ingress.externalPath -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "finance-portal.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "finance-portal.fullname" . }}-backend

--- a/finance-portal/templates/deployment.yaml
+++ b/finance-portal/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
-apiVersion: apps/v1beta1
+apiVersion: {{ template "finance-portal.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "finance-portal.fullname" . }}

--- a/finance-portal/templates/frontend-ingress.yaml
+++ b/finance-portal/templates/frontend-ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "finance-portal.fullname" . -}}
 {{- $frontendPort := .Values.frontend.service.port -}}
 {{- $frontendPath := .Values.frontend.ingress.externalPath -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "finance-portal.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "finance-portal.fullname" . }}-frontend

--- a/forensicloggingsidecar/templates/_helpers.tpl
+++ b/forensicloggingsidecar/templates/_helpers.tpl
@@ -15,3 +15,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "forensicloggingsidecar.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "finance-portal-settlement-management.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/forensicloggingsidecar/templates/deployment.yaml
+++ b/forensicloggingsidecar/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $dbHost := printf "%s-%s" .Release.Name .Values.postgresql.nameOverride -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "forensicloggingsidecar.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "forensicloggingsidecar.fullname" . }}

--- a/forensicloggingsidecar/templates/ingress.yaml
+++ b/forensicloggingsidecar/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "centralkms.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $servicePath := .Values.ingress.externalPath -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "forensicloggingsidecar.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "forensicloggingsidecar.fullname" . }}

--- a/kube-public/ingress-nginx/templates/_helpers.tpl
+++ b/kube-public/ingress-nginx/templates/_helpers.tpl
@@ -14,3 +14,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "nginx-ingress.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "nginx-ingress.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/kube-system/ntpd/templates/_helpers.tpl
+++ b/kube-system/ntpd/templates/_helpers.tpl
@@ -46,3 +46,11 @@ Create chart name and version as used by the chart label.
     {{- print "extensions/v1beta1" -}}
   {{- end -}}
 {{- end -}}
+
+{{- define "ntpd.apiVersion.DaemonSet" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/DaemonSet" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}

--- a/kube-system/ntpd/templates/_helpers.tpl
+++ b/kube-system/ntpd/templates/_helpers.tpl
@@ -30,3 +30,19 @@ Create chart name and version as used by the chart label.
 {{- define "ntpd.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "ntpd.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "ntpd.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/kube-system/ntpd/templates/deployment.yaml
+++ b/kube-system/ntpd/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: {{ template "ntpd.apiVersion.DaemonSet" . }}
 kind: DaemonSet
 metadata:
   name: {{ template "ntpd.fullname" . }}

--- a/ml-api-adapter/chart-handler-notification/templates/_helpers.tpl
+++ b/ml-api-adapter/chart-handler-notification/templates/_helpers.tpl
@@ -14,3 +14,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "ml-api-adapter-handler-notification.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "ml-api-adapter-handler-notification.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/ml-api-adapter/chart-handler-notification/templates/deployment.yaml
+++ b/ml-api-adapter/chart-handler-notification/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
-apiVersion: apps/v1
+apiVersion: {{ template "ml-api-adapter-handler-notification.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "ml-api-adapter-handler-notification.fullname" . }}

--- a/ml-api-adapter/chart-handler-notification/templates/ingress.yaml
+++ b/ml-api-adapter/chart-handler-notification/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "ml-api-adapter-handler-notification.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $servicePath := .Values.ingress.externalPath -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "ml-api-adapter-handler-notification.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "ml-api-adapter-handler-notification.fullname" . }}

--- a/ml-api-adapter/chart-service/templates/_helpers.tpl
+++ b/ml-api-adapter/chart-service/templates/_helpers.tpl
@@ -14,3 +14,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "ml-api-adapter-service.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "ml-api-adapter-service.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/ml-api-adapter/chart-service/templates/deployment.yaml
+++ b/ml-api-adapter/chart-service/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $kafkaHost := ( .Values.config.kafka_host | replace "$release_name" .Release.Name ) -}}
-apiVersion: apps/v1
+apiVersion: {{ template "ml-api-adapter-service.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "ml-api-adapter-service.fullname" . }}

--- a/ml-api-adapter/chart-service/templates/ingress.yaml
+++ b/ml-api-adapter/chart-service/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "ml-api-adapter-service.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $servicePath := .Values.ingress.externalPath -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "ml-api-adapter-service.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "ml-api-adapter-service.fullname" . }}

--- a/ml-testing-toolkit/chart-backend/templates/_helpers.tpl
+++ b/ml-testing-toolkit/chart-backend/templates/_helpers.tpl
@@ -14,3 +14,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "ml-testing-toolkit-backend.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "ml-testing-toolkit-backend.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/ml-testing-toolkit/chart-backend/templates/_helpers.tpl
+++ b/ml-testing-toolkit/chart-backend/templates/_helpers.tpl
@@ -30,3 +30,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
     {{- print "extensions/v1beta1" -}}
   {{- end -}}
 {{- end -}}
+
+{{- define "ml-testing-toolkit-backend.apiVersion.StatefulSet" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/StatefulSet" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}

--- a/ml-testing-toolkit/chart-backend/templates/ingress.yaml
+++ b/ml-testing-toolkit/chart-backend/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceFullName := include "ml-testing-toolkit-backend.fullname" . -}}
 {{- $serviceRef := .Values.service -}}
 {{- $servicePath := .Values.ingress.externalPath -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "ml-testing-toolkit-backend.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "ml-testing-toolkit-backend.fullname" . }}

--- a/ml-testing-toolkit/chart-backend/templates/statefulset.yaml
+++ b/ml-testing-toolkit/chart-backend/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- $serviceFullName := include "ml-testing-toolkit-backend.fullname" . -}}
-apiVersion: apps/v1beta2
+apiVersion: {{ template "ml-testing-toolkit-backend.apiVersion.StatefulSet" . }}
 kind: StatefulSet
 metadata:
   name: {{ template "ml-testing-toolkit-backend.fullname" . }}

--- a/ml-testing-toolkit/chart-frontend/templates/_helpers.tpl
+++ b/ml-testing-toolkit/chart-frontend/templates/_helpers.tpl
@@ -14,3 +14,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "ml-testing-toolkit-frontend.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "ml-testing-toolkit-frontend.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/ml-testing-toolkit/chart-frontend/templates/deployment.yaml
+++ b/ml-testing-toolkit/chart-frontend/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: {{ template "ml-testing-toolkit-frontend.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "ml-testing-toolkit-frontend.fullname" . }}

--- a/ml-testing-toolkit/chart-frontend/templates/ingress.yaml
+++ b/ml-testing-toolkit/chart-frontend/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceFullName := include "ml-testing-toolkit-frontend.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $servicePath := .Values.ingress.externalPath -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "ml-testing-toolkit-frontend.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "ml-testing-toolkit-frontend.fullname" . }}

--- a/mojaloop-bulk/requirements.yaml
+++ b/mojaloop-bulk/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   repository: "file://../bulk-centralledger"
   condition: bulk-centralledger.enabled
 - name: mongodb
-  version: 4.9.0
+  version: 7.8.10
   repository: https://kubernetes-charts.storage.googleapis.com/
   alias: mongodb
   condition: mongodb.enabled

--- a/mojaloop-bulk/values.yaml
+++ b/mojaloop-bulk/values.yaml
@@ -758,7 +758,7 @@ mongodb:
     ## Bitnami MongoDB image tag
     ## ref: https://hub.docker.com/r/bitnami/mongodb/tags/
     ##
-    tag: 4.0.3
+    tag: 4.2.4-debian-10-r0
 
     ## Specify a imagePullPolicy
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/mojaloop-simulator/templates/_helpers.tpl
+++ b/mojaloop-simulator/templates/_helpers.tpl
@@ -51,3 +51,19 @@ the init container afterward.
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "mojaloop-simulator.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "mojaloop-simulator.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/mojaloop-simulator/templates/deployment.yaml
+++ b/mojaloop-simulator/templates/deployment.yaml
@@ -3,7 +3,7 @@
 {{- $fullName := printf "%s%s" $prefix $name }}
 {{- $config := merge $customConfig $.Values.defaults }}
 {{- $initContainerEnv := dict "SIM_NAME" $name "SIM_SCHEME_ADAPTER_SERVICE_NAME" (printf "sim-%s-scheme-adapter" $name) "SIM_BACKEND_SERVICE_NAME" (printf "sim-%s-backend" $name) "SIM_CACHE_SERVICE_NAME" (printf "sim-%s-cache" $name) -}}
-apiVersion: apps/v1
+apiVersion: {{ template "mojaloop-simulator.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ $fullName }}-scheme-adapter
@@ -138,7 +138,7 @@ spec:
     {{- end }}
 
 ---
-apiVersion: apps/v1
+apiVersion: {{ template "mojaloop-simulator.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ $fullName }}-backend
@@ -229,7 +229,7 @@ spec:
     {{- end }}
 ---
 {{- if $config.config.cache.enabled }}
-apiVersion: apps/v1
+apiVersion: {{ template "mojaloop-simulator.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ $fullName }}-cache

--- a/mojaloop-simulator/templates/ingress.yaml
+++ b/mojaloop-simulator/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.simulators }}
 {{- $prefix := include "mojaloop-simulator.prefix" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "mojaloop-simulator.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ $prefix }}simulators

--- a/quoting-service/templates/_helpers.tpl
+++ b/quoting-service/templates/_helpers.tpl
@@ -14,3 +14,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "quotingservice.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "quotingservice.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/quoting-service/templates/deployment.yaml
+++ b/quoting-service/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $dbHost := ( .Values.config.db_host | replace "$release_name" .Release.Name ) -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "quotingservice.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "quotingservice.fullname" . }}

--- a/quoting-service/templates/ingress.yaml
+++ b/quoting-service/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "quotingservice.fullname" . -}}
 {{- $servicePort := .Values.service.ports.api.externalPort -}}
 {{- $servicePath := .Values.ingress.externalPath -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "quotingservice.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "quotingservice.fullname" . }}

--- a/simulator/templates/_helpers.tpl
+++ b/simulator/templates/_helpers.tpl
@@ -30,3 +30,19 @@ Create chart name and version as used by the chart label.
 {{- define "simulator.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "simulator.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "simulator.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/simulator/templates/deployment.yaml
+++ b/simulator/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: {{ template "simulator.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "simulator.fullname" . }}

--- a/simulator/templates/ingress.yaml
+++ b/simulator/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "simulator.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "simulator.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/transaction-requests-service/templates/_helpers.tpl
+++ b/transaction-requests-service/templates/_helpers.tpl
@@ -14,3 +14,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "transaction-requests-service.apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "transaction-requests-service.apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/transaction-requests-service/templates/deployment.yaml
+++ b/transaction-requests-service/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "transaction-requests-service.apiVersion.Deployment" . }}
 kind: Deployment
 metadata:
   name: {{ template "transaction-requests-service.fullname" . }}

--- a/transaction-requests-service/templates/ingress.yaml
+++ b/transaction-requests-service/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "transaction-requests-service.fullname" . -}}
 {{- $servicePort := .Values.service.ports.api.externalPort -}}
 {{- $servicePath := .Values.ingress.externalPath -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "transaction-requests-service.apiVersion.Ingress" . }}
 kind: Ingress
 metadata:
   name: {{ template "transaction-requests-service.fullname" . }}

--- a/update-charts-dep.sh
+++ b/update-charts-dep.sh
@@ -36,6 +36,7 @@ declare -a charts=(
     bulk-api-adapter
     mojaloop-bulk
     mojaloop-simulator
+    ml-testing-toolkit
     mojaloop
 )
 


### PR DESCRIPTION
Update Helm charts to support Kubernetes deployments 1.15 and later versions #1463: https://github.com/mojaloop/project/issues/1463
- Added template functions to helpers in all used charts to determine the correct capability for Ingress, Deployments, and StatefulSets
- Updated apiVersion mappings to call template function helpers to set the appropriate apiVersion

