### PR TITLE
Issue/mongodb repo changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ defaults_Environment: &defaults_environment
     helm repo add kiwigrid https://kiwigrid.github.io
     helm repo add elastic https://helm.elastic.co
     helm repo add codecentric https://codecentric.github.io/helm-charts
+    helm repo add bitnami https://charts.bitnami.com/bitnami
 
 ##
 # Executors

--- a/centraleventprocessor/requirements.yaml
+++ b/centraleventprocessor/requirements.yaml
@@ -7,6 +7,6 @@ dependencies:
 #   condition: kafka.enabled
 - name: mongodb
   version: 7.8.10
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.bitnami.com/bitnami/
   alias: mongodb
   condition: mongodb.enabled

--- a/ml-testing-toolkit/requirements.yaml
+++ b/ml-testing-toolkit/requirements.yaml
@@ -23,7 +23,7 @@ dependencies:
   condition: mysql.enabled
 - name: mongodb
   version: 7.8.10
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.bitnami.com/bitnami/
   alias: mongodb
   condition: mongodb.enabled
 - name: keycloak

--- a/mojaloop-bulk/requirements.yaml
+++ b/mojaloop-bulk/requirements.yaml
@@ -10,6 +10,6 @@ dependencies:
   condition: bulk-centralledger.enabled
 - name: mongodb
   version: 7.8.10
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.bitnami.com/bitnami/
   alias: mongodb
   condition: mongodb.enabled


### PR DESCRIPTION
Getting the following error for charts with mongodb dependency. It might be removed from that repository.
So changed the repo URL to bitnami.

```
Downloading mongodb from repo https://kubernetes-charts.storage.googleapis.com/
Save error occurred:  could not download https://charts.helm.sh/stable/mongodb-7.8.10.tgz: Failed to fetch https://charts.helm.sh/stable/mongodb-7.8.10.tgz : 404 Not Found
```