### PR TITLE
Fixed the scope to pass for the template apiVersion.Deployment

### DIFF
--- a/mojaloop-simulator/templates/deployment.yaml
+++ b/mojaloop-simulator/templates/deployment.yaml
@@ -3,7 +3,7 @@
 {{- $fullName := printf "%s%s" $prefix $name }}
 {{- $config := merge $customConfig $.Values.defaults }}
 {{- $initContainerEnv := dict "SIM_NAME" $name "SIM_SCHEME_ADAPTER_SERVICE_NAME" (printf "sim-%s-scheme-adapter" $name) "SIM_BACKEND_SERVICE_NAME" (printf "sim-%s-backend" $name) "SIM_CACHE_SERVICE_NAME" (printf "sim-%s-cache" $name) -}}
-apiVersion: {{ template "mojaloop-simulator.apiVersion.Deployment" . }}
+apiVersion: {{ template "mojaloop-simulator.apiVersion.Deployment" $ }}
 kind: Deployment
 metadata:
   name: {{ $fullName }}-scheme-adapter
@@ -140,7 +140,7 @@ spec:
     {{- end }}
 
 ---
-apiVersion: {{ template "mojaloop-simulator.apiVersion.Deployment" . }}
+apiVersion: {{ template "mojaloop-simulator.apiVersion.Deployment" $ }}
 kind: Deployment
 metadata:
   name: {{ $fullName }}-backend
@@ -231,7 +231,7 @@ spec:
     {{- end }}
 ---
 {{- if $config.config.cache.enabled }}
-apiVersion: {{ template "mojaloop-simulator.apiVersion.Deployment" . }}
+apiVersion: {{ template "mojaloop-simulator.apiVersion.Deployment" $ }}
 kind: Deployment
 metadata:
   name: {{ $fullName }}-cache


### PR DESCRIPTION
**Bug:**
Getting the following error when deploying mojaloop helm chart
`Error: template: mojaloop/charts/mojaloop-simulator/templates/_helpers.tpl:56:22: executing "mojaloop-simulator.apiVersion.Deployment" at <.Capabilities.APIVersions.Has>: nil pointer evaluating interface {}.APIVersions`

**Fix:**
In the file _mojaloop-simulator/templates/deployment.yaml_
The template reference "mojaloop-simulator.apiVersion.Deployment" inside the "range" block should be called by passing the parent scope `('$')` instead of current scope `('.')` beacuse the range operator is changing the current scope.