### PR TITLE
Added the option to pass a template as the rules.json

### DIFF
--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -17,7 +17,7 @@ dependencies:
   repository: "file://../account-lookup-service"
   condition: account-lookup-service.enabled
 - name: quoting-service
-  version: 10.4.0
+  version: 10.4.1
   repository: "file://../quoting-service"
   condition: quoting-service.enabled
 - name: simulator

--- a/quoting-service/Chart.yaml
+++ b/quoting-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Quoting-Service Helm chart for Kubernetes
 name: quoting-service
-version: 10.4.0
+version: 10.4.1
 appVersion: "10.5.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png

--- a/quoting-service/templates/config.yaml
+++ b/quoting-service/templates/config.yaml
@@ -14,7 +14,6 @@ data:
   {{- if (typeIs "string" .Values.rules.template) }}
   rules.json: {{ (tpl .Values.rules.template . ) }}
   {{- else if (typeIs "string" .Values.rules) }}
-  {{- if (typeIs "string" .Values.rules) }}
   rules.json: {{ .Values.rules | quote }}
   {{- else }}
   rules.json: {{ .Values.rules | toPrettyJson | quote }}

--- a/quoting-service/templates/config.yaml
+++ b/quoting-service/templates/config.yaml
@@ -11,6 +11,9 @@ metadata:
 data:
   default.json: {{ (tpl (.Files.Get "configs/default.json") . ) | quote }}
   {{- if .Values.rules }}
+  {{- if (typeIs "string" .Values.rules.template) }}
+  rules.json: {{ (tpl .Values.rules.template . ) }}
+  {{- else if (typeIs "string" .Values.rules) }}
   {{- if (typeIs "string" .Values.rules) }}
   rules.json: {{ .Values.rules | quote }}
   {{- else }}
@@ -19,7 +22,7 @@ data:
   {{- else }}
   rules.json: "[]"
   {{- end }}
-  
+
 {{- if .Values.sidecar.enabled }}
 ---
 apiVersion: v1


### PR DESCRIPTION
With this addition the user of this chart can pass the rules as a helm template file and then consume it like this: `helm template . --set-file mojaloop.quoting-service.rules.template=<PATH-TO-RULES-FILE>`