### PR TITLE
chore: release v13.0.2

### DIFF
--- a/.changelog/release-v13.0.0.md
+++ b/.changelog/release-v13.0.0.md
@@ -165,6 +165,6 @@ Mojaloop-simulators:
 
 - Contributing organizations: BMGF, CrossLake, ModusBox , Sybrin
 - Crosslake: @lewisdaly
-- ModusBox: @elnyry-sam-k , @mdebarros, @vgenev , @vijayg10, @shashi165, @kleyow, @partiallyordered
+- ModusBox: @elnyry-sam-k, @mdebarros, @vgenev, @vijayg10, @shashi165, @kleyow, @partiallyordered
 - Sybrin: @JohannWNel
 _Note: companies in alphabetical order_

--- a/.changelog/release-v13.0.2.md
+++ b/.changelog/release-v13.0.2.md
@@ -9,50 +9,21 @@ Date | Revision | Description
 
 ### 1. Maintenance updates
 
-1. feat(#2343): helm v13.0.1 release:
-   * Patch bump to Mojaloop Helm Charts
-   * Patch Bump to Central-Settlements
-     * Updated Central-Settlements from 13.2.0 to 13.4.1
-   * Bump to Account-Lookup-Service
-     * Updated Account-Lookup-Service from 11.5.3 to 11.7.0
-   * Bump to Testing-Toolkit Charts
-     * Updated Testing-Toolkit-Backend from 12.4.2 to 13.2.2
-     * Updated Testing-Toolkit-UI from 12.4.2 to 13.2.2
-     * Updated Testing-Toolkit-CLI from 12.4.2 to 13.2.2
-
-2. Testing-Toolkit
-   * Provisioned new APIs (https://github.com/mojaloop/project/issues/2336)
-     * Central Admin API v1.0
-     * Central Settlements API v2.0
-     * SDK Outbound Scheme Adapter API v1.0
-   * Refined callback rules
-   * Added Test-case definition generation functionality (https://github.com/mojaloop/project/issues/2237)
-   * Improvements in mobile simulator page with settlement related additions to support Deferred Multilateral Net Settlement (DMLNS) and Continuous Gross Settlement (CGS)demos
+N/A.
 
 ### 2. New Features
 
-1. Modify switch behaviour on receipt of a GET /parties message to avoid problems with duplicates (https://github.com/mojaloop/design-authority-project/issues/79)
+N/A.
 
 ### 3. Bug Fixes
 
-1. TTK Tests is using hard-coded USD currency [#2066](https://github.com/mojaloop/project/issues/2066)
-2. Default CGS model settles also Deferred Net transfers [#2325](https://github.com/mojaloop/project/issues/2325)
-3. ALS Admin Service DELETE API not working as expected [#2342](https://github.com/mojaloop/project/issues/2342)
-4. Tests coverage not provided for scenarios when Deferred Multilateral Net Settlement (DMLNS) and Continuous Gross Settlement (CGS) models are used on the same Switch [#2314](https://github.com/mojaloop/project/issues/2314)
-5. Central-Settlement-service is failing GP tests when enabling event-sdk sidecar [#2368](https://github.com/mojaloop/project/issues/2368)
-6. Testing-Toolkit
-     * Test execution stops with error 'max call stack' when http outbound errors like socket hangup [#2312](https://github.com/mojaloop/project/issues/2312)
-     * Proper progress updates [#2331](https://github.com/mojaloop/project/issues/2331)
-     * Change UI to insert normalized lower case request headers [#2310](https://github.com/mojaloop/project/issues/2310)
-     * Add input values not working [#2329](https://github.com/mojaloop/project/issues/2329)
-     * Callback timeout in settings [#2330](https://github.com/mojaloop/project/issues/2330)
-     * Login is not working in the hosted mode [#2359](https://github.com/mojaloop/project/issues/2359)
+1. **#2358:** firstname, middlename and lastname regex not supporting myanmar script unicode strings ([#423](https://github.com/mojaloop/account-lookup-service/issues/423)) ([049ce8a](https://github.com/mojaloop/account-lookup-service/commit/049ce8ab296d9eb44825c9cd0f7e7b3bd69d279c)), closes [#2358](https://github.com/mojaloop/project/issues/2358)
 
 ## 4. Application versions
 
 1. ml-api-adapter: **v11.1.6**
 2. central-ledger:  **v13.12.1**
-3. account-lookup-service: v11.5.3 -> **v11.7.0**
+3. account-lookup-service: v11.7.0 -> **v11.7.2**
 4. quoting-service: **v12.0.6**
 5. central-settlement: v13.2.0 -> **13.4.1**
 6. central-event-processor: **v11.0.2**
@@ -76,7 +47,7 @@ Date | Revision | Description
 
 1. ml-api-adapter - https://github.com/mojaloop/ml-api-adapter/releases/tag/v11.1.6
 2. central-ledger - https://github.com/mojaloop/central-ledger/releases/tag/v13.12.1
-3. account-lookup-service - https://github.com/mojaloop/account-lookup-service/releases/tag/v11.7.0
+3. account-lookup-service - https://github.com/mojaloop/account-lookup-service/releases/tag/v11.7.2
 4. quoting-service - https://github.com/mojaloop/quoting-service/releases/tag/v12.0.6
 5. central-settlement- https://github.com/mojaloop/central-settlement/releases/tag/v13.4.1
 6. central-event-processor - https://github.com/mojaloop/central-event-processor/releases/tag/v11.0.2
@@ -130,11 +101,10 @@ N/A
 
 1. [#2119 - Idempotency for duplicate quote request](https://github.com/mojaloop/project/issues/2119)
 2. [#2322 - Helm install failing with with "medium to large" release names](https://github.com/mojaloop/project/issues/2322)
-3. [#2358 - Firstname, Middlename and Lastname regex not supporting myanmar script unicode strings #2358](https://github.com/mojaloop/project/issues/2358)
 
 ## 10. Contributors
 
 - Contributing organizations: BMGF, ModusBox 
-- ModusBox: @elnyry-sam-k, @mdebarros, @vgenev, @vijayg10, @shashi165, @kleyow, @bushjames
+- ModusBox: @elnyry-sam-k, @mdebarros, @vijayg10
 
 _Note: companies in alphabetical order_

--- a/.changelog/release-v13.0.2.md
+++ b/.changelog/release-v13.0.2.md
@@ -1,15 +1,19 @@
 ## Helm release notes
-1. GitHub issue: https://github.com/mojaloop/project/issues/2343
+1. GitHub issue: https://github.com/mojaloop/project/issues/2382
 2. For breaking changes, please review the section `#7` "Breaking Changes" below.
 3. Revisions:
 
 Date | Revision | Description
 ---------|----------|---------
- 2021-08-03  | 0 | Initial release - https://github.com/mojaloop/helm/pull/443
+ 2021-08-11  | 0 | Initial release - https://github.com/mojaloop/helm/pull/446
 
 ### 1. Maintenance updates
 
-N/A.
+1. Patch bump to Mojaloop Helm Charts
+2. Bump to Quoting-Service Helm Chart
+   * Updated Quoting-Service from 12.0.6 to 12.0.7
+3. Bump to Account-Lookup-Service Helm Charts
+   * Updated Account-Lookup-Service from 11.7.0 to 11.7.2
 
 ### 2. New Features
 
@@ -24,7 +28,7 @@ N/A.
 1. ml-api-adapter: **v11.1.6**
 2. central-ledger:  **v13.12.1**
 3. account-lookup-service: v11.7.0 -> **v11.7.2**
-4. quoting-service: **v12.0.6**
+4. quoting-service: v12.0.6 -> **12.0.7**
 5. central-settlement: v13.2.0 -> **13.4.1**
 6. central-event-processor: **v11.0.2**
 7. bulk-api-adapter: **v11.1.4**
@@ -48,7 +52,7 @@ N/A.
 1. ml-api-adapter - https://github.com/mojaloop/ml-api-adapter/releases/tag/v11.1.6
 2. central-ledger - https://github.com/mojaloop/central-ledger/releases/tag/v13.12.1
 3. account-lookup-service - https://github.com/mojaloop/account-lookup-service/releases/tag/v11.7.2
-4. quoting-service - https://github.com/mojaloop/quoting-service/releases/tag/v12.0.6
+4. quoting-service - https://github.com/mojaloop/quoting-service/releases/tag/v12.0.7
 5. central-settlement- https://github.com/mojaloop/central-settlement/releases/tag/v13.4.1
 6. central-event-processor - https://github.com/mojaloop/central-event-processor/releases/tag/v11.0.2
 7. bulk-api-adapter - https://github.com/mojaloop/bulk-api-adapter/releases/tag/v11.1.4

--- a/account-lookup-service/Chart.yaml
+++ b/account-lookup-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 12.2.0
-appVersion: "account-lookup-service: v11.7.0; als-oracle-pathfinder: v11.0.0"
+version: 12.2.1
+appVersion: "account-lookup-service: v11.7.2; als-oracle-pathfinder: v11.0.0"
 description: Account Lookup Service Helm Chart for Mojaloop
 name: account-lookup-service

--- a/account-lookup-service/chart-admin/Chart.yaml
+++ b/account-lookup-service/chart-admin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 12.2.0
-appVersion: "11.7.0"
+version: 12.2.1
+appVersion: "11.7.2"
 description: A Helm chart for Kubernetes
 name: account-lookup-service-admin

--- a/account-lookup-service/chart-admin/values.yaml
+++ b/account-lookup-service/chart-admin/values.yaml
@@ -7,7 +7,7 @@ containers:
   api:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v11.7.0
+      tag: v11.7.2
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--api"]'
     service:
@@ -18,7 +18,7 @@ containers:
   admin:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v11.7.0
+      tag: v11.7.2
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--admin"]'
     service:

--- a/account-lookup-service/chart-service/Chart.yaml
+++ b/account-lookup-service/chart-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 12.2.0
-appVersion: "11.7.0"
+version: 12.2.1
+appVersion: "11.7.2"
 description: A Helm chart for Kubernetes
 name: account-lookup-service

--- a/account-lookup-service/chart-service/values.yaml
+++ b/account-lookup-service/chart-service/values.yaml
@@ -8,7 +8,7 @@ containers:
   api:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v11.7.0
+      tag: v11.7.2
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--api"]'
     service:
@@ -19,7 +19,7 @@ containers:
   admin:
     image:
       repository: mojaloop/account-lookup-service
-      tag: v11.7.0
+      tag: v11.7.2
       pullPolicy: IfNotPresent
       command: '["node", "src/index.js", "server", "--admin"]'
     service:

--- a/account-lookup-service/requirements.yaml
+++ b/account-lookup-service/requirements.yaml
@@ -1,11 +1,11 @@
 # requirements.yaml
 dependencies:
 - name: account-lookup-service
-  version: 12.2.0
+  version: 12.2.1
   repository: "file://./chart-service"
   condition: account-lookup-service.enabled
 - name: account-lookup-service-admin
-  version: 12.2.0
+  version: 12.2.1
   repository: "file://./chart-admin"
   condition: account-lookup-service-admin.enabled
 - name: als-oracle-pathfinder

--- a/account-lookup-service/values.yaml
+++ b/account-lookup-service/values.yaml
@@ -9,7 +9,7 @@ account-lookup-service:
     api:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v11.7.0
+        tag: v11.7.2
         pullPolicy: IfNotPresent
         command: '["node", "src/index.js", "server", "--api"]'
       service:
@@ -20,7 +20,7 @@ account-lookup-service:
     admin:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v11.7.0
+        tag: v11.7.2
         pullPolicy: IfNotPresent
         command: '["node", "src/index.js", "server", "--admin"]'
       service:
@@ -168,7 +168,7 @@ account-lookup-service-admin:
     api:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v11.7.0
+        tag: v11.7.2
         pullPolicy: IfNotPresent
         command: '["node", "src/index.js", "server", "--api"]'
       service:
@@ -179,7 +179,7 @@ account-lookup-service-admin:
     admin:
       image:
         repository: mojaloop/account-lookup-service
-        tag: v11.7.0
+        tag: v11.7.2
         pullPolicy: IfNotPresent
         command: '["node", "src/index.js", "server", "--admin"]'
       service:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 13.0.1
-appVersion: "ml-api-adapter: v11.1.6; central-ledger: v13.12.1; account-lookup-service: v11.7.0; quoting-service: v12.0.6; central-settlement: v13.4.1; central-event-processor: v11.0.2; bulk-api-adapter: v11.1.4; email-notifier: v11.0.2; als-oracle-pathfinder: v11.0.0; transaction-requests-service: v11.1.5; finance-portal-ui: v10.4.3; finance-portal-backend-service: v15.0.2; settlement-management: v11.0.0; operator-settlement: v11.0.0; simulator: v11.1.2; mojaloop-simulator: v11.4.3; sdk-scheme-adapter: v11.17.1; ml-testing-toolkit: v13.2.2; ml-testing-toolkit-ui: v13.2.2;"
+appVersion: "ml-api-adapter: v11.1.6; central-ledger: v13.12.1; account-lookup-service: v11.7.2; quoting-service: v12.0.6; central-settlement: v13.4.1; central-event-processor: v11.0.2; bulk-api-adapter: v11.1.4; email-notifier: v11.0.2; als-oracle-pathfinder: v11.0.0; transaction-requests-service: v11.1.5; finance-portal-ui: v10.4.3; finance-portal-backend-service: v15.0.2; settlement-management: v11.0.0; operator-settlement: v11.0.0; simulator: v11.1.2; mojaloop-simulator: v11.4.3; sdk-scheme-adapter: v11.17.1; ml-testing-toolkit: v13.2.2; ml-testing-toolkit-ui: v13.2.2;"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 13.0.1
-appVersion: "ml-api-adapter: v11.1.6; central-ledger: v13.12.1; account-lookup-service: v11.7.2; quoting-service: v12.0.6; central-settlement: v13.4.1; central-event-processor: v11.0.2; bulk-api-adapter: v11.1.4; email-notifier: v11.0.2; als-oracle-pathfinder: v11.0.0; transaction-requests-service: v11.1.5; finance-portal-ui: v10.4.3; finance-portal-backend-service: v15.0.2; settlement-management: v11.0.0; operator-settlement: v11.0.0; simulator: v11.1.2; mojaloop-simulator: v11.4.3; sdk-scheme-adapter: v11.17.1; ml-testing-toolkit: v13.2.2; ml-testing-toolkit-ui: v13.2.2;"
+appVersion: "ml-api-adapter: v11.1.6; central-ledger: v13.12.1; account-lookup-service: v11.7.2; quoting-service: v12.0.7; central-settlement: v13.4.1; central-event-processor: v11.0.2; bulk-api-adapter: v11.1.4; email-notifier: v11.0.2; als-oracle-pathfinder: v11.0.0; transaction-requests-service: v11.1.5; finance-portal-ui: v10.4.3; finance-portal-backend-service: v15.0.2; settlement-management: v11.0.0; operator-settlement: v11.0.0; simulator: v11.1.2; mojaloop-simulator: v11.4.3; sdk-scheme-adapter: v11.17.1; ml-testing-toolkit: v13.2.2; ml-testing-toolkit-ui: v13.2.2;"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   repository: "file://../ml-api-adapter"
   condition: ml-api-adapter.enabled
 - name: account-lookup-service
-  version: 12.2.0
+  version: 12.2.1
   repository: "file://../account-lookup-service"
   condition: account-lookup-service.enabled
 - name: quoting-service

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -13,7 +13,7 @@ dependencies:
   repository: "file://../account-lookup-service"
   condition: account-lookup-service.enabled
 - name: quoting-service
-  version: 12.0.0
+  version: 12.0.1
   repository: "file://../quoting-service"
   condition: quoting-service.enabled
 - name: simulator

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3919,7 +3919,7 @@ account-lookup-service:
       api:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v11.7.0
+          tag: v11.7.2
           pullPolicy: IfNotPresent
           command: '["node", "src/index.js", "server", "--api"]'
         service:
@@ -3930,7 +3930,7 @@ account-lookup-service:
       admin:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v11.7.0
+          tag: v11.7.2
           pullPolicy: IfNotPresent
           command: '["node", "src/index.js", "server", "--admin"]'
         service:
@@ -4131,7 +4131,7 @@ account-lookup-service:
       api:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v11.7.0
+          tag: v11.7.2
           pullPolicy: IfNotPresent
           command: '["node", "src/index.js", "server", "--api"]'
         service:
@@ -4142,7 +4142,7 @@ account-lookup-service:
       admin:
         image:
           repository: mojaloop/account-lookup-service
-          tag: v11.7.0
+          tag: v11.7.2
           pullPolicy: IfNotPresent
           command: '["node", "src/index.js", "server", "--admin"]'
         service:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -4676,7 +4676,7 @@ quoting-service:
   replicaCount: 1
   image:
     repository: mojaloop/quoting-service
-    tag: v12.0.6
+    tag: v12.0.7
     pullPolicy: IfNotPresent
 
   readinessProbe:

--- a/quoting-service/Chart.yaml
+++ b/quoting-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Quoting-Service Helm chart for Kubernetes
 name: quoting-service
-version: 12.0.0
-appVersion: "12.0.6"
+version: 12.0.1
+appVersion: "12.0.7"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/quoting-service/values.yaml
+++ b/quoting-service/values.yaml
@@ -8,7 +8,7 @@ global: {}
 replicaCount: 1
 image:
   repository: mojaloop/quoting-service
-  tag: v12.0.6
+  tag: v12.0.7
   pullPolicy: IfNotPresent
 
 readinessProbe:


### PR DESCRIPTION
* chore: release v13.0.2
   - Added release notes for v13.0.2
   - Fixed typos in release notes v13.0.0, v13.0.1
   - Added https://github.com/mojaloop/project/issues/2358 as a known issue to v13.0.1 release notes
   - Upgraded Account-lookup-service from v11.7.0 to v11.7.2 -> fix for https://github.com/mojaloop/project/issues/2358
   - Bump to Account-lookup-service helm chart
   - Upgraded Quoting-service from v12.0.6 to v12.0.7 -> fix for https://github.com/mojaloop/project/issues/2358
   - Bump to Quoting-service helm chart
   - Bump to Mojaloop helm chart