### PR TITLE
chore(release): v14.1.0-rc

### DIFF
--- a/.changelog/release-v14.1.0.md
+++ b/.changelog/release-v14.1.0.md
@@ -1,0 +1,141 @@
+# Helm Release Notes
+
+- For *BREAKING CHANGES*, please review the section `#5` "Breaking Changes" below.
+- For *KNOWN ISSUES*, please review the section `#8` "Known Issues" below.
+
+## 1. New Features
+
+1. **mojaloop/#2092:** add bulk error handling notification callbacks ([#911](https://github.com/mojaloop/central-ledger/issues/911)) ([9ac6e1a](https://github.com/mojaloop/central-ledger/commit/9ac6e1afe3a72cbad0c1b5fc2a7a559d6435ce63))
+2. TBD...
+3. **Testing Toolkit:**:
+    1. TBD...
+
+## 2. Bug Fixes
+
+1. **mojaloop/#XXXX:** Some bug-fix example ([central-ledger/#XXXX](https://github.com/mojaloop/central-ledger/issues/XXXX)) ([central-ledger/XXXXX](https://github.com/mojaloop/central-ledger/commit/XXXX)), closes [mojaloop/#XXXX](https://github.com/mojaloop/project/issues/XXXX)
+2. **Testing Toolkit:**:
+    1. TBD...
+
+## 3. Application versions
+
+1. ml-api-adapter: v13.0.0 -> **v14.0.0**
+2. central-ledger: v13.16.1 -> **v16.1.0**
+3. account-lookup-service: v13.0.0 -> **v14.0.0**
+4. quoting-service: v14.0.0 -> **15.0.2**
+5. central-settlement: 13.4.1 -> **v14.0.0**
+6. central-event-processor: v11.0.2 -> **v12.0.0**
+7. bulk-api-adapter: v13.0.1 -> **v14.0.0**
+8. email-notifier: v11.0.2 -> **v12.0.0**
+9. als-oracle-pathfinder: v11.0.4 -> **v12.0.0**
+10. transaction-requests-service: v13.0.0 -> **v14.0.1**
+11. finance-portal-ui: **v10.4.3** _(DEPRECATED)_
+12. finance-portal-backend-service: **v15.0.2** _(DEPRECATED)_
+13. settlement-management: **v11.0.0** _(DEPRECATED)_
+14. operator-settlement: **v11.0.0** _(DEPRECATED)_
+15. event-sidecar: **v12.0.0**
+16. event-stream-processor: v11.0.0-snapshot -> **v12.0.0-snapshot.7**
+17. simulator: 12.0.0 -> **v12.0.0**
+18. mojaloop-simulator: v12.1.1 -> **v13.0.0**
+19. sdk-scheme-adapter: v11.18.11 -> **v18.0.2**
+20. ml-testing-toolkit: v14.0.4 -> **v15.0.0**
+21. ml-testing-toolkit-ui: v13.5.5 -> **v15.0.0**
+22. ml-testing-toolkit-client-lib: **v1.0.0**
+23. auth-service: v11.11.1 -> **v13.0.2**
+24. als-consent-service: v0.0.8 -> **v0.2.0**
+25. thirdparty-api-svc: v11.21.0 -> **v13.0.2**
+26. thirdparty-sdk: v11.55.1 -> **v15.1.0**
+
+## 4. Application release notes
+
+1. ml-api-adapter - https://github.com/mojaloop/ml-api-adapter/releases/tag/v14.0.0
+2. central-ledger - https://github.com/mojaloop/central-ledger/releases/tag/v15.1.0
+3. account-lookup-service - https://github.com/mojaloop/account-lookup-service/releases/tag/v14.0.0
+4. quoting-service - https://github.com/mojaloop/quoting-service/releases/tag/v15.0.2
+5. central-settlement- https://github.com/mojaloop/central-settlement/releases/tag/v14.0.0
+6. central-event-processor - https://github.com/mojaloop/central-event-processor/releases/tag/v12.0.0
+7. bulk-api-adapter - https://github.com/mojaloop/bulk-api-adapter/releases/tag/v14.0.0
+8. email-notifier - https://github.com/mojaloop/email-notifier/releases/tag/v12.0.0
+9. als-oracle-pathfinder - https://github.com/mojaloop/als-oracle-pathfinder/releases/tag/v12.0.0
+10. transaction-requests-service - https://github.com/mojaloop/transaction-requests-service/releases/tag/v14.0.1
+11. finance-portal-ui _(DEPRECATED)_ - https://github.com/mojaloop/finance-portal-ui/releases/tag/v10.4.3
+12. finance-portal-backend-service _(DEPRECATED)_ - https://github.com/mojaloop/finance-portal-backend-service/releases/tag/v15.0.2
+13. settlement-management _(DEPRECATED)_ - https://github.com/mojaloop/settlement-management/releases/tag/v11.0.0
+14. operator-settlement _(DEPRECATED)_ - https://github.com/mojaloop/operator-settlement/releases/tag/v11.0.0
+15. event-sidecar - https://github.com/mojaloop/event-sidecar/releases/tag/v12.0.0
+16. event-stream-processor - https://github.com/mojaloop/event-stream-processor/releases/v12.0.0-snapshot.7
+17. simulator - https://github.com/mojaloop/simulator/releases/tag/v12.0.0
+18. mojaloop-simulator - https://github.com/mojaloop/mojaloop-simulator/releases/tag/v13.0.0
+19. sdk-scheme-adapter - https://github.com/mojaloop/sdk-scheme-adapter/releases/tag/v18.0.2
+20. ml-testing-toolkit - https://github.com/mojaloop/ml-testing-toolkit/releases/tag/v15.0.0
+21. ml-testing-toolkit-ui - https://github.com/mojaloop/ml-testing-toolkit-ui/releases/tag/v15.0.0
+22. ml-testing-toolkit-client-lib - https://github.com/mojaloop/ml-testing-toolkit-client-lib/releases/tag/v1.0.0
+23. auth-service - https://github.com/mojaloop/auth-service/releases/tag/v11.11.1
+24. als-consent-service - https://github.com/mojaloop/als-consent-oracle/releases/tag/v0.0.8
+25. thirdparty-api-svc - https://github.com/mojaloop/thirdparty-api-svc/releases/tag/v11.21.0
+26. thirdparty-sdk-adapter - https://github.com/mojaloop/thirdparty-sdk/releases/tag/v11.55.1
+
+## 5. Breaking changes
+
+_Note: Below changes are breaking for upgrades and implementations of a Mojaloop Switch but not for FSPs or other entities interacting with a Mojaloop Switch itself._
+
+1. **Central-Ledger:** The FSPIOP api errors for invalid/inactive/non-existant FSP's for Bulk Transfers are now updated to be more descriptive which have been updated to:
+    - ErrorHandler.Enums.FSPIOPErrorCodes.PAYER_FSP_ID_NOT_FOUND - 3202
+    - ErrorHandler.Enums.FSPIOPErrorCodes.PAYEE_FSP_ID_NOT_FOUND - 3203
+
+    If you have conditional logic based on error callbacks of POST /bulkTransfers you will need to update the error codes accordingly. [mojaloop/central-ledger/pull/913](https://github.com/mojaloop/central-ledger/pull/913)
+
+## 6. Deprecations
+
+N/A
+
+## 7. Testing notes
+
+1. It is recommended that all Mojaloop deployments are verified using the [Mojaloop Testing Toolkit](https://docs.mojaloop.io/documentation/mojaloop-technical-overview/ml-testing-toolkit/). More information can be found in the [Mojaloop Deployment Guide](https://docs.mojaloop.io/documentation/deployment-guide).
+
+2. The [testing-toolkit-test-cases](https://github.com/mojaloop/testing-toolkit-test-cases/releases/tag/v14.0.0)' Golden Path collections expects:
+    - the Quoting service operating mode to be set [quoting-service.config.simple_routing_mode_enabled=true](https://github.com/mojaloop/helm/blob/v13.1.0/mojaloop/values.yaml#L4664). If this is incorrectly configured, it will result in several failures in the quoting-service tests (7 expected failures). If this is disabled, ensure that you update the corresponding test-case environment variable parameter [SIMPLE_ROUTING_MODE_ENABLED](https://github.com/mojaloop/helm/blob/v14.0.0/mojaloop/values.yaml#L7420) to match.
+    - the [on-us transfers](https://github.com/mojaloop/helm/blob/v14.0.0/mojaloop/values.yaml#L321) configuration to be disabled. The test-case environment variable parameter ([ON_US_TRANSFERS_ENABLED](https://github.com/mojaloop/helm/blob/v14.0.0/mojaloop/values.yaml#L7423), the same name used on postman collections) must similarly match this value.
+
+3. Simulators
+    - We recommend using Testing Toolkit instead of Postman which is better suited for the async nature of the Mojaloop API specification (see above)
+    - [Mojaloop-Simulator](https://github.com/mojaloop/mojaloop-simulator) is enabled by default (six instances used).
+    - Ensure that correct Postman Scripts are used if you wish to test against the Mojaloop-Simulators:
+        - Setup Mojaloop Hub: [MojaloopHub_Setup](https://github.com/mojaloop/postman/blob/v12.0.0/MojaloopHub_Setup.postman_collection.json)
+        - Setup Mojaloop Simulators for testing : [MojaloopSims_Onboarding](https://github.com/mojaloop/postman/blob/v12.0.0/MojaloopSims_Onboarding.postman_collection.json)
+        - Golden path tests: [Golden_Path_Mojaloop](https://github.com/mojaloop/postman/blob/v12.0.0/Golden_Path_Mojaloop.postman_collection.json)
+    - Legacy Simulators are still required and deployed by default; disabling this will cause issues since there is Account Lookup directory mocking functionality in this service.
+
+4. This release has been tested against the following:
+    - Kubernetes: v1.20.6
+    - Nginx Ingress Controllers: 0.43.0
+    - Testing Toolkit Test Cases: [v14.0.0](https://github.com/mojaloop/testing-toolkit-test-cases/releases/tag/v14.0.0)
+
+5. Thirdparty Testing Toolkit Test Collections are not repeatable. Please refer to the following issue for more information [#2717 - Thirdparty TTK Test-Collection is not repeatable](https://github.com/mojaloop/project/issues/2717). It is possible to manually cleanup persistent data to re-run the test if required.
+
+6. Bulk API Helm Tests
+
+    Refer to the [Testing Deployments](../README.md#testing-deployments) section in the main README for detailed information on how to enable bulk-api-adapter tests.
+
+7. Thirdparty API Helm Tests
+
+    Refer to [thirdparty/README.md#validating-and-testing-the-3p-api](../thirdparty/README.md#validating-and-testing-the-3p-api) on how to enabled and execute Thirdparty verification tests.
+
+## 8. Known Issues
+
+1. [#2119 - Idempotency for duplicate quote request](https://github.com/mojaloop/project/issues/2119)
+2. [#2322 - Helm install failing with with "medium to large" release names](https://github.com/mojaloop/project/issues/2322)
+3. [#2352 - Mojaloop Helm support for Kubernetes 1.22](https://github.com/mojaloop/project/issues/2352)
+4. [#2448 - Nginx Ingress Controller v1.0.0 is incompatible with Mojaloop Helm v13.0.x releases](https://github.com/mojaloop/project/issues/2448)
+5. [#2317 - Mojaloop Helm deployments are not compatible when deployed to ARM-arch based hosts](https://github.com/mojaloop/project/issues/2317)
+6. Testing Toolkit Test Case issues causing instability/intermitant failures on Test Case Results
+    1. [#2717 - Thirdparty TTK Test-Collection is not repeatable](https://github.com/mojaloop/project/issues/2717)
+    2. [#2734 - Failures in daily cron job running GP tests](https://github.com/mojaloop/project/issues/2734)
+    3. [#2845 - QA: Replace Legacy-Simulator as a NORESPONSE_SIMPAYEE in Testing-Toolkit Goden Path Test-Suite](https://github.com/mojaloop/project/issues/2845)
+    4. [#2846 - QA: Mojaloop TTK GP Test Collections to reset available liquidity after each run](https://github.com/mojaloop/project/issues/2846)
+
+## 9. Contributors
+
+- Organizations: BMGF, ModusBox
+- Individuals: @elnyry-sam-k, @mdebarros, @vijayg10, @kleyow, @kirgene
+
+_Note: companies are in alphabetical order, individuals are in no particular order._

--- a/.changelog/release-v14.1.0.md
+++ b/.changelog/release-v14.1.0.md
@@ -13,8 +13,9 @@
 
 ## 2. Bug Fixes
 
-1. **mojaloop/#XXXX:** Some bug-fix example ([central-ledger/#XXXX](https://github.com/mojaloop/central-ledger/issues/XXXX)) ([central-ledger/XXXXX](https://github.com/mojaloop/central-ledger/commit/XXXX)), closes [mojaloop/#XXXX](https://github.com/mojaloop/project/issues/XXXX)
-2. **Testing Toolkit:**:
+1. **mojaloop/#2863:** fix put callback http code ([bulk-api-adapter/#89](https://github.com/mojaloop/bulk-api-adapter/issues/89)) ([c6699ad](https://github.com/mojaloop/bulk-api-adapter/commit/c6699ad695e0a4627fd76d4288b9ef6e64cd2130)), closes [mojaloop/#2863](https://github.com/mojaloop/project/issues/2863)
+2. **mojaloop/#XXXX:** Some bug-fix example ([central-ledger/#XXXX](https://github.com/mojaloop/central-ledger/issues/XXXX)) ([central-ledger/XXXXX](https://github.com/mojaloop/central-ledger/commit/XXXX)), closes [mojaloop/#XXXX](https://github.com/mojaloop/project/issues/XXXX)
+3. **Testing Toolkit:**:
     1. TBD...
 
 ## 3. Application versions

--- a/bulk-api-adapter/Chart.yaml
+++ b/bulk-api-adapter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: bulk-api-adapter Helm chart for Kubernetes
 name: bulk-api-adapter
-version: 12.0.0
-appVersion: "14.0.0"
+version: 12.1.0
+appVersion: "14.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/Chart.yaml
+++ b/bulk-api-adapter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: bulk-api-adapter Helm chart for Kubernetes
 name: bulk-api-adapter
 version: 12.1.0
-appVersion: "14.1.0"
+appVersion: "14.1.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/chart-handler-notification/Chart.yaml
+++ b/bulk-api-adapter/chart-handler-notification/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: bulk-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: bulk-api-adapter-handler-notification
 version: 12.1.0
-appVersion: "14.1.0"
+appVersion: "14.1.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/chart-handler-notification/Chart.yaml
+++ b/bulk-api-adapter/chart-handler-notification/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: bulk-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: bulk-api-adapter-handler-notification
-version: 12.0.0
-appVersion: "14.0.0"
+version: 12.1.0
+appVersion: "14.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/chart-handler-notification/values.yaml
+++ b/bulk-api-adapter/chart-handler-notification/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/bulk-api-adapter
-  tag: v14.0.0
+  tag: v14.1.0
   command: '["node", "src/handlers/index.js", "handler", "--notification"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/bulk-api-adapter/chart-handler-notification/values.yaml
+++ b/bulk-api-adapter/chart-handler-notification/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/bulk-api-adapter
-  tag: v14.1.0
+  tag: v14.1.1
   command: '["node", "src/handlers/index.js", "handler", "--notification"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/bulk-api-adapter/chart-service/Chart.yaml
+++ b/bulk-api-adapter/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: bulk-api-adapter API component Helm chart for Kubernetes
 name: bulk-api-adapter-service
-version: 12.0.0
-appVersion: "14.0.0"
+version: 12.1.0
+appVersion: "14.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/chart-service/Chart.yaml
+++ b/bulk-api-adapter/chart-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: bulk-api-adapter API component Helm chart for Kubernetes
 name: bulk-api-adapter-service
 version: 12.1.0
-appVersion: "14.1.0"
+appVersion: "14.1.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/chart-service/values.yaml
+++ b/bulk-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/bulk-api-adapter
-  tag: v14.0.0
+  tag: v14.1.0
   command: '["node", "src/api/index.js"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/bulk-api-adapter/chart-service/values.yaml
+++ b/bulk-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/bulk-api-adapter
-  tag: v14.1.0
+  tag: v14.1.1
   command: '["node", "src/api/index.js"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.

--- a/bulk-api-adapter/requirements.yaml
+++ b/bulk-api-adapter/requirements.yaml
@@ -1,10 +1,10 @@
 # requirements.yaml
 dependencies:
 - name: bulk-api-adapter-service
-  version: 12.0.0
+  version: 12.1.0
   repository: "file://./chart-service"
   condition: bulk-api-adapter-service.enabled
 - name: bulk-api-adapter-handler-notification
-  version: 12.0.0
+  version: 12.1.0
   repository: "file://./chart-handler-notification"
   condition: bulk-api-adapter-handler-notification.enabled

--- a/bulk-api-adapter/values.yaml
+++ b/bulk-api-adapter/values.yaml
@@ -12,7 +12,7 @@ bulk-api-adapter-service:
   replicaCount: 1
   image:
     repository: mojaloop/bulk-api-adapter
-    tag: v14.1.0
+    tag: v14.1.1
     command: '["node", "src/api/index.js"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -152,7 +152,7 @@ bulk-api-adapter-handler-notification:
   replicaCount: 1
   image:
     repository: mojaloop/bulk-api-adapter
-    tag: v14.1.0
+    tag: v14.1.1
     command: '["node", "src/handlers/index.js", "handler", "--notification"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bulk-api-adapter/values.yaml
+++ b/bulk-api-adapter/values.yaml
@@ -12,7 +12,7 @@ bulk-api-adapter-service:
   replicaCount: 1
   image:
     repository: mojaloop/bulk-api-adapter
-    tag: v14.0.0
+    tag: v14.1.0
     command: '["node", "src/api/index.js"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -152,7 +152,7 @@ bulk-api-adapter-handler-notification:
   replicaCount: 1
   image:
     repository: mojaloop/bulk-api-adapter
-    tag: v14.0.0
+    tag: v14.1.0
     command: '["node", "src/handlers/index.js", "handler", "--notification"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bulk-centralledger/Chart.yaml
+++ b/bulk-centralledger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Bulk Services Helm chart for Kubernetes
 name: bulk-centralledger
-version: 13.0.0
-appVersion: "15.1.2"
+version: 14.0.0
+appVersion: "16.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Bulk Transfer Fulfil Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-fulfil
-version: 13.0.0
-appVersion: "15.1.2"
+version: 14.0.0
+appVersion: "16.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v15.1.2
+      tag: v16.1.0
       pullPolicy: IfNotPresent
       command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
     service:

--- a/bulk-centralledger/chart-handler-bulk-transfer-get/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-get/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Bulk Transfer Get Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-get
-version: 13.0.0
-appVersion: "15.1.2"
+version: 14.0.0
+appVersion: "16.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-get/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-get/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v15.1.2
+      tag: v16.1.0
       pullPolicy: IfNotPresent
       command: '["node", "src/handlers/index.js", "handler", "--bulkget"]'
     service:

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Bulk Transfer Prepare Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-prepare
-version: 13.0.0
-appVersion: "15.1.2"
+version: 14.0.0
+appVersion: "16.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v15.1.2
+      tag: v16.1.0
       pullPolicy: IfNotPresent
       command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
     service:

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Bulk Transfer Processing Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-processing
-version: 13.0.0
-appVersion: "15.1.2"
+version: 14.0.0
+appVersion: "16.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v15.1.2
+      tag: v16.1.0
       pullPolicy: IfNotPresent
       command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
     service:

--- a/bulk-centralledger/requirements.yaml
+++ b/bulk-centralledger/requirements.yaml
@@ -1,18 +1,18 @@
 # requirements.yaml
 dependencies:
 - name: cl-handler-bulk-transfer-prepare
-  version: 13.0.0
+  version: 14.0.0
   repository: "file://./chart-handler-bulk-transfer-prepare"
   condition: cl-handler-bulk-transfer-prepare.enabled
 - name: cl-handler-bulk-transfer-fulfil
-  version: 13.0.0
+  version: 14.0.0
   repository: "file://./chart-handler-bulk-transfer-fulfil"
   condition: cl-handler-bulk-transfer-fulfil.enabled
 - name: cl-handler-bulk-transfer-processing
-  version: 13.0.0
+  version: 14.0.0
   repository: "file://./chart-handler-bulk-transfer-processing"
   condition: cl-handler-bulk-transfer-processing.enabled
 - name: cl-handler-bulk-transfer-get
-  version: 13.0.0
+  version: 14.0.0
   repository: "file://./chart-handler-bulk-transfer-get"
   condition: cl-handler-bulk-transfer-get.enabled

--- a/bulk-centralledger/values.yaml
+++ b/bulk-centralledger/values.yaml
@@ -14,7 +14,7 @@ cl-handler-bulk-transfer-prepare:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v15.1.2
+        tag: v16.1.0
         pullPolicy: IfNotPresent
         command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
       service:
@@ -199,7 +199,7 @@ cl-handler-bulk-transfer-fulfil:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v15.1.2
+        tag: v16.1.0
         pullPolicy: IfNotPresent
         command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
       service:
@@ -381,7 +381,7 @@ cl-handler-bulk-transfer-processing:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v15.1.2
+        tag: v16.1.0
         pullPolicy: IfNotPresent
         command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
       service:
@@ -562,7 +562,7 @@ cl-handler-bulk-transfer-get:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v15.1.2
+        tag: v16.1.0
         pullPolicy: IfNotPresent
         command: '["node", "src/handlers/index.js", "handler", "--bulkget"]'
       service:

--- a/central/Chart.yaml
+++ b/central/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central Helm chart for Kubernetes
 name: central
-version: 14.0.0
-appVersion: "central-ledger: v15.1.2; central-settlement: v14.0.0; central-event-processor: v12.0.0"
+version: 15.0.0
+appVersion: "central-ledger: v16.1.0; central-settlement: v14.0.0; central-event-processor: v12.0.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/central/requirements.yaml
+++ b/central/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: centralledger
-  version: 13.0.0
+  version: 14.0.0
   repository: "file://../centralledger"
   condition: centralledger.enabled
 - name: centralsettlement

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -22,7 +22,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v15.1.2
+          tag: v16.1.0
           pullPolicy: IfNotPresent
           command: '["node", "src/api/index.js"]'
         service:
@@ -200,7 +200,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v15.1.2
+          tag: v16.1.0
           pullPolicy: IfNotPresent
           command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
         service:
@@ -388,7 +388,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v15.1.2
+          tag: v16.1.0
           pullPolicy: IfNotPresent
           command: '["node", "src/handlers/index.js", "handler", "--position"]'
         service:
@@ -573,7 +573,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v15.1.2
+          tag: v16.1.0
           pullPolicy: IfNotPresent
           command: '["node", "src/handlers/index.js", "handler", "--get"]'
         service:
@@ -758,7 +758,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v15.1.2
+          tag: v16.1.0
           pullPolicy: IfNotPresent
           command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
         service:
@@ -943,7 +943,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v15.1.2
+          tag: v16.1.0
           pullPolicy: IfNotPresent
           command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
         service:
@@ -1133,7 +1133,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v15.1.2
+          tag: v16.1.0
           pullPolicy: IfNotPresent
           command: '["node", "src/handlers/index.js", "handler", "--admin"]'
         service:

--- a/centralledger/Chart.yaml
+++ b/centralledger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Helm chart for Kubernetes
 name: centralledger
-version: 13.0.0
-appVersion: "15.1.2"
+version: 14.0.0
+appVersion: "16.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-admin-transfer/Chart.yaml
+++ b/centralledger/chart-handler-admin-transfer/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-admin-transfer
-version: 13.0.0
-appVersion: "15.1.2"
+version: 14.0.0
+appVersion: "16.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-admin-transfer/values.yaml
+++ b/centralledger/chart-handler-admin-transfer/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v15.1.2
+      tag: v16.1.0
       pullPolicy: IfNotPresent
       command: '["node", "src/handlers/index.js", "handler", "--admin"]'
     service:

--- a/centralledger/chart-handler-timeout/Chart.yaml
+++ b/centralledger/chart-handler-timeout/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Timeout Handler Helm chart for Kubernetes
 name: centralledger-handler-timeout
-version: 13.0.0
-appVersion: "15.1.2"
+version: 14.0.0
+appVersion: "16.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-timeout/values.yaml
+++ b/centralledger/chart-handler-timeout/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v15.1.2
+      tag: v16.1.0
       pullPolicy: IfNotPresent
       command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
     service:

--- a/centralledger/chart-handler-transfer-fulfil/Chart.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Fulfil Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-fulfil
-version: 13.0.0
-appVersion: "15.1.2"
+version: 14.0.0
+appVersion: "16.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-fulfil/values.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v15.1.2
+      tag: v16.1.0
       pullPolicy: IfNotPresent
       command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
     service:

--- a/centralledger/chart-handler-transfer-get/Chart.yaml
+++ b/centralledger/chart-handler-transfer-get/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Get Transfer Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-get
-version: 13.0.0
-appVersion: "15.1.2"
+version: 14.0.0
+appVersion: "16.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-get/values.yaml
+++ b/centralledger/chart-handler-transfer-get/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v15.1.2
+      tag: v16.1.0
       pullPolicy: IfNotPresent
       command: '["node", "src/handlers/index.js", "handler", "--get"]'
     service:

--- a/centralledger/chart-handler-transfer-position/Chart.yaml
+++ b/centralledger/chart-handler-transfer-position/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Position Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-position
-version: 13.0.0
-appVersion: "15.1.2"
+version: 14.0.0
+appVersion: "16.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-position/values.yaml
+++ b/centralledger/chart-handler-transfer-position/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v15.1.2
+      tag: v16.1.0
       pullPolicy: IfNotPresent
       command: '["node", "src/handlers/index.js", "handler", "--position"]'
     service:

--- a/centralledger/chart-handler-transfer-prepare/Chart.yaml
+++ b/centralledger/chart-handler-transfer-prepare/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-prepare
-version: 13.0.0
-appVersion: "15.1.2"
+version: 14.0.0
+appVersion: "16.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-prepare/values.yaml
+++ b/centralledger/chart-handler-transfer-prepare/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v15.1.2
+      tag: v16.1.0
       pullPolicy: IfNotPresent
       command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
     service:

--- a/centralledger/chart-service/Chart.yaml
+++ b/centralledger/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Central-Ledger Service Helm chart for Kubernetes
 name: centralledger-service
-version: 13.0.0
-appVersion: "15.1.2"
+version: 14.0.0
+appVersion: "16.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v15.1.2
+      tag: v16.1.0
       pullPolicy: IfNotPresent
       command: '["node", "src/api/index.js"]'
     service:

--- a/centralledger/requirements.yaml
+++ b/centralledger/requirements.yaml
@@ -1,31 +1,31 @@
 # requirements.yaml
 dependencies:
 - name: centralledger-service
-  version: 13.0.0
+  version: 14.0.0
   repository: "file://./chart-service"
   condition: centralledger-service.enabled
 - name: centralledger-handler-transfer-prepare
-  version: 13.0.0
+  version: 14.0.0
   repository: "file://./chart-handler-transfer-prepare"
   condition: centralledger-handler-transfer-prepare.enabled
 - name: centralledger-handler-transfer-position
-  version: 13.0.0
+  version: 14.0.0
   repository: "file://./chart-handler-transfer-position"
   condition: centralledger-handler-transfer-position.enabled
 - name: centralledger-handler-transfer-get
-  version: 13.0.0
+  version: 14.0.0
   repository: "file://./chart-handler-transfer-get"
   condition: centralledger-handler-transfer-get.enabled
 - name: centralledger-handler-transfer-fulfil
-  version: 13.0.0
+  version: 14.0.0
   repository: "file://./chart-handler-transfer-fulfil"
   condition: centralledger-handler-transfer-fulfil.enabled
 - name: centralledger-handler-timeout
-  version: 13.0.0
+  version: 14.0.0
   repository: "file://./chart-handler-timeout"
   condition: centralledger-handler-timeout.enabled
 - name: centralledger-handler-admin-transfer
-  version: 13.0.0
+  version: 14.0.0
   repository: "file://./chart-handler-admin-transfer"
   condition: centralledger-handler-transfer-get.enabled
 #- name: forensicloggingsidecar

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -17,7 +17,7 @@ centralledger-service:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v15.1.2
+        tag: v16.1.0
         pullPolicy: IfNotPresent
         command: '["node", "src/api/index.js"]'
       service:
@@ -196,7 +196,7 @@ centralledger-handler-transfer-prepare:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v15.1.2
+        tag: v16.1.0
         pullPolicy: IfNotPresent
         command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
       service:
@@ -385,7 +385,7 @@ centralledger-handler-transfer-position:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v15.1.2
+        tag: v16.1.0
         pullPolicy: IfNotPresent
         command: '["node", "src/handlers/index.js", "handler", "--position"]'
       service:
@@ -571,7 +571,7 @@ centralledger-handler-transfer-get:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v15.1.2
+        tag: v16.1.0
         pullPolicy: IfNotPresent
         command: '["node", "src/handlers/index.js", "handler", "--get"]'
       service:
@@ -757,7 +757,7 @@ centralledger-handler-transfer-fulfil:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v15.1.2
+        tag: v16.1.0
         pullPolicy: IfNotPresent
         command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
       service:
@@ -943,7 +943,7 @@ centralledger-handler-timeout:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v15.1.2
+        tag: v16.1.0
         pullPolicy: IfNotPresent
         command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
       service:
@@ -1134,7 +1134,7 @@ centralledger-handler-admin-transfer:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v15.1.2
+        tag: v16.1.0
         pullPolicy: IfNotPresent
         command: '["node", "src/handlers/index.js", "handler", "--admin"]'
       service:

--- a/mojaloop-bulk/Chart.yaml
+++ b/mojaloop-bulk/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Mojaloop Bulk Helm chart for Kubernetes
 name: mojaloop-bulk
-version: 14.0.0
-appVersion: "bulk-api-adapter: v14.0.0; central-ledger: v15.1.0"
+version: 15.0.0
+appVersion: "bulk-api-adapter: v14.1.0; central-ledger: v16.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop-bulk/Chart.yaml
+++ b/mojaloop-bulk/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Bulk Helm chart for Kubernetes
 name: mojaloop-bulk
 version: 15.0.0
-appVersion: "bulk-api-adapter: v14.1.0; central-ledger: v16.2.0"
+appVersion: "bulk-api-adapter: v14.1.1; central-ledger: v16.2.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop-bulk/requirements.yaml
+++ b/mojaloop-bulk/requirements.yaml
@@ -1,11 +1,11 @@
 # requirements.yaml
 dependencies:
 - name: bulk-api-adapter
-  version: 12.0.0
+  version: 12.1.0
   repository: "file://../bulk-api-adapter"
   condition: bulk-api-adapter.enabled
 - name: bulk-centralledger
-  version: 13.0.0
+  version: 14.0.0
   repository: "file://../bulk-centralledger"
   condition: bulk-centralledger.enabled
 - name: mongodb

--- a/mojaloop-bulk/values.yaml
+++ b/mojaloop-bulk/values.yaml
@@ -13,7 +13,7 @@ bulk-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/bulk-api-adapter
-      tag: v14.0.0
+      tag: v14.1.0
       command: '["node", "src/api/index.js"]'
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
@@ -153,7 +153,7 @@ bulk-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/bulk-api-adapter
-      tag: v14.0.0
+      tag: v14.1.0
       command: '["node", "src/handlers/index.js", "handler", "--notification"]'
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
@@ -297,7 +297,7 @@ bulk-centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v15.1.2
+          tag: v16.1.0
           pullPolicy: IfNotPresent
           command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
         service:
@@ -470,7 +470,7 @@ bulk-centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v15.1.2
+          tag: v16.1.0
           pullPolicy: IfNotPresent
           command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
         service:
@@ -640,7 +640,7 @@ bulk-centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v15.1.2
+          tag: v16.1.0
           pullPolicy: IfNotPresent
           command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
         service:
@@ -810,7 +810,7 @@ bulk-centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v15.1.2
+          tag: v16.1.0
           pullPolicy: IfNotPresent
           command: '["node", "src/handlers/index.js", "handler", "--bulkget"]'
         service:

--- a/mojaloop-bulk/values.yaml
+++ b/mojaloop-bulk/values.yaml
@@ -13,7 +13,7 @@ bulk-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/bulk-api-adapter
-      tag: v14.1.0
+      tag: v14.1.1
       command: '["node", "src/api/index.js"]'
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
@@ -153,7 +153,7 @@ bulk-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/bulk-api-adapter
-      tag: v14.1.0
+      tag: v14.1.1
       command: '["node", "src/handlers/index.js", "handler", "--notification"]'
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 14.1.0
-appVersion: "ml-api-adapter: v14.0.0; central-ledger: v16.2.0; account-lookup-service: v13.0.0; quoting-service: v15.0.2; central-settlement: v14.0.0; central-event-processor: v12.0.0; bulk-api-adapter: v14.1.0; email-notifier: v12.0.0; als-oracle-pathfinder: v12.0.0; transaction-requests-service: v14.0.1; simulator: v12.0.0; mojaloop-simulator: v13.0.0; sdk-scheme-adapter: v18.0.2; thirdparty-sdk: v15.1.0; ml-testing-toolkit: v15.0.0; ml-testing-toolkit-ui: v15.0.0;"
+appVersion: "ml-api-adapter: v14.0.0; central-ledger: v16.2.0; account-lookup-service: v13.0.0; quoting-service: v15.0.2; central-settlement: v14.0.0; central-event-processor: v12.0.0; bulk-api-adapter: v14.1.1; email-notifier: v12.0.0; als-oracle-pathfinder: v12.0.0; transaction-requests-service: v14.0.1; simulator: v12.0.0; mojaloop-simulator: v13.0.0; sdk-scheme-adapter: v18.0.2; thirdparty-sdk: v15.1.0; ml-testing-toolkit: v15.0.0; ml-testing-toolkit-ui: v15.0.0;"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
-version: 14.0.0
-appVersion: "ml-api-adapter: v14.0.0; central-ledger: v15.1.0; account-lookup-service: v13.0.0; quoting-service: v15.0.2; central-settlement: v14.0.0; central-event-processor: v12.0.0; bulk-api-adapter: v13.0.1; email-notifier: v12.0.0; als-oracle-pathfinder: v12.0.0; transaction-requests-service: v14.0.1; simulator: v12.0.0; mojaloop-simulator: v13.0.0; sdk-scheme-adapter: v18.0.2; thirdparty-sdk: v15.1.0; ml-testing-toolkit: v15.0.0; ml-testing-toolkit-ui: v15.0.0;"
+version: 14.1.0
+appVersion: "ml-api-adapter: v14.0.0; central-ledger: v16.1.0; account-lookup-service: v13.0.0; quoting-service: v15.0.2; central-settlement: v14.0.0; central-event-processor: v12.0.0; bulk-api-adapter: v14.1.0; email-notifier: v12.0.0; als-oracle-pathfinder: v12.0.0; transaction-requests-service: v14.0.1; simulator: v12.0.0; mojaloop-simulator: v13.0.0; sdk-scheme-adapter: v18.0.2; thirdparty-sdk: v15.1.0; ml-testing-toolkit: v15.0.0; ml-testing-toolkit-ui: v15.0.0;"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: central
-  version: 14.0.0
+  version: 15.0.0
   repository: "file://../central"
   condition: central.enabled
 - name: ml-api-adapter
@@ -25,7 +25,7 @@ dependencies:
   repository: "file://../mojaloop-simulator"
   condition: mojaloop-simulator.enabled
 - name: mojaloop-bulk
-  version: 14.0.0
+  version: 15.0.0
   repository: "file://../mojaloop-bulk"
   condition: mojaloop-bulk.enabled
 - name: transaction-requests-service

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -7631,8 +7631,8 @@ ml-ttk-posthook-setup:
     weight: -5
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
-    testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/v14.1.0-snapshot.1.zip
-    testCasesPathInZip: &ttkGitPathSetup testing-toolkit-test-cases-14.1.0-snapshot.1/collections/hub/provisioning
+    testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/v14.1.0-snapshot.2.zip
+    testCasesPathInZip: &ttkGitPathSetup testing-toolkit-test-cases-14.1.0-snapshot.2/collections/hub/provisioning
     ttkBackendURL: http://$release_name-ml-testing-toolkit-backend:5050
   parameters:
     <<: *simNames
@@ -7645,7 +7645,7 @@ ml-ttk-posthook-tests:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: &ttkGitPathGP testing-toolkit-test-cases-14.1.0-snapshot.1/collections/hub/golden_path
+    testCasesPathInZip: &ttkGitPathGP testing-toolkit-test-cases-14.1.0-snapshot.2/collections/hub/golden_path
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
     ttkBackendURL: http://$release_name-ml-testing-toolkit-backend:5050
@@ -7788,7 +7788,7 @@ ml-ttk-test-val-bulk:
     testCasesZipUrl: *ttkGitUrl
     # testCasesPathInZip: *ttkGitPathGP
     # testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/refs/heads/release/v14.0.0.zip
-    testCasesPathInZip: testing-toolkit-test-cases-14.1.0-snapshot.1/collections/hub/other_tests/bulk_transfers
+    testCasesPathInZip: testing-toolkit-test-cases-14.1.0-snapshot.2/collections/hub/other_tests/bulk_transfers
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
@@ -7828,7 +7828,7 @@ ml-ttk-test-setup-tp:
     testCasesZipUrl: *ttkGitUrl
     # testCasesPathInZip: *ttkGitPathGP
     # testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/refs/heads/release/v14.0.0.zip
-    testCasesPathInZip: testing-toolkit-test-cases-14.1.0-snapshot.1/collections/hub/provisioning_thirdparty
+    testCasesPathInZip: testing-toolkit-test-cases-14.1.0-snapshot.2/collections/hub/provisioning_thirdparty
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
@@ -7868,7 +7868,7 @@ ml-ttk-test-val-tp:
     testCasesZipUrl: *ttkGitUrl
     # testCasesPathInZip: *ttkGitPathGP
     # testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/refs/heads/release/v14.0.0.zip
-    testCasesPathInZip: testing-toolkit-test-cases-14.1.0-snapshot.1/collections/hub/thirdparty
+    testCasesPathInZip: testing-toolkit-test-cases-14.1.0-snapshot.2/collections/hub/thirdparty
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -6351,7 +6351,7 @@ mojaloop-bulk:
       replicaCount: 1
       image:
         repository: mojaloop/bulk-api-adapter
-        tag: v14.1.0
+        tag: v14.1.1
         command: '["node", "src/api/index.js"]'
         ## Optionally specify an array of imagePullSecrets.
         ## Secrets must be manually created in the namespace.
@@ -6486,7 +6486,7 @@ mojaloop-bulk:
       replicaCount: 1
       image:
         repository: mojaloop/bulk-api-adapter
-        tag: v14.1.0
+        tag: v14.1.1
         command: '["node", "src/handlers/index.js", "handler", "--notification"]'
         ## Optionally specify an array of imagePullSecrets.
         ## Secrets must be manually created in the namespace.

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -25,7 +25,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v15.1.2
+            tag: v16.1.0
             pullPolicy: IfNotPresent
             command: '["node", "src/api/index.js"]'
           service:
@@ -212,7 +212,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v15.1.2
+            tag: v16.1.0
             pullPolicy: IfNotPresent
             command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
           service:
@@ -409,7 +409,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v15.1.2
+            tag: v16.1.0
             pullPolicy: IfNotPresent
             command: '["node", "src/handlers/index.js", "handler", "--admin"]'
           service:
@@ -603,7 +603,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v15.1.2
+            tag: v16.1.0
             pullPolicy: IfNotPresent
             command: '["node", "src/handlers/index.js", "handler", "--position"]'
           service:
@@ -797,7 +797,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v15.1.2
+            tag: v16.1.0
             pullPolicy: IfNotPresent
             command: '["node", "src/handlers/index.js", "handler", "--get"]'
           service:
@@ -991,7 +991,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v15.1.2
+            tag: v16.1.0
             pullPolicy: IfNotPresent
             command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
           service:
@@ -1185,7 +1185,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v15.1.2
+            tag: v16.1.0
             pullPolicy: IfNotPresent
             command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
           service:
@@ -6351,7 +6351,7 @@ mojaloop-bulk:
       replicaCount: 1
       image:
         repository: mojaloop/bulk-api-adapter
-        tag: v14.0.0
+        tag: v14.1.0
         command: '["node", "src/api/index.js"]'
         ## Optionally specify an array of imagePullSecrets.
         ## Secrets must be manually created in the namespace.
@@ -6486,7 +6486,7 @@ mojaloop-bulk:
       replicaCount: 1
       image:
         repository: mojaloop/bulk-api-adapter
-        tag: v14.0.0
+        tag: v14.1.0
         command: '["node", "src/handlers/index.js", "handler", "--notification"]'
         ## Optionally specify an array of imagePullSecrets.
         ## Secrets must be manually created in the namespace.
@@ -6625,7 +6625,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v15.1.2
+            tag: v16.1.0
             pullPolicy: IfNotPresent
             command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
           service:
@@ -6797,7 +6797,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v15.1.2
+            tag: v16.1.0
             pullPolicy: IfNotPresent
             command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
           service:
@@ -6966,7 +6966,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v15.1.2
+            tag: v16.1.0
             pullPolicy: IfNotPresent
             command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
           service:
@@ -7135,7 +7135,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v15.1.2
+            tag: v16.1.0
             pullPolicy: IfNotPresent
             command: '["node", "src/handlers/index.js", "handler", "--bulkget"]'
           service:
@@ -7631,8 +7631,8 @@ ml-ttk-posthook-setup:
     weight: -5
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
-    testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/v14.0.0.zip
-    testCasesPathInZip: &ttkGitPathSetup testing-toolkit-test-cases-14.0.0/collections/hub/provisioning
+    testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/v14.1.0-snapshot.0.zip
+    testCasesPathInZip: &ttkGitPathSetup testing-toolkit-test-cases-14.1.0-snapshot.0/collections/hub/provisioning
     ttkBackendURL: http://$release_name-ml-testing-toolkit-backend:5050
   parameters:
     <<: *simNames
@@ -7645,7 +7645,7 @@ ml-ttk-posthook-tests:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: &ttkGitPathGP testing-toolkit-test-cases-14.0.0/collections/hub/golden_path
+    testCasesPathInZip: &ttkGitPathGP testing-toolkit-test-cases-14.1.0-snapshot.0/collections/hub/golden_path
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
     ttkBackendURL: http://$release_name-ml-testing-toolkit-backend:5050
@@ -7788,7 +7788,7 @@ ml-ttk-test-val-bulk:
     testCasesZipUrl: *ttkGitUrl
     # testCasesPathInZip: *ttkGitPathGP
     # testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/refs/heads/release/v14.0.0.zip
-    testCasesPathInZip: testing-toolkit-test-cases-14.0.0/collections/hub/other_tests/bulk_transfers
+    testCasesPathInZip: testing-toolkit-test-cases-14.1.0-snapshot.0/collections/hub/other_tests/bulk_transfers
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
@@ -7828,7 +7828,7 @@ ml-ttk-test-setup-tp:
     testCasesZipUrl: *ttkGitUrl
     # testCasesPathInZip: *ttkGitPathGP
     # testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/refs/heads/release/v14.0.0.zip
-    testCasesPathInZip: testing-toolkit-test-cases-14.0.0/collections/hub/provisioning_thirdparty
+    testCasesPathInZip: testing-toolkit-test-cases-14.1.0-snapshot.0/collections/hub/provisioning_thirdparty
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
@@ -7868,7 +7868,7 @@ ml-ttk-test-val-tp:
     testCasesZipUrl: *ttkGitUrl
     # testCasesPathInZip: *ttkGitPathGP
     # testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/refs/heads/release/v14.0.0.zip
-    testCasesPathInZip: testing-toolkit-test-cases-14.0.0/collections/hub/thirdparty
+    testCasesPathInZip: testing-toolkit-test-cases-14.1.0-snapshot.0/collections/hub/thirdparty
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -7632,7 +7632,7 @@ ml-ttk-posthook-setup:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/v14.1.0-snapshot.0.zip
-    testCasesPathInZip: &ttkGitPathSetup testing-toolkit-test-cases-14.1.0-snapshot.0/collections/hub/provisioning
+    testCasesPathInZip: &ttkGitPathSetup testing-toolkit-test-cases-v14.1.0-snapshot.0/collections/hub/provisioning
     ttkBackendURL: http://$release_name-ml-testing-toolkit-backend:5050
   parameters:
     <<: *simNames
@@ -7645,7 +7645,7 @@ ml-ttk-posthook-tests:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: &ttkGitPathGP testing-toolkit-test-cases-14.1.0-snapshot.0/collections/hub/golden_path
+    testCasesPathInZip: &ttkGitPathGP testing-toolkit-test-cases-v14.1.0-snapshot.0/collections/hub/golden_path
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
     ttkBackendURL: http://$release_name-ml-testing-toolkit-backend:5050


### PR DESCRIPTION
- upgraded central-ledger from v15.1.2 to v16.1.0
- upgraded bulk-api-adapter from v14.0.0 to v14.1.0
- bumped up versions to reflect the above changes for impacted charts
- upgraded testing-toolkit-test-cases from v14.0.0 v14.1.0-snapshot.0 in mojaloop/values.yaml config
- added v14.1.0 release notes (placeholder)

See [Changelog](https://github.com/mojaloop/helm/blob/release/v14.1.0/.changelog/release-v14.1.0.md) for more details: https://github.com/mojaloop/helm/blob/release/v14.1.0/.changelog/release-v14.1.0.md