### PR TITLE
feat: #1957 TTK is not being deployed with published mojaloop helm (master)

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -38,11 +38,11 @@ declare -a charts=(
     bulk-centralledger/
     bulk-api-adapter/
     mojaloop-bulk/
-    mojaloop
-    kube-system/ntpd/
     mojaloop-simulator
     ml-testing-toolkit
     ml-testing-toolkit-cli
+    mojaloop
+    kube-system/ntpd/
 )
 
 for chart in "${charts[@]}"


### PR DESCRIPTION
Fixed ordering of packaged helm charts in the package.sh raised by the following issue: https://github.com/mojaloop/project/issues/1957

The issue was due to the ordering of helm charts specified in the package.sh, i.e. the Mojaloop helm chart was being packaged before the TTK chart....thus resulting in the missing dependencies required by the TTK chart.