### PR TITLE
feat(thirdparty): add consent-oracle chart

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -3,6 +3,6 @@
 Helm charts for Mojaloop Thirdparty API
 
 ## Sub-Charts
-- [chart-auth-svc](./chart-auth-svc)
-- [chart-consent-oracle](./chart-consent-oracle)
-- [chart-tp-api-svc](./chart-tp-api-svc)
+- [chart-auth-svc](./chart-auth-svc) - Central Auth-Svc
+- [chart-consent-oracle](./chart-consent-oracle) - CONSENT IdType oracle for the ALS
+- [chart-tp-api-svc](./chart-tp-api-svc) - Thirdparty Api Service

--- a/thirdparty/chart-auth-svc/Chart.yaml
+++ b/thirdparty/chart-auth-svc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-description: consent-oracle chart for Mojaloop Thirdparty Overlay Services
-name: consent-oracle
+description: auth-svc chart for Mojaloop Thirdparty Overlay Services
+name: auth-svc
 version: 0.1.0
 appVersion: "1.0.0"
 home: http://mojaloop.io
@@ -8,7 +8,7 @@ icon: http://mojaloop.io/images/logo.png
 sources:
   - https://github.com/mojaloop/mojaloop
   - https://github.com/mojaloop/helm
-  - https://github.com/mojaloop/als-consent-oracle
+  - https://github.com/mojaloop/auth-service
 maintainers:
   - name: Lewis Daly
     email: lewisd@crosslaketech.com

--- a/thirdparty/chart-auth-svc/values.yaml
+++ b/thirdparty/chart-auth-svc/values.yaml
@@ -35,8 +35,9 @@ readinessProbe:
 env:
   - name: NODE_ENV
     value: production
-  - name: LOG_LEVEL
-    value: debug
+  # e.g. to change the Log Level:
+  # - name: LOG_LEVEL
+  #   value: debug
 
 config:
   production.json: {

--- a/thirdparty/chart-consent-oracle/Chart.yaml
+++ b/thirdparty/chart-consent-oracle/Chart.yaml
@@ -8,7 +8,7 @@ icon: http://mojaloop.io/images/logo.png
 sources:
   - https://github.com/mojaloop/mojaloop
   - https://github.com/mojaloop/helm
-  - https://github.com/mojaloop/als-consent-oracle
+  - https://github.com/mojaloop/auth-service
 maintainers:
   - name: Lewis Daly
     email: lewisd@crosslaketech.com

--- a/thirdparty/chart-consent-oracle/README.md
+++ b/thirdparty/chart-consent-oracle/README.md
@@ -1,0 +1,15 @@
+# Consent-Oracle
+
+Consent-Oracle is an Oracle for the Account Lookup Service.
+
+When a Consent is verified by the Auth-Svc or a DFSP, it
+sends a `POST /participants/CONSENT/{ID}` to the ALS to
+store the 'authoritative source' of the Consent.
+
+## Dependencies
+
+This chart has the following dependencies:
+- mysql
+
+See `example_dependencies.yaml` for a simple example of installing and using the chart
+with base dependencies.

--- a/thirdparty/chart-consent-oracle/example_dependencies.yaml
+++ b/thirdparty/chart-consent-oracle/example_dependencies.yaml
@@ -1,0 +1,71 @@
+##
+# mysql-consent-oracle
+##
+
+# PersistentVolumeClaim
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-consent-oracle-pv-claim
+spec:
+  storageClassName: awsgp2
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+## Expose MySQL for consent-oracle
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-consent-oracle
+spec:
+  ports:
+  - port: 3306
+  selector:
+    app: mysql-consent-oracle
+  clusterIP: None
+---
+## Simple MySQL for consent-oracle
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql-consent-oracle
+spec:
+  selector:
+    matchLabels:
+      app: mysql-consent-oracle
+  serviceName: mysql-consent-oracle-svc
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mysql-consent-oracle
+    spec:
+      containers:
+      - image: mysql:5.7
+        name: mysql-consent-oracle
+        # command: [ '/bin/sh' ]
+        # args: ['-c', 'tail -f /dev/null']
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: password
+        - name: MYSQL_USER
+          value: consent-oracle
+        - name: MYSQL_PASSWORD
+          value: password
+        - name: MYSQL_DATABASE
+          value: consent-oracle
+        - name: NODE_ENV
+          value: development
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: mysql-consent-oracle-persistent-storage
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: mysql-consent-oracle-persistent-storage
+        persistentVolumeClaim:
+          claimName: mysql-consent-oracle-pv-claim

--- a/thirdparty/chart-consent-oracle/templates/_helpers.tpl
+++ b/thirdparty/chart-consent-oracle/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "consent-oracle.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "consent-oracle.name" -}}
+{{- default .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "consent-oracle.labels" -}}
+helm.sh/chart: {{ include "consent-oracle.chart" . }}
+app.kubernetes.io/name: {{ include "consent-oracle.name" . }}
+{{ include "consent-oracle.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "consent-oracle.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "consent-oracle.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+
+{{- define "apiVersion.Deployment" -}}
+  {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- print "apps/v1" -}}
+  {{- else -}}
+    {{- print "apps/v1beta2" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "apiVersion.Ingress" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/thirdparty/chart-consent-oracle/templates/configmap.yaml
+++ b/thirdparty/chart-consent-oracle/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "consent-oracle-config"
+  labels:
+    {{- include "consent-oracle.labels" . | nindent 4 }}
+data:
+  {{- range $k, $v := index .Values.config }}
+    {{ $k }}: {{ ($v | toPrettyJson | squote ) }}
+  {{- end }}

--- a/thirdparty/chart-consent-oracle/templates/deployment.yaml
+++ b/thirdparty/chart-consent-oracle/templates/deployment.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.enabled -}}
+apiVersion: {{ template "apiVersion.Deployment" . }}
+kind: Deployment
+metadata:
+  name: {{ include "consent-oracle.name" . }}
+  labels:
+    {{- include "consent-oracle.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+  selector:
+    matchLabels:
+      {{- include "consent-oracle.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "consent-oracle.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          command: {{ .Values.image.command }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.httpGet.path }}
+              port: {{ .Values.service.ports.internalPort }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.httpGet.path }}
+              port: {{ .Values.service.ports.internalPort }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          {{- end }}
+          volumeMounts:
+            - name: consent-oracle-config-volume
+              mountPath: /opt/als-consent-oracle/config/production.json
+              subPath: production.json
+          env:
+          {{- range $envItem := .Values.env }}
+            - name: {{ $envItem.name }}
+              value: {{ $envItem.value }}
+          {{- end }}
+      volumes:
+        - name: consent-oracle-config-volume
+          configMap:
+            name: consent-oracle-config
+            items:
+              - key: default.json
+                path: default.json
+{{- end -}}

--- a/thirdparty/chart-consent-oracle/templates/ingress.yaml
+++ b/thirdparty/chart-consent-oracle/templates/ingress.yaml
@@ -1,0 +1,30 @@
+{{- if index .Values "ingress" "enabled" -}}
+apiVersion: {{ template "apiVersion.Ingress" . }}
+kind: Ingress
+metadata:
+  name: {{ include "consent-oracle.name" . }}-ingress
+  labels:
+    {{- include "consent-oracle.labels" . | nindent 4 }}
+{{- with index .Values "ingress" "annotations" }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  rules:
+    {{- range $hostType, $service := .Values.ingress.hosts }}
+      - host: {{ index $service "host" }}
+        http:
+          paths:
+            {{- range $path := (index $service "paths") }}
+            - path: {{ $path }}
+              backend:
+                serviceName: {{ index $service "name" }}
+                servicePort: {{ index $service "port" }}
+            {{- end -}}
+      {{- end -}}
+    {{- if .Values.ingress.tls }}
+    tls:
+      {{ toYaml .Values.ingress.tls | indent 4 }}
+    {{- end -}}
+
+{{- end }}

--- a/thirdparty/chart-consent-oracle/templates/service.yaml
+++ b/thirdparty/chart-consent-oracle/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name:  {{ include "consent-oracle.name" . }}
+  labels:
+    app: consent-oracle
+    {{- include "consent-oracle.labels" . | nindent 4 }}
+spec:
+  ports:
+    {{- with .Values.service.ports }}
+    - port: {{ .externalPort }}
+      targetPort: {{ .internalPort }}
+      name: {{ .name }}
+    {{- end }}
+  selector:
+    {{- include "consent-oracle.selectorLabels" . | nindent 6 }}
+  clusterIP: None

--- a/thirdparty/chart-consent-oracle/values.yaml
+++ b/thirdparty/chart-consent-oracle/values.yaml
@@ -3,8 +3,8 @@ replicaCount: 1
 image:
   repository: mojaloop/als-consent-oracle
   tag: v0.0.6
-  command: '[ "tail", "-f", "/dev/null" ]'
-  # command: '[ "npm", "run", "start" ]'
+  # command: '[ "tail", "-f", "/dev/null" ]'
+  command: '[ "npm", "run", "start" ]'
   pullPolicy: IfNotPresent
 
 ## Pod scheduling preferences.
@@ -34,7 +34,8 @@ readinessProbe:
     port: 3000
 
 # Add exta environment variables here
-env:
+env: {}
+  # e.g.
   # - name: LOG_LEVEL
   #   value: debug
 
@@ -49,11 +50,11 @@ config:
     },
     "DATABASE": {
       "DIALECT": "mysql",
-      "HOST": "mysql-oracle-consent",
+      "HOST": "mysql-consent-oracle",
       "PORT": 3306,
-      "USER": "oracle_consent",
+      "USER": "consent-oracle",
       "PASSWORD": "password",
-      "DATABASE": "oracle_consent",
+      "DATABASE": "consent-oracle",
       "POOL_MIN_SIZE": 10,
       "POOL_MAX_SIZE": 10,
       "ACQUIRE_TIMEOUT_MILLIS": 30000,

--- a/thirdparty/chart-consent-oracle/values.yaml
+++ b/thirdparty/chart-consent-oracle/values.yaml
@@ -1,0 +1,93 @@
+enabled: true
+replicaCount: 1
+image:
+  repository: mojaloop/als-consent-oracle
+  tag: v0.0.6
+  command: '[ "tail", "-f", "/dev/null" ]'
+  # command: '[ "npm", "run", "start" ]'
+  pullPolicy: IfNotPresent
+
+## Pod scheduling preferences.
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
+## Node labels for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+nodeSelector: {}
+
+## Set toleration for scheduler
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  httpGet:
+    path: /health
+    port: 3000
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  httpGet:
+    path: /health
+    port: 3000
+
+# Add exta environment variables here
+env:
+  # - name: LOG_LEVEL
+  #   value: debug
+
+config:
+  default.json: {
+    "PORT": 3000,
+    "HOST": "0.0.0.0",
+    "INSPECT": {
+      "DEPTH": 4,
+      "SHOW_HIDDEN": false,
+      "COLOR": true
+    },
+    "DATABASE": {
+      "DIALECT": "mysql",
+      "HOST": "mysql-oracle-consent",
+      "PORT": 3306,
+      "USER": "oracle_consent",
+      "PASSWORD": "password",
+      "DATABASE": "oracle_consent",
+      "POOL_MIN_SIZE": 10,
+      "POOL_MAX_SIZE": 10,
+      "ACQUIRE_TIMEOUT_MILLIS": 30000,
+      "CREATE_TIMEOUT_MILLIS": 30000,
+      "DESTROY_TIMEOUT_MILLIS": 5000,
+      "IDLE_TIMEOUT_MILLIS": 30000,
+      "REAP_INTERVAL_MILLIS": 1000,
+      "CREATE_RETRY_INTERVAL_MILLIS": 200
+    }
+  }
+
+service:
+  type: ClusterIP
+  ports:
+    name: api
+    externalPort: 3000
+    internalPort: 3000
+
+ingress:
+  enabled: true
+  # Used to create an Ingress record.
+  hosts:
+    - host: consent-oracle.local
+      port: 3000
+      name: consent-oracle
+      paths: ['/']
+
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 8m
+    ## https://kubernetes.github.io/ingress-nginx/examples/rewrite/
+    # nginx.ingress.kubernetes.io/rewrite-target: '/'
+    # nginx.ingress.kubernetes.io/rewrite-target: '/$2'
+    ## https://kubernetes.github.io/ingress-nginx/user-guide/multiple-ingress/
+    # kubernetes.io/ingress.class: nginx
+    ## https://kubernetes.github.io/ingress-nginx/user-guide/tls/#automated-certificate-management-with-kube-lego
+    # kubernetes.io/tls-acme: "true"
+  tls: []


### PR DESCRIPTION
PR 2/3 for the base Thirdparty charts

- Adds support for a Consent oracle type that the ALS can use to store the owner of the Consent object.
- Cleans up log level in the auth-svc charts


Part of mojaloop/project#2450