### PR TITLE
Release/v11.0.0

### DIFF
--- a/account-lookup-service/Chart.yaml
+++ b/account-lookup-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 version: 11.0.0
-appVersion: "account-lookup-service: v11.0.2; als-oracle-pathfinder: v9.4.0"
+appVersion: "account-lookup-service: v11.0.2; als-oracle-pathfinder: v10.2.0"
 description: Account Lookup Service Helm Chart for Mojaloop
 name: account-lookup-service

--- a/account-lookup-service/Chart.yaml
+++ b/account-lookup-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 version: 11.0.0
-appVersion: "account-lookup-service: v11.0.2; als-oracle-pathfinder: v10.2.0"
+appVersion: "account-lookup-service: v11.1.2; als-oracle-pathfinder: v10.2.0"
 description: Account Lookup Service Helm Chart for Mojaloop
 name: account-lookup-service

--- a/account-lookup-service/chart-admin/Chart.yaml
+++ b/account-lookup-service/chart-admin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 version: 11.0.0
-appVersion: "11.0.2"
+appVersion: "11.1.2"
 description: A Helm chart for Kubernetes
 name: account-lookup-service-admin

--- a/account-lookup-service/chart-admin/values.yaml
+++ b/account-lookup-service/chart-admin/values.yaml
@@ -7,7 +7,7 @@ containers:
   api:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v11.0.2
+      tag: v11.1.2
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--api"]'
     service:
@@ -18,7 +18,7 @@ containers:
   admin:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v11.0.2
+      tag: v11.1.2
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--admin"]'
     service:

--- a/account-lookup-service/chart-service/Chart.yaml
+++ b/account-lookup-service/chart-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 version: 11.0.0
-appVersion: "11.0.2"
+appVersion: "11.1.2"
 description: A Helm chart for Kubernetes
 name: account-lookup-service

--- a/account-lookup-service/chart-service/values.yaml
+++ b/account-lookup-service/chart-service/values.yaml
@@ -8,7 +8,7 @@ containers:
   api:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v11.0.2
+      tag: v11.1.2
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--api"]'
     service:
@@ -19,7 +19,7 @@ containers:
   admin:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v11.0.2
+      tag: v11.1.2
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--admin"]'
     service:

--- a/account-lookup-service/values.yaml
+++ b/account-lookup-service/values.yaml
@@ -9,7 +9,7 @@ account-lookup-service:
     api:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v11.0.2
+        tag: v11.1.2
         pullPolicy: Always
         command: '["node", "src/index.js", "server", "--api"]'
       service:
@@ -20,7 +20,7 @@ account-lookup-service:
     admin:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v11.0.2
+        tag: v11.1.2
         pullPolicy: Always
         command: '["node", "src/index.js", "server", "--admin"]'
       service:
@@ -159,7 +159,7 @@ account-lookup-service-admin:
     api:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v11.0.2
+        tag: v11.1.2
         pullPolicy: IfNotPresent
         command: '["node", "src/index.js", "server", "--api"]'
       service:
@@ -170,7 +170,7 @@ account-lookup-service-admin:
     admin:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v11.0.2
+        tag: v11.1.2
         pullPolicy: IfNotPresent
         command: '["node", "src/index.js", "server", "--admin"]'
       service:

--- a/account-lookup-service/values.yaml
+++ b/account-lookup-service/values.yaml
@@ -308,7 +308,7 @@ als-oracle-pathfinder:
   replicaCount: 1
   image:
     repository: mojaloop/als-oracle-pathfinder
-    tag: v9.4.0
+    tag: v10.2.0
     pullPolicy: Always
     command: '["node", "/opt/als-oracle-pathfinder/src/index.js"]'
     imagePullSecrets: []

--- a/als-oracle-pathfinder/Chart.yaml
+++ b/als-oracle-pathfinder/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "9.4.0"
+appVersion: "10.2.0"
 description: A PathFinder oracle for ALS. Resolves MSISDN to participant ID.
 name: als-oracle-pathfinder
 version: 11.0.0

--- a/als-oracle-pathfinder/values.yaml
+++ b/als-oracle-pathfinder/values.yaml
@@ -8,7 +8,7 @@ global: {}
 replicaCount: 1
 image:
   repository: mojaloop/als-oracle-pathfinder
-  tag: v9.4.0
+  tag: v10.2.0
   pullPolicy: Always
   command: '["node", "/opt/als-oracle-pathfinder/src/index.js"]'
   imagePullSecrets: []

--- a/bulk-api-adapter/Chart.yaml
+++ b/bulk-api-adapter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: bulk-api-adapter Helm chart for Kubernetes
 name: bulk-api-adapter
 version: 11.0.0
-appVersion: "11.0.0"
+appVersion: "11.0.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/Chart.yaml
+++ b/bulk-api-adapter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: bulk-api-adapter Helm chart for Kubernetes
 name: bulk-api-adapter
 version: 11.0.0
-appVersion: "10.6.1"
+appVersion: "11.0.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/Chart.yaml
+++ b/bulk-api-adapter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: bulk-api-adapter Helm chart for Kubernetes
 name: bulk-api-adapter
 version: 11.0.0
-appVersion: "11.0.1"
+appVersion: "11.0.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/chart-handler-notification/Chart.yaml
+++ b/bulk-api-adapter/chart-handler-notification/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: bulk-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: bulk-api-adapter-handler-notification
 version: 11.0.0
-appVersion: "11.0.1"
+appVersion: "11.0.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/chart-handler-notification/Chart.yaml
+++ b/bulk-api-adapter/chart-handler-notification/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: bulk-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: bulk-api-adapter-handler-notification
 version: 11.0.0
-appVersion: "10.5.0"
+appVersion: "11.0.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/chart-handler-notification/Chart.yaml
+++ b/bulk-api-adapter/chart-handler-notification/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: bulk-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: bulk-api-adapter-handler-notification
 version: 11.0.0
-appVersion: "11.0.0"
+appVersion: "11.0.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/chart-handler-notification/values.yaml
+++ b/bulk-api-adapter/chart-handler-notification/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/bulk-api-adapter
-  tag: v11.0.1
+  tag: v11.0.2
   command: '["node", "src/handlers/index.js", "handler", "--notification"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/bulk-api-adapter/chart-handler-notification/values.yaml
+++ b/bulk-api-adapter/chart-handler-notification/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/bulk-api-adapter
-  tag: v10.6.1
+  tag: v11.0.0
   command: '["node", "src/handlers/index.js", "handler", "--notification"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/bulk-api-adapter/chart-handler-notification/values.yaml
+++ b/bulk-api-adapter/chart-handler-notification/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/bulk-api-adapter
-  tag: v11.0.0
+  tag: v11.0.1
   command: '["node", "src/handlers/index.js", "handler", "--notification"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/bulk-api-adapter/chart-service/Chart.yaml
+++ b/bulk-api-adapter/chart-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: bulk-api-adapter API component Helm chart for Kubernetes
 name: bulk-api-adapter-service
 version: 11.0.0
-appVersion: "10.5.0"
+appVersion: "11.0.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/chart-service/Chart.yaml
+++ b/bulk-api-adapter/chart-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: bulk-api-adapter API component Helm chart for Kubernetes
 name: bulk-api-adapter-service
 version: 11.0.0
-appVersion: "11.0.0"
+appVersion: "11.0.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/chart-service/Chart.yaml
+++ b/bulk-api-adapter/chart-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: bulk-api-adapter API component Helm chart for Kubernetes
 name: bulk-api-adapter-service
 version: 11.0.0
-appVersion: "11.0.1"
+appVersion: "11.0.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/chart-service/values.yaml
+++ b/bulk-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/bulk-api-adapter
-  tag: v11.0.1
+  tag: v11.0.2
   command: '["node", "src/api/index.js"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/bulk-api-adapter/chart-service/values.yaml
+++ b/bulk-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/bulk-api-adapter
-  tag: v10.6.1
+  tag: v11.0.0
   command: '["node", "src/api/index.js"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/bulk-api-adapter/chart-service/values.yaml
+++ b/bulk-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/bulk-api-adapter
-  tag: v11.0.0
+  tag: v11.0.1
   command: '["node", "src/api/index.js"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/bulk-api-adapter/values.yaml
+++ b/bulk-api-adapter/values.yaml
@@ -12,7 +12,7 @@ bulk-api-adapter-service:
   replicaCount: 1
   image:
     repository: mojaloop/bulk-api-adapter
-    tag: v10.6.1
+    tag: v11.0.0
     command: '["node", "src/api/index.js"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -127,7 +127,7 @@ bulk-api-adapter-handler-notification:
   replicaCount: 1
   image:
     repository: mojaloop/bulk-api-adapter
-    tag: v10.6.1
+    tag: v11.0.0
     command: '["node", "src/handlers/index.js", "handler", "--notification"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bulk-api-adapter/values.yaml
+++ b/bulk-api-adapter/values.yaml
@@ -12,7 +12,7 @@ bulk-api-adapter-service:
   replicaCount: 1
   image:
     repository: mojaloop/bulk-api-adapter
-    tag: v11.0.1
+    tag: v11.0.2
     command: '["node", "src/api/index.js"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -127,7 +127,7 @@ bulk-api-adapter-handler-notification:
   replicaCount: 1
   image:
     repository: mojaloop/bulk-api-adapter
-    tag: v11.0.1
+    tag: v11.0.2
     command: '["node", "src/handlers/index.js", "handler", "--notification"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bulk-api-adapter/values.yaml
+++ b/bulk-api-adapter/values.yaml
@@ -12,7 +12,7 @@ bulk-api-adapter-service:
   replicaCount: 1
   image:
     repository: mojaloop/bulk-api-adapter
-    tag: v11.0.0
+    tag: v11.0.1
     command: '["node", "src/api/index.js"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -127,7 +127,7 @@ bulk-api-adapter-handler-notification:
   replicaCount: 1
   image:
     repository: mojaloop/bulk-api-adapter
-    tag: v11.0.0
+    tag: v11.0.1
     command: '["node", "src/handlers/index.js", "handler", "--notification"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bulk-centralledger/Chart.yaml
+++ b/bulk-centralledger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Bulk Services Helm chart for Kubernetes
 name: bulk-centralledger
 version: 11.0.0
-appVersion: "10.5.2"
+appVersion: "11.2.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/Chart.yaml
+++ b/bulk-centralledger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Bulk Services Helm chart for Kubernetes
 name: bulk-centralledger
 version: 11.0.0
-appVersion: "11.2.2"
+appVersion: "11.2.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Bulk Transfer Fulfil Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-fulfil
 version: 11.0.0
-appVersion: "10.5.2"
+appVersion: "11.2.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Bulk Transfer Fulfil Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-fulfil
 version: 11.0.0
-appVersion: "11.2.2"
+appVersion: "11.2.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v10.6.1
+      tag: v11.2.3
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
     service:

--- a/bulk-centralledger/chart-handler-bulk-transfer-get/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-get/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Bulk Transfer Get Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-get
 version: 11.0.0
-appVersion: "11.0.1"
+appVersion: "11.2.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-get/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-get/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v11.0.1
+      tag: v11.2.3
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--bulkget"]'
     service:

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Bulk Transfer Prepare Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-prepare
 version: 11.0.0
-appVersion: "10.5.2"
+appVersion: "11.2.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Bulk Transfer Prepare Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-prepare
 version: 11.0.0
-appVersion: "11.2.2"
+appVersion: "11.2.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v10.6.1
+      tag: v11.2.3
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
     service:

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Bulk Transfer Processing Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-processing
 version: 11.0.0
-appVersion: "11.2.2"
+appVersion: "11.2.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Bulk Transfer Processing Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-processing
 version: 11.0.0
-appVersion: "10.5.2"
+appVersion: "11.2.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v10.6.1
+      tag: v11.2.3
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
     service:

--- a/bulk-centralledger/values.yaml
+++ b/bulk-centralledger/values.yaml
@@ -14,7 +14,7 @@ cl-handler-bulk-transfer-prepare:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v10.6.1
+        tag: v11.2.3
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
       service:
@@ -195,7 +195,7 @@ cl-handler-bulk-transfer-fulfil:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v10.6.1
+        tag: v11.2.3
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
       service:
@@ -373,7 +373,7 @@ cl-handler-bulk-transfer-processing:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v10.6.1
+        tag: v11.2.3
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
       service:
@@ -550,7 +550,7 @@ cl-handler-bulk-transfer-get:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v11.0.1
+        tag: v11.2.3
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--bulkget"]'
       service:

--- a/central/Chart.yaml
+++ b/central/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central Helm chart for Kubernetes
 name: central
 version: 11.0.0
-appVersion: "central-ledger: v10.5.2; central-settlement: v10.5.0; central-event-processor: v10.5.0"
+appVersion: "central-ledger: v11.2.2; central-settlement: v10.5.0; central-event-processor: v10.5.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/central/Chart.yaml
+++ b/central/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central Helm chart for Kubernetes
 name: central
 version: 11.0.0
-appVersion: "central-ledger: v11.2.2; central-settlement: v10.5.0; central-event-processor: v10.5.0"
+appVersion: "central-ledger: v11.2.3; central-settlement: v10.5.0; central-event-processor: v10.5.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -22,7 +22,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v11.2.2
+          tag: v11.2.3
           pullPolicy: Always
           command: '["node", "src/api/index.js"]'
         service:
@@ -196,7 +196,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v11.2.2
+          tag: v11.2.3
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
         service:
@@ -380,7 +380,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v11.2.2
+          tag: v11.2.3
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--position"]'
         service:
@@ -561,7 +561,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v11.2.2
+          tag: v11.2.3
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--get"]'
         service:
@@ -742,7 +742,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v11.2.2
+          tag: v11.2.3
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
         service:
@@ -923,7 +923,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v11.2.2
+          tag: v11.2.3
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
         service:
@@ -1104,7 +1104,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v11.2.2
+          tag: v11.2.3
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--admin"]'
         service:

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -22,7 +22,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v10.6.1
+          tag: v11.2.0
           pullPolicy: Always
           command: '["node", "src/api/index.js"]'
         service:
@@ -196,7 +196,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v10.6.1
+          tag: v11.2.0
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
         service:
@@ -380,7 +380,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v10.6.1
+          tag: v11.2.0
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--position"]'
         service:
@@ -561,7 +561,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v10.6.1
+          tag: v11.2.0
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--get"]'
         service:
@@ -742,7 +742,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v10.6.1
+          tag: v11.2.0
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
         service:
@@ -923,7 +923,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v10.6.1
+          tag: v11.2.0
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
         service:
@@ -1104,7 +1104,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v10.6.1
+          tag: v11.2.0
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--admin"]'
         service:

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -22,7 +22,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v11.2.0
+          tag: v11.2.2
           pullPolicy: Always
           command: '["node", "src/api/index.js"]'
         service:
@@ -196,7 +196,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v11.2.0
+          tag: v11.2.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
         service:
@@ -380,7 +380,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v11.2.0
+          tag: v11.2.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--position"]'
         service:
@@ -561,7 +561,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v11.2.0
+          tag: v11.2.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--get"]'
         service:
@@ -742,7 +742,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v11.2.0
+          tag: v11.2.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
         service:
@@ -923,7 +923,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v11.2.0
+          tag: v11.2.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
         service:
@@ -1104,7 +1104,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v11.2.0
+          tag: v11.2.2
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--admin"]'
         service:

--- a/centralledger/Chart.yaml
+++ b/centralledger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Helm chart for Kubernetes
 name: centralledger
 version: 11.0.0
-appVersion: "11.2.2"
+appVersion: "11.2.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/Chart.yaml
+++ b/centralledger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Helm chart for Kubernetes
 name: centralledger
 version: 11.0.0
-appVersion: "10.5.2"
+appVersion: "11.2.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-admin-transfer/Chart.yaml
+++ b/centralledger/chart-handler-admin-transfer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-admin-transfer
 version: 11.0.0
-appVersion: "10.5.2"
+appVersion: "11.2.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-admin-transfer/Chart.yaml
+++ b/centralledger/chart-handler-admin-transfer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-admin-transfer
 version: 11.0.0
-appVersion: "11.2.2"
+appVersion: "11.2.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-admin-transfer/templates/deployment.yaml
+++ b/centralledger/chart-handler-admin-transfer/templates/deployment.yaml
@@ -127,6 +127,8 @@ spec:
               value: {{ .Values.config.event_async_override | quote }}
             - name: EVENT_SDK_TRACEID_PER_VENDOR
               value: {{ .Values.config.event_traceid_per_vendor | quote }}
+            - name: LIB_RESOURCE_VERSIONS
+              value: {{ .Values.config.resource_versions}}
           volumeMounts:
           - name: {{ template "centralledger-handler-admin-transfer.fullname" . }}-config-volume
             mountPath: /opt/central-ledger/config

--- a/centralledger/chart-handler-admin-transfer/values.yaml
+++ b/centralledger/chart-handler-admin-transfer/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v11.2.0
+      tag: v11.2.2
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--admin"]'
     service:

--- a/centralledger/chart-handler-admin-transfer/values.yaml
+++ b/centralledger/chart-handler-admin-transfer/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v10.6.1
+      tag: v11.2.0
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--admin"]'
     service:
@@ -146,7 +146,7 @@ config:
   cache_enabled: false
   cache_max_byte_size: 10000000
   cache_expires_in_ms: 1000
-
+  resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
 
 init:
   enabled: true

--- a/centralledger/chart-handler-admin-transfer/values.yaml
+++ b/centralledger/chart-handler-admin-transfer/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v11.2.2
+      tag: v11.2.3
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--admin"]'
     service:

--- a/centralledger/chart-handler-timeout/Chart.yaml
+++ b/centralledger/chart-handler-timeout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Timeout Handler Helm chart for Kubernetes
 name: centralledger-handler-timeout
 version: 11.0.0
-appVersion: "11.2.2"
+appVersion: "11.2.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-timeout/Chart.yaml
+++ b/centralledger/chart-handler-timeout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Timeout Handler Helm chart for Kubernetes
 name: centralledger-handler-timeout
 version: 11.0.0
-appVersion: "10.5.2"
+appVersion: "11.2.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-timeout/templates/deployment.yaml
+++ b/centralledger/chart-handler-timeout/templates/deployment.yaml
@@ -127,6 +127,8 @@ spec:
               value: {{ .Values.config.event_async_override | quote }}
             - name: EVENT_SDK_TRACEID_PER_VENDOR
               value: {{ .Values.config.event_traceid_per_vendor | quote }}
+            - name: LIB_RESOURCE_VERSIONS
+              value: {{ .Values.config.resource_versions}}
           volumeMounts:
           - name: {{ template "centralledger-handler-timeout.fullname" . }}-config-volume
             mountPath: /opt/central-ledger/config

--- a/centralledger/chart-handler-timeout/values.yaml
+++ b/centralledger/chart-handler-timeout/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v11.2.2
+      tag: v11.2.3
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
     service:

--- a/centralledger/chart-handler-timeout/values.yaml
+++ b/centralledger/chart-handler-timeout/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v11.2.0
+      tag: v11.2.2
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
     service:

--- a/centralledger/chart-handler-timeout/values.yaml
+++ b/centralledger/chart-handler-timeout/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v10.6.1
+      tag: v11.2.0
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
     service:
@@ -146,6 +146,7 @@ config:
   cache_enabled: false
   cache_max_byte_size: 10000000
   cache_expires_in_ms: 1000
+  resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
 
 init:
   enabled: true

--- a/centralledger/chart-handler-transfer-fulfil/Chart.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Transfer Fulfil Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-fulfil
 version: 11.0.0
-appVersion: "11.1.4"
+appVersion: "11.2.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-fulfil/templates/deployment.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/templates/deployment.yaml
@@ -127,6 +127,8 @@ spec:
               value: {{ .Values.config.event_async_override | quote }}
             - name: EVENT_SDK_TRACEID_PER_VENDOR
               value: {{ .Values.config.event_traceid_per_vendor | quote }}
+            - name: LIB_RESOURCE_VERSIONS
+              value: {{ .Values.config.resource_versions}}
           volumeMounts:
           - name: {{ template "centralledger-handler-transfer-fulfil.fullname" . }}-config-volume
             mountPath: /opt/central-ledger/config

--- a/centralledger/chart-handler-transfer-fulfil/values.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v11.1.4
+      tag: v11.2.3
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
     service:

--- a/centralledger/chart-handler-transfer-fulfil/values.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/values.yaml
@@ -146,6 +146,7 @@ config:
   cache_enabled: false
   cache_max_byte_size: 10000000
   cache_expires_in_ms: 1000
+  resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
 
 init:
   enabled: true

--- a/centralledger/chart-handler-transfer-get/Chart.yaml
+++ b/centralledger/chart-handler-transfer-get/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Get Transfer Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-get
 version: 11.0.0
-appVersion: "11.2.2"
+appVersion: "11.2.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-get/Chart.yaml
+++ b/centralledger/chart-handler-transfer-get/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Get Transfer Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-get
 version: 11.0.0
-appVersion: "10.5.2"
+appVersion: "11.2.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-get/templates/deployment.yaml
+++ b/centralledger/chart-handler-transfer-get/templates/deployment.yaml
@@ -131,6 +131,8 @@ spec:
               value: {{ .Values.config.event_async_override | quote }}
             - name: EVENT_SDK_TRACEID_PER_VENDOR
               value: {{ .Values.config.event_traceid_per_vendor | quote }}
+            - name: LIB_RESOURCE_VERSIONS
+              value: {{ .Values.config.resource_versions}}
           volumeMounts:
           - name: {{ template "centralledger-handler-transfer-get.fullname" . }}-config-volume
             mountPath: /opt/central-ledger/config

--- a/centralledger/chart-handler-transfer-get/values.yaml
+++ b/centralledger/chart-handler-transfer-get/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v11.2.0
+      tag: v11.2.2
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--get"]'
     service:

--- a/centralledger/chart-handler-transfer-get/values.yaml
+++ b/centralledger/chart-handler-transfer-get/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v11.2.2
+      tag: v11.2.3
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--get"]'
     service:

--- a/centralledger/chart-handler-transfer-get/values.yaml
+++ b/centralledger/chart-handler-transfer-get/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v10.6.1
+      tag: v11.2.0
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--get"]'
     service:
@@ -146,6 +146,7 @@ config:
   cache_enabled: false
   cache_max_byte_size: 10000000
   cache_expires_in_ms: 1000
+  resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
 
 init:
   enabled: true

--- a/centralledger/chart-handler-transfer-position/Chart.yaml
+++ b/centralledger/chart-handler-transfer-position/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Transfer Position Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-position
 version: 11.0.0
-appVersion: "11.1.4"
+appVersion: "11.2.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-position/templates/deployment.yaml
+++ b/centralledger/chart-handler-transfer-position/templates/deployment.yaml
@@ -127,6 +127,8 @@ spec:
               value: {{ .Values.config.event_async_override | quote }}
             - name: EVENT_SDK_TRACEID_PER_VENDOR
               value: {{ .Values.config.event_traceid_per_vendor | quote }}
+            - name: LIB_RESOURCE_VERSIONS
+              value: {{ .Values.config.resource_versions}}
           volumeMounts:
           - name: {{ template "centralledger-handler-transfer-position.fullname" . }}-config-volume
             mountPath: /opt/central-ledger/config

--- a/centralledger/chart-handler-transfer-position/values.yaml
+++ b/centralledger/chart-handler-transfer-position/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v11.1.4
+      tag: v11.2.3
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--position"]'
     service:

--- a/centralledger/chart-handler-transfer-position/values.yaml
+++ b/centralledger/chart-handler-transfer-position/values.yaml
@@ -146,6 +146,7 @@ config:
   cache_enabled: false
   cache_max_byte_size: 10000000
   cache_expires_in_ms: 1000
+  resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
 
 init:
   enabled: true

--- a/centralledger/chart-handler-transfer-prepare/Chart.yaml
+++ b/centralledger/chart-handler-transfer-prepare/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-prepare
 version: 11.0.0
-appVersion: "10.5.2"
+appVersion: "11.2.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-prepare/Chart.yaml
+++ b/centralledger/chart-handler-transfer-prepare/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-prepare
 version: 11.0.0
-appVersion: "11.2.2"
+appVersion: "11.2.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-prepare/templates/deployment.yaml
+++ b/centralledger/chart-handler-transfer-prepare/templates/deployment.yaml
@@ -127,6 +127,8 @@ spec:
               value: {{ .Values.config.event_async_override | quote }}
             - name: EVENT_SDK_TRACEID_PER_VENDOR
               value: {{ .Values.config.event_traceid_per_vendor | quote }}
+            - name: LIB_RESOURCE_VERSIONS
+              value: {{ .Values.config.resource_versions}}
           volumeMounts:
           - name: {{ template "centralledger-handler-transfer-prepare.fullname" . }}-config-volume
             mountPath: /opt/central-ledger/config

--- a/centralledger/chart-handler-transfer-prepare/values.yaml
+++ b/centralledger/chart-handler-transfer-prepare/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v11.2.0
+      tag: v11.2.2
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
     service:

--- a/centralledger/chart-handler-transfer-prepare/values.yaml
+++ b/centralledger/chart-handler-transfer-prepare/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v11.2.2
+      tag: v11.2.3
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
     service:

--- a/centralledger/chart-handler-transfer-prepare/values.yaml
+++ b/centralledger/chart-handler-transfer-prepare/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v10.6.1
+      tag: v11.2.0
       pullPolicy: Always
       command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
     service:
@@ -149,6 +149,7 @@ config:
 
   ## Enable On-Us transfers
   enable_on_us_transfers: false
+  resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
 
 init:
   enabled: true

--- a/centralledger/chart-service/Chart.yaml
+++ b/centralledger/chart-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Service Helm chart for Kubernetes
 name: centralledger-service
 version: 11.0.0
-appVersion: "10.5.2"
+appVersion: "11.2.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-service/templates/deployment.yaml
+++ b/centralledger/chart-service/templates/deployment.yaml
@@ -129,6 +129,8 @@ spec:
               value: {{ .Values.config.event_async_override | quote }}
             - name: EVENT_SDK_TRACEID_PER_VENDOR
               value: {{ .Values.config.event_traceid_per_vendor | quote }}
+            - name: LIB_RESOURCE_VERSIONS
+              value: {{ .Values.config.resource_versions}}
           volumeMounts:
           - name: {{ template "centralledger-service.fullname" . }}-config-volume
             mountPath: /opt/central-ledger/config

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v11.2.2
+      tag: v11.2.3
       pullPolicy: Always
       command: '["node", "src/api/index.js"]'
     service:

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v11.2.0
+      tag: v11.2.2
       pullPolicy: Always
       command: '["node", "src/api/index.js"]'
     service:

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v10.6.1
+      tag: v11.2.0
       pullPolicy: Always
       command: '["node", "src/api/index.js"]'
     service:
@@ -148,6 +148,7 @@ config:
   event_async_override: 'log,trace'
   event_trace_state_enabled: true
   event_traceid_per_vendor: false
+  resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
 
 init:
   enabled: true

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -17,7 +17,7 @@ centralledger-service:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v10.6.1
+        tag: v11.2.0
         pullPolicy: Always
         command: '["node", "src/api/index.js"]'
       service:
@@ -192,7 +192,7 @@ centralledger-handler-transfer-prepare:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v10.6.1
+        tag: v11.2.0
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
       service:
@@ -377,7 +377,7 @@ centralledger-handler-transfer-position:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v10.6.1
+        tag: v11.2.0
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--position"]'
       service:
@@ -559,7 +559,7 @@ centralledger-handler-transfer-get:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v10.6.1
+        tag: v11.2.0
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--get"]'
       service:
@@ -741,7 +741,7 @@ centralledger-handler-transfer-fulfil:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v10.6.1
+        tag: v11.2.0
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
       service:
@@ -923,7 +923,7 @@ centralledger-handler-timeout:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v10.6.1
+        tag: v11.2.0
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
       service:
@@ -1105,7 +1105,7 @@ centralledger-handler-admin-transfer:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v10.6.1
+        tag: v11.2.0
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--admin"]'
       service:

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -17,7 +17,7 @@ centralledger-service:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v11.2.0
+        tag: v11.2.2
         pullPolicy: Always
         command: '["node", "src/api/index.js"]'
       service:
@@ -192,7 +192,7 @@ centralledger-handler-transfer-prepare:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v11.2.0
+        tag: v11.2.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
       service:
@@ -377,7 +377,7 @@ centralledger-handler-transfer-position:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v11.2.0
+        tag: v11.2.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--position"]'
       service:
@@ -559,7 +559,7 @@ centralledger-handler-transfer-get:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v11.2.0
+        tag: v11.2.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--get"]'
       service:
@@ -741,7 +741,7 @@ centralledger-handler-transfer-fulfil:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v11.2.0
+        tag: v11.2.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
       service:
@@ -923,7 +923,7 @@ centralledger-handler-timeout:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v11.2.0
+        tag: v11.2.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
       service:
@@ -1105,7 +1105,7 @@ centralledger-handler-admin-transfer:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v11.2.0
+        tag: v11.2.2
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--admin"]'
       service:

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -17,7 +17,7 @@ centralledger-service:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v11.2.2
+        tag: v11.2.3
         pullPolicy: Always
         command: '["node", "src/api/index.js"]'
       service:
@@ -192,7 +192,7 @@ centralledger-handler-transfer-prepare:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v11.2.2
+        tag: v11.2.3
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
       service:
@@ -377,7 +377,7 @@ centralledger-handler-transfer-position:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v11.2.2
+        tag: v11.2.3
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--position"]'
       service:
@@ -559,7 +559,7 @@ centralledger-handler-transfer-get:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v11.2.2
+        tag: v11.2.3
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--get"]'
       service:
@@ -741,7 +741,7 @@ centralledger-handler-transfer-fulfil:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v11.2.2
+        tag: v11.2.3
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
       service:
@@ -923,7 +923,7 @@ centralledger-handler-timeout:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v11.2.2
+        tag: v11.2.3
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
       service:
@@ -1105,7 +1105,7 @@ centralledger-handler-admin-transfer:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v11.2.2
+        tag: v11.2.3
         pullPolicy: Always
         command: '["node", "src/handlers/index.js", "handler", "--admin"]'
       service:

--- a/ml-api-adapter/Chart.yaml
+++ b/ml-api-adapter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: ml-api-adapter Helm chart for Kubernetes
 name: ml-api-adapter
 version: 11.0.0
-appVersion: "11.0.3"
+appVersion: "11.1.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-handler-notification/Chart.yaml
+++ b/ml-api-adapter/chart-handler-notification/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: ml-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: ml-api-adapter-handler-notification
 version: 11.0.0
-appVersion: "11.0.3"
+appVersion: "11.1.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-handler-notification/templates/deployment.yaml
+++ b/ml-api-adapter/chart-handler-notification/templates/deployment.yaml
@@ -117,6 +117,9 @@ spec:
               value: {{ .Values.config.event_async_override | quote }}
             - name: EVENT_SDK_TRACEID_PER_VENDOR
               value: {{ .Values.config.event_traceid_per_vendor | quote }}
+            - name: LIB_RESOURCE_VERSIONS
+              value: {{ .Values.config.resource_versions}}
+  
         {{- if .Values.sidecar.enabled }}
         - name: {{ .Chart.Name }}-sidecar
           image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v11.0.3
+  tag: v11.1.0
   command: '["node", "src/handlers/index.js", "handler", "--notification"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.
@@ -155,6 +155,7 @@ config:
   error_handling:
     include_cause_extension: false
     truncate_extensions: true
+  resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
 
 service:
   type: ClusterIP

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v11.1.0
+  tag: v11.1.2
   command: '["node", "src/handlers/index.js", "handler", "--notification"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/chart-service/templates/deployment.yaml
+++ b/ml-api-adapter/chart-service/templates/deployment.yaml
@@ -113,6 +113,9 @@ spec:
               value: {{ .Values.config.event_async_override | quote }}
             - name: EVENT_SDK_TRACEID_PER_VENDOR
               value: {{ .Values.config.event_traceid_per_vendor | quote }}
+            - name: LIB_RESOURCE_VERSIONS
+              value: {{ .Values.config.resource_versions}}
+
         {{- if .Values.sidecar.enabled }}
         - name: {{ .Chart.Name }}-sidecar
           image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"

--- a/ml-api-adapter/chart-service/values.yaml
+++ b/ml-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v11.0.3
+  tag: v11.1.0
   command: '["node", "src/api/index.js"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.
@@ -130,6 +130,7 @@ config:
   error_handling:
     include_cause_extension: false
     truncate_extensions: true
+  resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
 
 service:
   type: ClusterIP

--- a/ml-api-adapter/chart-service/values.yaml
+++ b/ml-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/ml-api-adapter
-  tag: v11.1.0
+  tag: v11.1.2
   command: '["node", "src/api/index.js"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -13,7 +13,7 @@ ml-api-adapter-service:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v11.0.3
+    tag: v11.1.0
     command: '["node", "src/api/index.js"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -167,7 +167,7 @@ ml-api-adapter-handler-notification:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v11.0.3
+    tag: v11.1.0
     command: '["node", "src/handlers/index.js", "handler", "--notification"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -13,7 +13,7 @@ ml-api-adapter-service:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v11.1.0
+    tag: v11.1.2
     command: '["node", "src/api/index.js"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -167,7 +167,7 @@ ml-api-adapter-handler-notification:
   replicaCount: 1
   image:
     repository: mojaloop/ml-api-adapter
-    tag: v11.1.0
+    tag: v11.1.2
     command: '["node", "src/handlers/index.js", "handler", "--notification"]'
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.

--- a/ml-testing-toolkit/Chart.yaml
+++ b/ml-testing-toolkit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description:  ml-testing-toolkit Helm chart for Kubernetes
 name: ml-testing-toolkit
-version: 11.0.1
+version: 11.0.0
 appVersion: "ml-testing-toolkit: v11.0.1 ml-testing-toolkit-ui: v11.0.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png

--- a/ml-testing-toolkit/chart-backend/Chart.yaml
+++ b/ml-testing-toolkit/chart-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: ml-testing-toolkit-backend Helm chart for Kubernetes
 name: ml-testing-toolkit-backend
-version: 11.0.1
+version: 11.0.0
 appVersion: "11.0.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png

--- a/ml-testing-toolkit/chart-frontend/Chart.yaml
+++ b/ml-testing-toolkit/chart-frontend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: ml-testing-toolkit-frontend Helm chart for Kubernetes
 name: ml-testing-toolkit-frontend
 version: 11.0.0
-appVersion: "10.4.1"
+appVersion: "11.0.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-testing-toolkit/requirements.yaml
+++ b/ml-testing-toolkit/requirements.yaml
@@ -5,6 +5,6 @@ dependencies:
   repository: "file://./chart-frontend"
   condition: ml-testing-toolkit-frontend.enabled
 - name: ml-testing-toolkit-backend
-  version: 11.0.1
+  version: 11.0.0
   repository: "file://./chart-backend"
   condition: ml-testing-toolkit-backend.enabled

--- a/mojaloop-bulk/Chart.yaml
+++ b/mojaloop-bulk/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Bulk Helm chart for Kubernetes
 name: mojaloop-bulk
 version: 11.0.0
-appVersion: "bulk-api-adapter: v11.0.0; central-ledger: v10.6.0"
+appVersion: "bulk-api-adapter: v11.0.2; central-ledger: v11.2.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop-bulk/Chart.yaml
+++ b/mojaloop-bulk/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Bulk Helm chart for Kubernetes
 name: mojaloop-bulk
 version: 11.0.0
-appVersion: "bulk-api-adapter: v10.6.0; central-ledger: v10.6.0"
+appVersion: "bulk-api-adapter: v11.0.0; central-ledger: v10.6.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop-bulk/values.yaml
+++ b/mojaloop-bulk/values.yaml
@@ -13,7 +13,7 @@ bulk-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/bulk-api-adapter
-      tag: v11.0.0
+      tag: v11.0.2
       command: '["node", "src/api/index.js"]'
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
@@ -128,7 +128,7 @@ bulk-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/bulk-api-adapter
-      tag: v11.0.0
+      tag: v11.0.2
       command: '["node", "src/handlers/index.js", "handler", "--notification"]'
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.

--- a/mojaloop-bulk/values.yaml
+++ b/mojaloop-bulk/values.yaml
@@ -247,7 +247,7 @@ bulk-centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v10.6.1
+          tag: v11.2.3
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
         service:
@@ -416,7 +416,7 @@ bulk-centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v10.6.1
+          tag: v11.2.3
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
         service:
@@ -582,7 +582,7 @@ bulk-centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v10.6.1
+          tag: v11.2.3
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
         service:
@@ -747,7 +747,7 @@ bulk-centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v11.0.1
+          tag: v11.2.3
           pullPolicy: Always
           command: '["node", "src/handlers/index.js", "handler", "--bulkget"]'
         service:

--- a/mojaloop-bulk/values.yaml
+++ b/mojaloop-bulk/values.yaml
@@ -13,7 +13,7 @@ bulk-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/bulk-api-adapter
-      tag: v10.6.1
+      tag: v11.0.0
       command: '["node", "src/api/index.js"]'
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
@@ -128,7 +128,7 @@ bulk-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/bulk-api-adapter
-      tag: v10.6.1
+      tag: v11.0.0
       command: '["node", "src/handlers/index.js", "handler", "--notification"]'
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.

--- a/mojaloop-simulator/Chart.yaml
+++ b/mojaloop-simulator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-description: "Helm Chart for the Mojaloop (SDK based) Simulator - mojaloop-simulator: v11.2.1; sdk-scheme-adapter: v11.2.5"
+description: "Helm Chart for the Mojaloop (SDK based) Simulator - mojaloop-simulator: v11.2.1; sdk-scheme-adapter: v11.3.0"
 name: mojaloop-simulator
 version: 11.0.0
 appVersion: "11.0.0"

--- a/mojaloop-simulator/values.yaml
+++ b/mojaloop-simulator/values.yaml
@@ -251,7 +251,7 @@ defaults: &defaults
           publicKey: ''
       image:
         repository: mojaloop/sdk-scheme-adapter
-        tag: v11.2.5
+        tag: v11.3.0
         pullPolicy: Always
       <<: *defaultProbes
 
@@ -414,7 +414,7 @@ defaults: &defaults
         # The incoming transfer request should consist of an ILP packet and a matching condition in this case.
         # The fulfilment will be generated from the provided ILP packet, and must hash to the provided condition.
         ALLOW_TRANSFER_WITHOUT_QUOTE: false
-
+        RESOURCE_VERSIONS: transfers=1.1,quotes=1.0
     backend:
       image:
         repository: mojaloop/mojaloop-simulator

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 11.0.0
-appVersion: "ml-api-adapter: v11.1.2; central-ledger: v11.2.3; account-lookup-service: v11.1.2; quoting-service: v11.1.2; central-settlement: v10.5.0; central-event-processor: v10.5.0; bulk-api-adapter: v11.0.1; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v11.1.2; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v11.0.2; mojaloop-simulator: v10.6.5; sdk-scheme-adapter: v11.3.0"
+appVersion: "ml-api-adapter: v11.1.2; central-ledger: v11.2.3; account-lookup-service: v11.1.2; quoting-service: v11.1.2; central-settlement: v10.5.0; central-event-processor: v10.5.0; bulk-api-adapter: v11.0.2; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v11.1.2; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v11.0.2; mojaloop-simulator: v10.6.5; sdk-scheme-adapter: v11.3.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 11.0.0
-appVersion: "ml-api-adapter: v11.1.2; central-ledger: v11.2.3; account-lookup-service: v11.1.2; quoting-service: v11.1.2; central-settlement: v10.5.0; central-event-processor: v10.5.0; bulk-api-adapter: v11.0.2; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v11.1.2; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v11.0.2; mojaloop-simulator: v10.6.5; sdk-scheme-adapter: v11.3.0"
+appVersion: "ml-api-adapter: v11.1.2; central-ledger: v11.2.3; account-lookup-service: v11.1.2; quoting-service: v11.1.4; central-settlement: v10.5.0; central-event-processor: v10.5.0; bulk-api-adapter: v11.0.2; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v11.1.2; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v11.0.2; mojaloop-simulator: v10.6.5; sdk-scheme-adapter: v11.3.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 11.0.0
-appVersion: "ml-api-adapter: v11.1.2; central-ledger: v11.2.3; account-lookup-service: v11.1.2; quoting-service: v11.1.4; central-settlement: v10.5.0; central-event-processor: v10.5.0; bulk-api-adapter: v11.0.2; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v11.1.2; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v11.0.2; mojaloop-simulator: v10.6.5; sdk-scheme-adapter: v11.3.0"
+appVersion: "ml-api-adapter: v11.1.2; central-ledger: v11.2.3; account-lookup-service: v11.1.2; quoting-service: v11.1.4; central-settlement: v10.5.0; central-event-processor: v10.5.0; bulk-api-adapter: v11.0.2; email-notifier: v9.5.0; als-oracle-pathfinder: v10.2.0; transaction-requests-service: v11.1.2; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v11.0.2; mojaloop-simulator: v10.6.5; sdk-scheme-adapter: v11.3.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 11.0.0
-appVersion: "ml-api-adapter: v11.1.0; central-ledger: v11.2.0; account-lookup-service: v11.0.1; quoting-service: v11.1.0; central-settlement: v10.5.0; central-event-processor: v10.5.0; bulk-api-adapter: v10.6.1; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v10.4.0; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v10.6.1; mojaloop-simulator: v10.6.5; sdk-scheme-adapter: v11.3.0"
+appVersion: "ml-api-adapter: v11.1.0; central-ledger: v11.2.2; account-lookup-service: v11.0.1; quoting-service: v11.1.0; central-settlement: v10.5.0; central-event-processor: v10.5.0; bulk-api-adapter: v10.6.1; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v10.4.0; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v10.6.1; mojaloop-simulator: v10.6.5; sdk-scheme-adapter: v11.3.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 11.0.0
-appVersion: "ml-api-adapter: v11.1.0; central-ledger: v11.2.2; account-lookup-service: v11.0.1; quoting-service: v11.1.0; central-settlement: v10.5.0; central-event-processor: v10.5.0; bulk-api-adapter: v10.6.1; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v10.4.0; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v10.6.1; mojaloop-simulator: v10.6.5; sdk-scheme-adapter: v11.3.0"
+appVersion: "ml-api-adapter: v11.1.2; central-ledger: v11.2.3; account-lookup-service: v11.1.2; quoting-service: v11.1.2; central-settlement: v10.5.0; central-event-processor: v10.5.0; bulk-api-adapter: v11.0.1; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v11.1.2; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v11.0.2; mojaloop-simulator: v10.6.5; sdk-scheme-adapter: v11.3.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 11.0.0
-appVersion: "ml-api-adapter: v11.0.3; central-ledger: v10.6.1; account-lookup-service: v11.0.2; quoting-service: v10.5.5; central-settlement: v10.5.0; central-event-processor: v10.5.0; bulk-api-adapter: v10.6.1; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v10.4.0; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v11.0.0; mojaloop-simulator: v10.6.5; sdk-scheme-adapter: v10.5.3"
+appVersion: "ml-api-adapter: v11.1.0; central-ledger: v11.2.0; account-lookup-service: v11.0.1; quoting-service: v11.1.0; central-settlement: v10.5.0; central-event-processor: v10.5.0; bulk-api-adapter: v10.6.1; email-notifier: v9.5.0; als-oracle-pathfinder: v8.7.1; transaction-requests-service: v10.4.0; finance-portal-ui: v10.4.0; finance-portal-backend-service: v10.4.0; settlement-management: v8.8.2; operator-settlement: v9.2.1; simulator: v10.6.1; mojaloop-simulator: v10.6.5; sdk-scheme-adapter: v11.3.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -24,7 +24,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v10.6.1
+            tag: v11.2.0
             pullPolicy: Always
             command: '["node", "src/api/index.js"]'
           service:
@@ -128,7 +128,7 @@ central:
         cache_enabled: false
         cache_max_byte_size: 10000000
         cache_expires_in_ms: 1000
-
+        resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
       init:
         enabled: true
         psql:
@@ -207,7 +207,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v10.6.1
+            tag: v11.2.0
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
           service:
@@ -314,6 +314,7 @@ central:
 
         ## Enable On-Us transfers
         enable_on_us_transfers: false
+        resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
 
       init:
         enabled: true
@@ -400,7 +401,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v10.6.1
+            tag: v11.2.0
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--admin"]'
           service:
@@ -504,6 +505,7 @@ central:
         cache_enabled: false
         cache_max_byte_size: 10000000
         cache_expires_in_ms: 1000
+        resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
 
       init:
         enabled: true
@@ -694,6 +696,7 @@ central:
         cache_enabled: false
         cache_max_byte_size: 10000000
         cache_expires_in_ms: 1000
+        resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
 
       init:
         enabled: true
@@ -780,7 +783,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v10.6.1
+            tag: v11.2.0
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--get"]'
           service:
@@ -884,6 +887,7 @@ central:
         cache_enabled: false
         cache_max_byte_size: 10000000
         cache_expires_in_ms: 1000
+        resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
 
       init:
         enabled: true
@@ -1074,6 +1078,7 @@ central:
         cache_enabled: false
         cache_max_byte_size: 10000000
         cache_expires_in_ms: 1000
+        resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
 
       init:
         enabled: true
@@ -1160,7 +1165,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v10.6.1
+            tag: v11.2.0
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
           service:
@@ -1264,6 +1269,7 @@ central:
         cache_enabled: false
         cache_max_byte_size: 10000000
         cache_expires_in_ms: 1000
+        resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
 
       init:
         enabled: true
@@ -2345,7 +2351,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v11.0.3
+      tag: v11.1.0
       command: '["node", "src/api/index.js"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -2435,6 +2441,7 @@ ml-api-adapter:
       error_handling:
         include_cause_extension: false
         truncate_extensions: true
+      resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
 
     service:
       type: ClusterIP
@@ -2477,7 +2484,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v11.0.3
+      tag: v11.1.0
       command: '["node", "src/handlers/index.js", "handler", "--notification"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -2579,6 +2586,7 @@ ml-api-adapter:
       error_handling:
         include_cause_extension: false
         truncate_extensions: true
+      resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
 
     service:
       type: ClusterIP
@@ -3077,7 +3085,7 @@ account-lookup-service:
     replicaCount: 1
     image:
       repository: mojaloop/als-oracle-pathfinder
-      tag: v8.7.1
+      tag: v10.2.0
       pullPolicy: Always
       command: '["node", "/opt/als-oracle-pathfinder/src/index.js"]'
       imagePullSecrets: []
@@ -3426,7 +3434,7 @@ quoting-service:
   replicaCount: 1
   image:
     repository: mojaloop/quoting-service
-    tag: v10.5.5
+    tag: v11.1.0
     pullPolicy: Always
 
   readinessProbe:
@@ -3479,6 +3487,8 @@ quoting-service:
     error_handling:
       include_cause_extension: false
       truncate_extensions: true
+
+    resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
 
     endpointSecurity:
       jwsSign: false
@@ -4028,7 +4038,7 @@ mojaloop-simulator:
             publicKey: ''
         image:
           repository: mojaloop/sdk-scheme-adapter
-          tag: v11.2.5
+          tag: v11.3.0
           pullPolicy: Always
         <<: *defaultProbes
 
@@ -4187,6 +4197,9 @@ mojaloop-simulator:
           # The incoming transfer request should consist of an ILP packet and a matching condition in this case.
           # The fulfilment will be generated from the provided ILP packet, and must hash to the provided condition.
           ALLOW_TRANSFER_WITHOUT_QUOTE: false
+          RESERVE_NOTIFICATION: true
+          RESOURCE_VERSIONS: transfers=1.1,quotes=1.0
+
 
       backend:
         image:
@@ -4579,7 +4592,7 @@ mojaloop-bulk:
       replicaCount: 1
       image:
         repository: mojaloop/bulk-api-adapter
-        tag: v10.6.1
+        tag: v11.0.0
         command: '["node", "src/api/index.js"]'
         ## Optionally specify an array of imagePullSecrets.
         ## Secrets must be manually created in the namespace.
@@ -4689,7 +4702,7 @@ mojaloop-bulk:
       replicaCount: 1
       image:
         repository: mojaloop/bulk-api-adapter
-        tag: v10.6.1
+        tag: v11.0.0
         command: '["node", "src/handlers/index.js", "handler", "--notification"]'
         ## Optionally specify an array of imagePullSecrets.
         ## Secrets must be manually created in the namespace.
@@ -4803,7 +4816,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v10.6.1
+            tag: v11.2.0
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
           service:
@@ -4971,7 +4984,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v10.6.1
+            tag: v11.2.0
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
           service:
@@ -5136,7 +5149,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v10.6.1
+            tag: v11.2.0
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
           service:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -24,7 +24,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v11.2.0
+            tag: v11.2.2
             pullPolicy: Always
             command: '["node", "src/api/index.js"]'
           service:
@@ -207,7 +207,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v11.2.0
+            tag: v11.2.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
           service:
@@ -401,7 +401,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v11.2.0
+            tag: v11.2.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--admin"]'
           service:
@@ -783,7 +783,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v11.2.0
+            tag: v11.2.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--get"]'
           service:
@@ -1165,7 +1165,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v11.2.0
+            tag: v11.2.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
           service:
@@ -4816,7 +4816,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v11.2.0
+            tag: v11.2.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
           service:
@@ -4984,7 +4984,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v11.2.0
+            tag: v11.2.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
           service:
@@ -5149,7 +5149,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v11.2.0
+            tag: v11.2.2
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
           service:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -24,7 +24,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v11.2.2
+            tag: v11.2.3
             pullPolicy: Always
             command: '["node", "src/api/index.js"]'
           service:
@@ -207,7 +207,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v11.2.2
+            tag: v11.2.3
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
           service:
@@ -401,7 +401,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v11.2.2
+            tag: v11.2.3
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--admin"]'
           service:
@@ -592,7 +592,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v11.1.4
+            tag: v11.2.3
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--position"]'
           service:
@@ -783,7 +783,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v11.2.2
+            tag: v11.2.3
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--get"]'
           service:
@@ -974,7 +974,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v11.1.4
+            tag: v11.2.3
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
           service:
@@ -1165,7 +1165,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v11.2.2
+            tag: v11.2.3
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
           service:
@@ -2351,7 +2351,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v11.1.0
+      tag: v11.1.2
       command: '["node", "src/api/index.js"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -2484,7 +2484,7 @@ ml-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/ml-api-adapter
-      tag: v11.1.0
+      tag: v11.1.2
       command: '["node", "src/handlers/index.js", "handler", "--notification"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -2741,7 +2741,7 @@ account-lookup-service:
       api:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v11.0.2
+          tag: v11.1.2
           pullPolicy: Always
           command: '["node", "src/index.js", "server", "--api"]'
         service:
@@ -2752,7 +2752,7 @@ account-lookup-service:
       admin:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v11.0.2
+          tag: v11.1.2
           pullPolicy: Always
           command: '["node", "src/index.js", "server", "--admin"]'
         service:
@@ -2915,7 +2915,7 @@ account-lookup-service:
       api:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v11.0.2
+          tag: v11.1.2
           pullPolicy: Always
           command: '["node", "src/index.js", "server", "--api"]'
         service:
@@ -2926,7 +2926,7 @@ account-lookup-service:
       admin:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v11.0.2
+          tag: v11.1.2
           pullPolicy: Always
           command: '["node", "src/index.js", "server", "--admin"]'
         service:
@@ -3434,7 +3434,7 @@ quoting-service:
   replicaCount: 1
   image:
     repository: mojaloop/quoting-service
-    tag: v11.1.0
+    tag: v11.1.2
     pullPolicy: Always
 
   readinessProbe:
@@ -3590,7 +3590,7 @@ transaction-requests-service:
   replicaCount: 1
   image:
     repository: mojaloop/transaction-requests-service
-    tag: v10.4.0
+    tag: v11.1.2
     pullPolicy: Always
     command: '["node", "src/index.js", "api"]'
 
@@ -3720,7 +3720,7 @@ simulator:
 
   image:
     repository: mojaloop/simulator
-    tag: v11.0.0
+    tag: v11.0.2
     pullPolicy: Always
 
   imagePullSecrets: []
@@ -4592,7 +4592,7 @@ mojaloop-bulk:
       replicaCount: 1
       image:
         repository: mojaloop/bulk-api-adapter
-        tag: v11.0.0
+        tag: v11.0.1
         command: '["node", "src/api/index.js"]'
         ## Optionally specify an array of imagePullSecrets.
         ## Secrets must be manually created in the namespace.
@@ -4702,7 +4702,7 @@ mojaloop-bulk:
       replicaCount: 1
       image:
         repository: mojaloop/bulk-api-adapter
-        tag: v11.0.0
+        tag: v11.0.1
         command: '["node", "src/handlers/index.js", "handler", "--notification"]'
         ## Optionally specify an array of imagePullSecrets.
         ## Secrets must be manually created in the namespace.
@@ -4816,7 +4816,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v11.2.2
+            tag: v11.2.3
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
           service:
@@ -4984,7 +4984,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v11.2.2
+            tag: v11.2.3
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
           service:
@@ -5149,7 +5149,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v11.2.2
+            tag: v11.2.3
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
           service:
@@ -5313,7 +5313,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v11.0.1
+            tag: v11.2.3
             pullPolicy: Always
             command: '["node", "src/handlers/index.js", "handler", "--bulkget"]'
           service:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3434,7 +3434,7 @@ quoting-service:
   replicaCount: 1
   image:
     repository: mojaloop/quoting-service
-    tag: v11.1.2
+    tag: v11.1.4
     pullPolicy: Always
 
   readinessProbe:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -128,7 +128,7 @@ central:
         cache_enabled: false
         cache_max_byte_size: 10000000
         cache_expires_in_ms: 1000
-        resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
+        resource_versions: 'transfers=1.0,participants=1.0,quotes=1.0'
       init:
         enabled: true
         psql:
@@ -314,7 +314,7 @@ central:
 
         ## Enable On-Us transfers
         enable_on_us_transfers: false
-        resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
+        resource_versions: 'transfers=1.0,participants=1.0,quotes=1.0'
 
       init:
         enabled: true
@@ -505,7 +505,7 @@ central:
         cache_enabled: false
         cache_max_byte_size: 10000000
         cache_expires_in_ms: 1000
-        resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
+        resource_versions: 'transfers=1.0,participants=1.0,quotes=1.0'
 
       init:
         enabled: true
@@ -696,7 +696,7 @@ central:
         cache_enabled: false
         cache_max_byte_size: 10000000
         cache_expires_in_ms: 1000
-        resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
+        resource_versions: 'transfers=1.0,participants=1.0,quotes=1.0'
 
       init:
         enabled: true
@@ -887,7 +887,7 @@ central:
         cache_enabled: false
         cache_max_byte_size: 10000000
         cache_expires_in_ms: 1000
-        resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
+        resource_versions: 'transfers=1.0,participants=1.0,quotes=1.0'
 
       init:
         enabled: true
@@ -1078,7 +1078,7 @@ central:
         cache_enabled: false
         cache_max_byte_size: 10000000
         cache_expires_in_ms: 1000
-        resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
+        resource_versions: 'transfers=1.0,participants=1.0,quotes=1.0'
 
       init:
         enabled: true
@@ -1269,7 +1269,7 @@ central:
         cache_enabled: false
         cache_max_byte_size: 10000000
         cache_expires_in_ms: 1000
-        resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
+        resource_versions: 'transfers=1.0,participants=1.0,quotes=1.0'
 
       init:
         enabled: true
@@ -2441,7 +2441,7 @@ ml-api-adapter:
       error_handling:
         include_cause_extension: false
         truncate_extensions: true
-      resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
+      resource_versions: 'transfers=1.0,participants=1.0,quotes=1.0'
 
     service:
       type: ClusterIP
@@ -2586,7 +2586,7 @@ ml-api-adapter:
       error_handling:
         include_cause_extension: false
         truncate_extensions: true
-      resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
+      resource_versions: 'transfers=1.0,participants=1.0,quotes=1.0'
 
     service:
       type: ClusterIP
@@ -3488,7 +3488,7 @@ quoting-service:
       include_cause_extension: false
       truncate_extensions: true
 
-    resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
+    resource_versions: 'transfers=1.0,participants=1.0,quotes=1.0'
 
     endpointSecurity:
       jwsSign: false
@@ -4197,8 +4197,8 @@ mojaloop-simulator:
           # The incoming transfer request should consist of an ILP packet and a matching condition in this case.
           # The fulfilment will be generated from the provided ILP packet, and must hash to the provided condition.
           ALLOW_TRANSFER_WITHOUT_QUOTE: false
-          RESERVE_NOTIFICATION: true
-          RESOURCE_VERSIONS: transfers=1.1,quotes=1.0
+          RESERVE_NOTIFICATION: false
+          RESOURCE_VERSIONS: transfers=1.0,quotes=1.0
 
 
       backend:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -4592,7 +4592,7 @@ mojaloop-bulk:
       replicaCount: 1
       image:
         repository: mojaloop/bulk-api-adapter
-        tag: v11.0.1
+        tag: v11.0.2
         command: '["node", "src/api/index.js"]'
         ## Optionally specify an array of imagePullSecrets.
         ## Secrets must be manually created in the namespace.
@@ -4702,7 +4702,7 @@ mojaloop-bulk:
       replicaCount: 1
       image:
         repository: mojaloop/bulk-api-adapter
-        tag: v11.0.1
+        tag: v11.0.2
         command: '["node", "src/handlers/index.js", "handler", "--notification"]'
         ## Optionally specify an array of imagePullSecrets.
         ## Secrets must be manually created in the namespace.

--- a/quoting-service/Chart.yaml
+++ b/quoting-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Quoting-Service Helm chart for Kubernetes
 name: quoting-service
 version: 11.0.0
-appVersion: "10.5.5"
+appVersion: "11.1.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/quoting-service/Chart.yaml
+++ b/quoting-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Quoting-Service Helm chart for Kubernetes
 name: quoting-service
 version: 11.0.0
-appVersion: "11.1.2"
+appVersion: "11.1.4"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/quoting-service/templates/deployment.yaml
+++ b/quoting-service/templates/deployment.yaml
@@ -100,6 +100,9 @@ spec:
               value: {{ .Values.config.event_async_override | quote }}
             - name: EVENT_SDK_TRACEID_PER_VENDOR
               value: {{ .Values.config.event_traceid_per_vendor | quote }}
+            - name: LIB_RESOURCE_VERSIONS
+              value: {{ .Values.config.resource_versions}}
+
           volumeMounts:
           - name: {{ template "quotingservice.fullname" . }}-config-volume
             mountPath: /opt/quoting-service/config

--- a/quoting-service/values.yaml
+++ b/quoting-service/values.yaml
@@ -8,7 +8,7 @@ global: {}
 replicaCount: 1
 image:
   repository: mojaloop/quoting-service
-  tag: v11.1.0
+  tag: v11.1.2
   pullPolicy: Always
 
 readinessProbe:

--- a/quoting-service/values.yaml
+++ b/quoting-service/values.yaml
@@ -8,7 +8,7 @@ global: {}
 replicaCount: 1
 image:
   repository: mojaloop/quoting-service
-  tag: v11.1.2
+  tag: v11.1.4
   pullPolicy: Always
 
 readinessProbe:

--- a/quoting-service/values.yaml
+++ b/quoting-service/values.yaml
@@ -8,7 +8,7 @@ global: {}
 replicaCount: 1
 image:
   repository: mojaloop/quoting-service
-  tag: v10.5.5
+  tag: v11.1.0
   pullPolicy: Always
 
 readinessProbe:
@@ -126,6 +126,8 @@ config:
   error_handling:
     include_cause_extension: false
     truncate_extensions: true
+  resource_versions: 'transfers=1.1,participants=1.1,quotes=1.0'
+
 
 rules: []
 

--- a/simulator/Chart.yaml
+++ b/simulator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: Simulator Helm Chart for Simultors
 name: simulator
 version: 11.0.0
-appVersion: "11.0.0"
+appVersion: "11.0.2"

--- a/simulator/Chart.yaml
+++ b/simulator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: Simulator Helm Chart for Simultors
 name: simulator
 version: 11.0.0
-appVersion: "10.6.2"
+appVersion: "11.0.0"

--- a/simulator/values.yaml
+++ b/simulator/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: mojaloop/simulator
-  tag: v11.0.0
+  tag: v11.0.2
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/transaction-requests-service/Chart.yaml
+++ b/transaction-requests-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Transaction-Requests-Service Helm chart for Kubernetes
 name: transaction-requests-service
 version: 11.0.0
-appVersion: "10.4.0"
+appVersion: "11.1.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/transaction-requests-service/values.yaml
+++ b/transaction-requests-service/values.yaml
@@ -8,7 +8,7 @@ global: {}
 replicaCount: 1
 image:
   repository: mojaloop/transaction-requests-service
-  tag: v10.4.0
+  tag: v11.1.2
   pullPolicy: Always
   command: '["node", "src/index.js", "api"]'
 


### PR DESCRIPTION
Changes for v11.0.0

## Application versions
Application versions that are supported for this update:
1. ml-api-adapter: v10.5.0 -> **v11.1.2**
2. central-ledger: v10.5.1 -> **v11.2.3**
3. account-lookup-service: v10.4.2 -> **v11.1.2**
4. quoting-service: v10.5.5 -> **v11.1.4**
5. central-settlement: **v10.5.0** (no change)
6. central-event-processor: **v10.5.0** (no change)
7. bulk-api-adapter: v10.5.0 -> **v11.0.2**
8. email-notifier: **v9.5.0** (no change)
9. als-oracle-pathfinder: v9.4.0 --> **v10.2.0**
10. transaction-requests-service: v10.4.0 -> **v11.1.2**
11. finance-portal-ui: **v10.4.0** (no change)
12. finance-portal-backend-service: **v10.4.0** (no change)
13. settlement-management: **v8.8.2** (no change)
14. event-sidecar: **v9.5.1**  (no change)
15. event-stream-processor: **v9.5.0-snapshot**
16. simulator: v10.5.3 -> **v11.0.2**
17. mojaloop-simulator: v10.4.1 -> **v11.2.1**
18. sdk-scheme-adapter: v10.5.0 -> **v11.3.0**


Co-authored-by: Steven Oderayi <oderayi@gmail.com>
Co-authored-by: Sam <10507686+elnyry-sam-k@users.noreply.github.com>
Co-authored-by: Valentin <valentin.genev@modusbox.com>