### PR TITLE
Package development versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,8 @@ jobs:
             echo 'export GITHUB_TAG=$CIRCLE_TAG' >> $BASH_ENV
             echo 'export GIT_CI_USER=$GIT_CI_USER' >> $BASH_ENV
             echo 'export GIT_CI_EMAIL=$GIT_CI_EMAIL' >> $BASH_ENV
+            echo 'export GIT_SHA1=$CIRCLE_SHA1' >> $BASH_ENV
+            echo 'export BUILD_NUM=$CIRCLE_BUILD_NUM' >> $BASH_ENV
       - run:
           <<: *defaults_git_identity_setup
       - run:
@@ -231,5 +233,5 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
             branches:
-              ignore:
-                - /.*/
+              only:
+                - master

--- a/package.sh
+++ b/package.sh
@@ -1,141 +1,75 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -ex
 
 LOCAL_HELM_MOJALOOP_REPO_URI=${HELM_MOJALOOP_REPO_URI:-'https://docs.mojaloop.io/helm/repo'}
 
 #
-# Script to Package all charts, and created an index.yaml in ./repo directory
+# Script to Package all charts, and create an index.yaml in ./repo directory
 #
 
-# Function to check the last command's result exited with a value of 0, otherwise the script will exit with a 1
-function checkCommandResult () {
-    if [ $? -eq 0 ]; then
-        echo ""
-    else
-        echo "Command failed...exiting. Please fix me!";
-        exit 1
-    fi
-}
+trap 'echo "Command failed...exiting. Please fix me!"' ERR
 
 echo "Removing old charts..."
 find ./ -name "charts"| xargs rm -Rf
 
 mkdir ./repo
 
-echo "Updating Event Stream Processor..."
-helm package -u -d ./repo ./eventstreamprocessor
-checkCommandResult
+declare -a charts=(
+    eventstreamprocessor
+    simulator
+    monitoring/promfana
+    monitoring/efk
+    account-lookup-service
+    als-oracle-pathfinder
+    centralkms
+    forensicloggingsidecar
+    centralledger
+    centralenduserregistry
+    centralsettlement
+    emailnotifier
+    centraleventprocessor
+    central
+    ml-api-adapter
+    quoting-service
+    finance-portal
+    finance-portal-settlement-management
+    transaction-requests-service
+    bulk-centralledger/
+    bulk-api-adapter/
+    mojaloop-bulk/
+    mojaloop
+    kube-public/ingress-nginx/
+    kube-system/ntpd/
+    mojaloop-simulator
+    ml-testing-toolkit
+)
 
-echo "Packaging Simulator..."
-helm package -u -d ./repo ./simulator
-checkCommandResult
-
-echo "Packaging Promfana..."
-helm package -u -d ./repo ./monitoring/promfana
-checkCommandResult
-
-echo "Packaging EFK..."
-helm package -u -d ./repo ./monitoring/efk
-checkCommandResult
-
-echo "Packaging Account Lookup Service..."
-helm package -u -d ./repo  ./account-lookup-service
-checkCommandResult
-
-echo "Packaging ALS Oracle Pathfinder..."
-helm package -u -d ./repo  ./als-oracle-pathfinder
-checkCommandResult
-
-echo "Packaging Central-KMS..."
-helm package -u -d ./repo ./centralkms
-checkCommandResult
-
-echo "Packaging Forensic Logging Sidecar..."
-helm package -u -d ./repo ./forensicloggingsidecar
-checkCommandResult
-
-echo "Packaging Central-Ledger..."
-helm package -u -d ./repo ./centralledger
-checkCommandResult
-
-
-echo "Packaging Central-End-User-Registry..."
-helm package -u -d ./repo ./centralenduserregistry
-checkCommandResult
-
-echo "Packaging Central-Settlement..."
-helm package -u -d ./repo ./centralsettlement
-checkCommandResult
-
-echo "Packaging Email Notifier..."
-helm package -u -d ./repo ./emailnotifier
-checkCommandResult
-
-echo "Packaging Central Event Processor..."
-helm package -u -d ./repo ./centraleventprocessor
-checkCommandResult
-
-echo "Packaging Central..."
-helm package -u -d ./repo ./central
-checkCommandResult
-
-echo "Packaging ml-api-adapter..."
-helm package -u -d ./repo ./ml-api-adapter
-checkCommandResult
-
-echo "Packaging quoting-service..."
-helm package -u -d ./repo ./quoting-service
-checkCommandResult
-
-echo "Packaging finance-portal..."
-helm package -u -d ./repo ./finance-portal
-checkCommandResult
-
-echo "Packaging finance-portal-settlement-management..."
-helm package -u -d ./repo ./finance-portal-settlement-management
-checkCommandResult
-
-echo "Packaging transaction-requests-service..."
-helm package -u -d ./repo ./transaction-requests-service
-checkCommandResult
-
-echo "Updating bulk-centralledger..."
-helm package -u -d ./repo ./bulk-centralledger/
-checkCommandResult
-
-echo "Updating bulk-api-adapter..."
-helm package -u -d ./repo ./bulk-api-adapter/
-checkCommandResult
-
-echo "Updating Mojaloop Bulk..."
-helm package -u -d ./repo ./mojaloop-bulk/
-checkCommandResult
-
-echo "Packaging Mojaloop..."
-helm package -u -d ./repo ./mojaloop
-checkCommandResult
-
-echo "Packaging Ingress-Nginx..."
-helm package -u -d ./repo ./kube-public/ingress-nginx/
-checkCommandResult
-
-echo "Packaging ntpd..."
-helm package -u -d ./repo ./kube-system/ntpd/
-checkCommandResult
-
-echo "Packaging Mojaloop Simulator..."
-helm package -u -d ./repo ./mojaloop-simulator
-checkCommandResult
-
-echo "Packaging Mojaloop Testing Toolkit..."
-helm package -u -d ./repo ./ml-testing-toolkit
-checkCommandResult
-
+for chart in "${charts[@]}"
+do
+    if [ -z $GITHUB_TAG ]; then
+        set -u
+        # When $GITHUB_TAG is not present, we'll build a development version. This versioning
+        # scheme, utilising the incrementing "BUILD_NUM" means users can request the latest
+        # development version using the --devel argument to `helm upgrade` or `helm install`.
+        # Development versions can be found with `helm search --devel`. Additionally, it is
+        # possible to specify a development version in requirements.yaml.
+        CURRENT_VERSION=$(grep '^version: [0-9]\+\.[0-9]\+\.[0-9]\+\s*$' "$chart/Chart.yaml" | cut -d' ' -f2)
+        NEW_VERSION="$CURRENT_VERSION-$BUILD_NUM.$GIT_SHA1"
+        helm package -u -d ./repo "$chart" --version="$NEW_VERSION"
+        set +u
+    else
+        # When $GITHUB_TAG is present, we're actually releasing the chart- so we won't modify any
+        # versions
+        helm package -u -d ./repo "$chart"
+    fi
+done
 
 cd ./repo
 
-echo "Creating Helm repo index for '$LOCAL_HELM_MOJALOOP_REPO_URI'..."
 helm repo index . --url $LOCAL_HELM_MOJALOOP_REPO_URI
-checkCommandResult
+
+set +x
 
 echo "\
 Packaging completed.\n \

--- a/update-charts-dep.sh
+++ b/update-charts-dep.sh
@@ -4,7 +4,7 @@
 # Script to update all Helm Chart Dependencies
 #
 
-set -e
+set -eux
 
 trap 'echo "Dep update failed...exiting. Please fix me!"' ERR
 
@@ -12,7 +12,6 @@ echo "Removing old charts..."
 find ./ -name "charts"| xargs rm -Rf
 find ./ -name "tmpcharts"| xargs rm -Rf
 
-echo "Updating all Charts..."
 declare -a charts=(
     eventstreamprocessor
     monitoring/promfana
@@ -39,11 +38,13 @@ declare -a charts=(
     mojaloop
 )
 
+echo "Updating all Charts..."
 for chart in "${charts[@]}"
 do
-    echo "Updating $chart"
     helm dep up "$chart"
 done
+
+set +x
 
 echo "\
 Chart updates completed.\n \


### PR DESCRIPTION
This will publish a development version of each chart on every commit to master.

* A release/tag will still package and publish as previously- no change there.
* When a user installs the latest version of the chart, they will receive the latest _released_ version.
* Users can provide the `--devel` argument to `helm upgrade` `helm install` or `helm search` to receive development versions.
* It is possible to request development versions in requirements.yaml.
* Development versions are identified with semver using a suffix -x.y.z. See for more: https://helm.sh/docs/topics/charts/#charts-and-versioning