### PR TITLE
Fix for the following error when not releasing a tagged release

### DIFF
--- a/.circleci/publish_helm_charts.sh
+++ b/.circleci/publish_helm_charts.sh
@@ -7,7 +7,7 @@ else
   COMMIT_MESSAGE="Updating release to $REVISION"
 fi
 
-set -euox pipefail
+set -eox pipefail
 
 echo "Setting BASH_ENV..." | tee git.log 
 source $BASH_ENV


### PR DESCRIPTION
Build failing when merging into master branch: https://app.circleci.com/pipelines/github/mojaloop/helm/537/workflows/6d17fa89-f0f4-4c2f-b88a-ffea298de8ff/jobs/3816

Error: `CIRCLE_TAG: unbound variable` on .circleci/publish_helm_charts.sh when running the `source $BASH_ENV` line. Removed the `-u` from the set bulletin line.

Ref: http://manpages.ubuntu.com/manpages/bionic/en/man1/bash.1.html#shell%20builtin%20commands
```
-u      Treat  unset variables and parameters other than the special parameters "@"
                      and "*" as an error when performing parameter expansion.  If  expansion  is
                      attempted  on  an  unset  variable  or parameter, the shell prints an error
                      message, and, if not interactive, exits with a non-zero status.
```