### PR TITLE
install mysql client in pathfinder init container

### DIFF
--- a/als-oracle-pathfinder/values.yaml
+++ b/als-oracle-pathfinder/values.yaml
@@ -209,7 +209,7 @@ init:
       repository: mojaloop/als-oracle-pathfinder
       tag: latest
       pullPolicy: Always
-      command: mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -e "SET @service_name='$service_name'; source /opt/als-oracle-pathfinder/init-central-ledger.sql;";
+      command: apk add mysql-client && mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -e "SET @service_name='$service_name'; source /opt/als-oracle-pathfinder/init-central-ledger.sql;";
     accountLookup:
       enabled: true
       name: init-account-lookup-mysql


### PR DESCRIPTION
The reason we install the mysql-client inside the init container command instead of the docker image since we don't want to have the mysql client in the running service.