### PR TITLE
Fixed bug supplying external JWS private key secret

### DIFF
--- a/mojaloop-simulator/templates/secret.yaml
+++ b/mojaloop-simulator/templates/secret.yaml
@@ -2,7 +2,7 @@
 {{- range $name, $customConfig := .Values.simulators }}
 {{- $config := merge $customConfig $.Values.defaults }}
 {{- $fullName := printf "%s%s" (include "mojaloop-simulator.prefix" $) $name -}}
-{{- if $config.config.schemeAdapter.env.JWS_SIGN }}
+{{- if (and $config.config.schemeAdapter.env.JWS_SIGN (not $config.config.schemeAdapter.secrets.jws.privKeySecretName)) }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
Before this change, the following configuration will not work. Afterward, it will. This enables supply of a private JWS key secret by an external source.
```yaml
simulators:
  payerfsp:
    config:
      schemeAdapter:
        secrets:
          jws:
            privKeySecretName: hello
        env:
          JWS_SIGN: true
```