### PR TITLE
fix(ci): slack announcement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,24 +211,23 @@ workflows:
                 - /feature.*/
                 - /bugfix.*/
                 - gh-pages
-      # TODO: reenable
-      # - audit-licenses:
-      #     context: org-global
-      #     requires:
-      #       - setup
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      #       branches:
-      #         ignore:
-      #           - /feature.*/
-      #           - /bugfix.*/
-      #           - gh-pages
+      - audit-licenses:
+          context: org-global
+          requires:
+            - setup
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore:
+                - /feature.*/
+                - /bugfix.*/
+                - gh-pages
       - build:
           context: org-global
           requires:
             - test
-            # - audit-licenses
+            - audit-licenses
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,32 +45,6 @@ defaults_Environment: &defaults_environment
     helm repo add kiwigrid https://kiwigrid.github.io
     helm repo add elastic https://helm.elastic.co
 
-defaults_slack_announcement: &defaults_slack_announcement
-  name: Slack announcement for tag releases
-  command: |
-    curl -X POST \
-      $SLACK_WEBHOOK_ANNOUNCEMENT \
-      -H 'Content-type: application/json' \
-      -H 'cache-control: no-cache' \
-      -d "{
-      \"text\": \"*${CIRCLE_PROJECT_REPONAME}* - Release \`${CIRCLE_TAG}\`: https://github.com/mojaloop/${CIRCLE_PROJECT_REPONAME}/releases/tag/${CIRCLE_TAG}\"
-    }"
-
-defaults_git_identity_setup: &defaults_git_identity_setup
-  name: Setup Git Identity
-  command: |
-    echo "Setting BASH_ENV..."
-    source $BASH_ENV
-
-    git config --global user.email "$GIT_CI_USER"
-    git config --global user.password "$GIT_CI_PASSWORD"
-    git config --global user.name "$GIT_CI_EMAIL"
-    git remote add $GITHUB_PROJECT_USERNAME https://$GIT_CI_USER:$GITHUB_TOKEN@github.com/$GITHUB_PROJECT_USERNAME/$GITHUB_PROJECT_REPONAME.git
-
-defaults_publish: &defaults_publish
-  name: Publish helm charts
-  command: bash $CIRCLE_WORKING_DIRECTORY/.circleci/publish_helm_charts.sh
-
 ##
 # Executors
 #
@@ -188,11 +162,21 @@ jobs:
             echo 'export GIT_SHA1=$CIRCLE_SHA1' >> $BASH_ENV
             echo 'export BUILD_NUM=$CIRCLE_BUILD_NUM' >> $BASH_ENV
       - run:
-          <<: *defaults_git_identity_setup
+          name: Setup Git Identity
+          command: |
+            echo "Setting BASH_ENV..."
+            source $BASH_ENV
+            
+            git config --global user.email "$GIT_CI_USER"
+            git config --global user.password "$GIT_CI_PASSWORD"
+            git config --global user.name "$GIT_CI_EMAIL"
+            git remote add $GITHUB_PROJECT_USERNAME https://$GIT_CI_USER:$GITHUB_TOKEN@github.com/$GITHUB_PROJECT_USERNAME/$GITHUB_PROJECT_REPONAME.git
       - run:
-          <<: *defaults_publish
-      - run:
-          <<: *defaults_slack_announcement
+          name: Publish Helm Charts
+          command: .circleci/publish_helm_charts.sh
+      - slack/status:
+          webhook: "$SLACK_WEBHOOK_ANNOUNCEMENT"
+          success_message: '*"${CIRCLE_PROJECT_REPONAME}"* - Release \`"${CIRCLE_TAG}"\` \nhttps://github.com/mojaloop/"${CIRCLE_PROJECT_REPONAME}"/releases/tag/"${CIRCLE_TAG}"'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ defaults_Dependencies: &defaults_Dependencies
   name: Install default dependencies
   command: |
     apk --no-cache add git
+    apk --no-cache add bash
     apk --no-cache add ca-certificates
     apk --no-cache add curl
     apk --no-cache add openssh-client
@@ -178,6 +179,8 @@ jobs:
   slack-announcement:
     executor: default-docker-helm
     steps:
+      - run:
+          <<: *defaults_Dependencies
       - slack/status:
           webhook: "$SLACK_WEBHOOK_ANNOUNCEMENT"
           success_message: '*"${CIRCLE_PROJECT_REPONAME}"* - Release \`"${CIRCLE_TAG}"\` \nhttps://github.com/mojaloop/"${CIRCLE_PROJECT_REPONAME}"/releases/tag/"${CIRCLE_TAG}"'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
           command: |
             echo "Setting BASH_ENV..."
             source $BASH_ENV
-            
+
             git config --global user.email "$GIT_CI_USER"
             git config --global user.password "$GIT_CI_PASSWORD"
             git config --global user.name "$GIT_CI_EMAIL"
@@ -174,6 +174,10 @@ jobs:
       - run:
           name: Publish Helm Charts
           command: .circleci/publish_helm_charts.sh
+
+  slack-announcement:
+    executor: default-docker-helm
+    steps:
       - slack/status:
           webhook: "$SLACK_WEBHOOK_ANNOUNCEMENT"
           success_message: '*"${CIRCLE_PROJECT_REPONAME}"* - Release \`"${CIRCLE_TAG}"\` \nhttps://github.com/mojaloop/"${CIRCLE_PROJECT_REPONAME}"/releases/tag/"${CIRCLE_TAG}"'
@@ -238,3 +242,12 @@ workflows:
               only: /v[0-9]+(\.[0-9]+)*/
             branches:
               only: master
+      - slack-announcement:
+          context: org-global
+          requires:
+            - deploy
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,23 +208,24 @@ workflows:
                 - /feature.*/
                 - /bugfix.*/
                 - gh-pages
-      - audit-licenses:
-          context: org-global
-          requires:
-            - setup
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore:
-                - /feature.*/
-                - /bugfix.*/
-                - gh-pages
+      # TODO: reenable
+      # - audit-licenses:
+      #     context: org-global
+      #     requires:
+      #       - setup
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #       branches:
+      #         ignore:
+      #           - /feature.*/
+      #           - /bugfix.*/
+      #           - gh-pages
       - build:
           context: org-global
           requires:
             - test
-            - audit-licenses
+            # - audit-licenses
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,19 @@
-# CircleCI v2 Config
-version: 2
+# CircleCI v2.1 Config
+version: 2.1
 
-defaults_working_directory: &defaults_working_directory
-  working_directory: /home/circleci/project
+##
+# orbs
+#
+# Orbs used in this pipeline
+##
+orbs:
+  slack: circleci/slack@3.4.2
 
-#TODO: add proper defaults for node, rename this to defaults_docker_helm
-
-defaults_docker_helm: &defaults_docker_helm
-  docker:
-    - image: alpine/helm:2.13.1
-
+##
+# defaults
+#
+# yaml templates to be shared across jobs
+##
 defaults_Dependencies: &defaults_Dependencies
   name: Install default dependencies
   command: |
@@ -67,10 +71,29 @@ defaults_publish: &defaults_publish
   name: Publish helm charts
   command: bash $CIRCLE_WORKING_DIRECTORY/.circleci/publish_helm_charts.sh
 
+##
+# Executors
+#
+# CircleCI Executors
+##
+executors:
+  default-docker-helm:
+    working_directory: /home/circleci/project
+    docker:
+      - image: alpine/helm:2.13.1
+
+  default-machine:
+    machine:
+      image: ubuntu-1604:201903-01
+
+##
+# Jobs
+#
+# A map of CircleCI jobs
+##
 jobs:
   setup:
-    <<: *defaults_working_directory
-    <<: *defaults_docker_helm
+    executor: default-docker-helm
     steps:
       - checkout
       - run:
@@ -78,8 +101,7 @@ jobs:
           command: echo "Placeholder for setup - Nothing to do here"
 
   test:
-    <<: *defaults_working_directory
-    <<: *defaults_docker_helm
+    executor: default-docker-helm
     steps:
       - checkout
       - run:
@@ -92,7 +114,7 @@ jobs:
             sh lint-charts.sh
 
   audit-licenses:
-    machine: true
+    executor: default-machine
     steps:
       - checkout
       - run:
@@ -133,8 +155,7 @@ jobs:
           prefix: licenses
 
   build:
-    <<: *defaults_working_directory
-    <<: *defaults_docker_helm
+    executor: default-docker-helm
     steps:
       - checkout
       - run:
@@ -147,8 +168,7 @@ jobs:
             bash update-charts-dep.sh
 
   deploy:
-    <<: *defaults_working_directory
-    <<: *defaults_docker_helm
+    executor: default-docker-helm
     steps:
       - checkout
       - run:

--- a/.circleci/publish_helm_charts.sh
+++ b/.circleci/publish_helm_charts.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euox pipefail
+
 echo "Setting BASH_ENV..." | tee git.log 
 source $BASH_ENV
 

--- a/.circleci/publish_helm_charts.sh
+++ b/.circleci/publish_helm_charts.sh
@@ -42,7 +42,7 @@ echo "Staging packaged Helm charts..." | tee git.log
 git add -f repo/*.*
 
 echo "Commiting changes..." | tee git.log 
-git commit -a -m $COMMIT_MESSAGE
+git commit -a -m "'$COMMIT_MESSAGE'"
 
 echo "Publishing $REVISION release to $GITHUB_TARGET_BRANCH on github..." | tee git.log 
 git push -q $GITHUB_PROJECT_USERNAME $GITHUB_TARGET_BRANCH &> git.log

--- a/.circleci/publish_helm_charts.sh
+++ b/.circleci/publish_helm_charts.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+REVISION=${GITHUB_TAG:-$GIT_SHA1}
+if [ -n ${GITHUB_TAG} ]; then
+  COMMIT_MESSAGE="Updating release to $REVISION"
+else 
+  COMMIT_MESSAGE="Updating release to $REVISION"
+fi
+
 set -euox pipefail
 
 echo "Setting BASH_ENV..." | tee git.log 
@@ -14,7 +21,6 @@ git fetch -q --tags $GITHUB_PROJECT_USERNAME &> git.log
 echo "Checking out $GITHUB_TARGET_BRANCH" | tee git.log 
 git checkout -b $GITHUB_TARGET_BRANCH $GITHUB_PROJECT_USERNAME/$GITHUB_TARGET_BRANCH &> git.log
 
-REVISION=${GITHUB_TAG:-$GIT_SHA1}
 echo "Merging code from $REVISION..." | tee git.log 
 git merge --no-commit $REVISION &> git.log
 
@@ -36,11 +42,7 @@ echo "Staging packaged Helm charts..." | tee git.log
 git add -f repo/*.*
 
 echo "Commiting changes..." | tee git.log 
-if [ -z $GITHUB_TAG ]; then
-    git commit -a -m "Updating release to $GITHUB_TAG"
-else
-    git commit -a -m "Updating development release to $GIT_SHA1"
-fi
+git commit -a -m $COMMIT_MESSAGE
 
 echo "Publishing $REVISION release to $GITHUB_TARGET_BRANCH on github..." | tee git.log 
 git push -q $GITHUB_PROJECT_USERNAME $GITHUB_TARGET_BRANCH &> git.log

--- a/.circleci/publish_helm_charts.sh
+++ b/.circleci/publish_helm_charts.sh
@@ -2,7 +2,7 @@
 
 REVISION=${GITHUB_TAG:-$GIT_SHA1}
 if [ -n ${GITHUB_TAG} ]; then
-  COMMIT_MESSAGE="Updating release to $REVISION"
+  COMMIT_MESSAGE="Updating development release to $REVISION"
 else 
   COMMIT_MESSAGE="Updating release to $REVISION"
 fi


### PR DESCRIPTION
- upgrades circleci version to 2.1 to keep things more consistent with our other pipelines
- tidy up of the scripts and yaml templates
- fix an issue where the commit message for `gh_pages` was missing information
- move slack announcement to *git tags only*, so we don't get an empty alert every time there's a merge into master


Tested manually:

<img width="1448" alt="Screen Shot 2020-08-14 at 10 20 51 am" src="https://user-images.githubusercontent.com/1683980/90207057-e07b1c00-de17-11ea-9a90-2540ed8aad4f.png">

<img width="534" alt="Screen Shot 2020-08-14 at 10 21 16 am" src="https://user-images.githubusercontent.com/1683980/90207072-ebce4780-de17-11ea-9b8c-cb76b0b329f6.png">
