### PR TITLE
chore(mojaloop/#2801): bump bulk images for bulk negative transfer scenarios

### DIFF
--- a/.changelog/release-v14.1.0.md
+++ b/.changelog/release-v14.1.0.md
@@ -6,8 +6,9 @@
 ## 1. New Features
 
 1. **mojaloop/#2092:** add bulk error handling notification callbacks ([#911](https://github.com/mojaloop/central-ledger/issues/911)) ([9ac6e1a](https://github.com/mojaloop/central-ledger/commit/9ac6e1afe3a72cbad0c1b5fc2a7a559d6435ce63))
-2. TBD...
-3. **Testing Toolkit:**:
+2. **mojaloop/#2801:** add fulfil timestamp validation and more error handling ([#916](https://github.com/mojaloop/central-ledger/issues/916)) ([336a0a2](https://github.com/mojaloop/central-ledger/commit/336a0a27e908eedeb0dcf8b171ad8c0edfb4c3d8))
+3. TBD...
+4. **Testing Toolkit:**:
     1. TBD...
 
 ## 2. Bug Fixes
@@ -48,7 +49,7 @@
 ## 4. Application release notes
 
 1. ml-api-adapter - https://github.com/mojaloop/ml-api-adapter/releases/tag/v14.0.0
-2. central-ledger - https://github.com/mojaloop/central-ledger/releases/tag/v15.1.0
+2. central-ledger - https://github.com/mojaloop/central-ledger/releases/tag/v16.2.0
 3. account-lookup-service - https://github.com/mojaloop/account-lookup-service/releases/tag/v14.0.0
 4. quoting-service - https://github.com/mojaloop/quoting-service/releases/tag/v15.0.2
 5. central-settlement- https://github.com/mojaloop/central-settlement/releases/tag/v14.0.0

--- a/.changelog/release-v14.1.0.md
+++ b/.changelog/release-v14.1.0.md
@@ -19,7 +19,7 @@
 ## 3. Application versions
 
 1. ml-api-adapter: v13.0.0 -> **v14.0.0**
-2. central-ledger: v13.16.1 -> **v16.1.0**
+2. central-ledger: v13.16.1 -> **v16.2.0**
 3. account-lookup-service: v13.0.0 -> **v14.0.0**
 4. quoting-service: v14.0.0 -> **15.0.2**
 5. central-settlement: 13.4.1 -> **v14.0.0**

--- a/bulk-centralledger/Chart.yaml
+++ b/bulk-centralledger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Bulk Services Helm chart for Kubernetes
 name: bulk-centralledger
 version: 14.0.0
-appVersion: "16.1.0"
+appVersion: "16.2.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Bulk Transfer Fulfil Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-fulfil
 version: 14.0.0
-appVersion: "16.1.0"
+appVersion: "16.2.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v16.1.0
+      tag: v16.2.0
       pullPolicy: IfNotPresent
       command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
     service:

--- a/bulk-centralledger/chart-handler-bulk-transfer-get/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-get/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Bulk Transfer Get Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-get
 version: 14.0.0
-appVersion: "16.1.0"
+appVersion: "16.2.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-get/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-get/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v16.1.0
+      tag: v16.2.0
       pullPolicy: IfNotPresent
       command: '["node", "src/handlers/index.js", "handler", "--bulkget"]'
     service:

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Bulk Transfer Prepare Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-prepare
 version: 14.0.0
-appVersion: "16.1.0"
+appVersion: "16.2.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v16.1.0
+      tag: v16.2.0
       pullPolicy: IfNotPresent
       command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
     service:

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Bulk Transfer Processing Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-processing
 version: 14.0.0
-appVersion: "16.1.0"
+appVersion: "16.2.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
@@ -24,7 +24,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v16.1.0
+      tag: v16.2.0
       pullPolicy: IfNotPresent
       command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
     service:

--- a/bulk-centralledger/values.yaml
+++ b/bulk-centralledger/values.yaml
@@ -14,7 +14,7 @@ cl-handler-bulk-transfer-prepare:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v16.1.0
+        tag: v16.2.0
         pullPolicy: IfNotPresent
         command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
       service:
@@ -199,7 +199,7 @@ cl-handler-bulk-transfer-fulfil:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v16.1.0
+        tag: v16.2.0
         pullPolicy: IfNotPresent
         command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
       service:
@@ -381,7 +381,7 @@ cl-handler-bulk-transfer-processing:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v16.1.0
+        tag: v16.2.0
         pullPolicy: IfNotPresent
         command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
       service:
@@ -562,7 +562,7 @@ cl-handler-bulk-transfer-get:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v16.1.0
+        tag: v16.2.0
         pullPolicy: IfNotPresent
         command: '["node", "src/handlers/index.js", "handler", "--bulkget"]'
       service:

--- a/central/Chart.yaml
+++ b/central/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central Helm chart for Kubernetes
 name: central
 version: 15.0.0
-appVersion: "central-ledger: v16.1.0; central-settlement: v14.0.0; central-event-processor: v12.0.0"
+appVersion: "central-ledger: v16.2.0; central-settlement: v14.0.0; central-event-processor: v12.0.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -22,7 +22,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v16.1.0
+          tag: v16.2.0
           pullPolicy: IfNotPresent
           command: '["node", "src/api/index.js"]'
         service:
@@ -200,7 +200,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v16.1.0
+          tag: v16.2.0
           pullPolicy: IfNotPresent
           command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
         service:
@@ -388,7 +388,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v16.1.0
+          tag: v16.2.0
           pullPolicy: IfNotPresent
           command: '["node", "src/handlers/index.js", "handler", "--position"]'
         service:
@@ -573,7 +573,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v16.1.0
+          tag: v16.2.0
           pullPolicy: IfNotPresent
           command: '["node", "src/handlers/index.js", "handler", "--get"]'
         service:
@@ -758,7 +758,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v16.1.0
+          tag: v16.2.0
           pullPolicy: IfNotPresent
           command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
         service:
@@ -943,7 +943,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v16.1.0
+          tag: v16.2.0
           pullPolicy: IfNotPresent
           command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
         service:
@@ -1133,7 +1133,7 @@ centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v16.1.0
+          tag: v16.2.0
           pullPolicy: IfNotPresent
           command: '["node", "src/handlers/index.js", "handler", "--admin"]'
         service:

--- a/centralledger/Chart.yaml
+++ b/centralledger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Helm chart for Kubernetes
 name: centralledger
 version: 14.0.0
-appVersion: "16.1.0"
+appVersion: "16.2.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-admin-transfer/Chart.yaml
+++ b/centralledger/chart-handler-admin-transfer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-admin-transfer
 version: 14.0.0
-appVersion: "16.1.0"
+appVersion: "16.2.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-admin-transfer/values.yaml
+++ b/centralledger/chart-handler-admin-transfer/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v16.1.0
+      tag: v16.2.0
       pullPolicy: IfNotPresent
       command: '["node", "src/handlers/index.js", "handler", "--admin"]'
     service:

--- a/centralledger/chart-handler-timeout/Chart.yaml
+++ b/centralledger/chart-handler-timeout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Timeout Handler Helm chart for Kubernetes
 name: centralledger-handler-timeout
 version: 14.0.0
-appVersion: "16.1.0"
+appVersion: "16.2.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-timeout/values.yaml
+++ b/centralledger/chart-handler-timeout/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v16.1.0
+      tag: v16.2.0
       pullPolicy: IfNotPresent
       command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
     service:

--- a/centralledger/chart-handler-transfer-fulfil/Chart.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Transfer Fulfil Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-fulfil
 version: 14.0.0
-appVersion: "16.1.0"
+appVersion: "16.2.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-fulfil/values.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v16.1.0
+      tag: v16.2.0
       pullPolicy: IfNotPresent
       command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
     service:

--- a/centralledger/chart-handler-transfer-get/Chart.yaml
+++ b/centralledger/chart-handler-transfer-get/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Get Transfer Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-get
 version: 14.0.0
-appVersion: "16.1.0"
+appVersion: "16.2.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-get/values.yaml
+++ b/centralledger/chart-handler-transfer-get/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v16.1.0
+      tag: v16.2.0
       pullPolicy: IfNotPresent
       command: '["node", "src/handlers/index.js", "handler", "--get"]'
     service:

--- a/centralledger/chart-handler-transfer-position/Chart.yaml
+++ b/centralledger/chart-handler-transfer-position/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Transfer Position Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-position
 version: 14.0.0
-appVersion: "16.1.0"
+appVersion: "16.2.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-position/values.yaml
+++ b/centralledger/chart-handler-transfer-position/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v16.1.0
+      tag: v16.2.0
       pullPolicy: IfNotPresent
       command: '["node", "src/handlers/index.js", "handler", "--position"]'
     service:

--- a/centralledger/chart-handler-transfer-prepare/Chart.yaml
+++ b/centralledger/chart-handler-transfer-prepare/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-prepare
 version: 14.0.0
-appVersion: "16.1.0"
+appVersion: "16.2.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-prepare/values.yaml
+++ b/centralledger/chart-handler-transfer-prepare/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v16.1.0
+      tag: v16.2.0
       pullPolicy: IfNotPresent
       command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
     service:

--- a/centralledger/chart-service/Chart.yaml
+++ b/centralledger/chart-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Central-Ledger Service Helm chart for Kubernetes
 name: centralledger-service
 version: 14.0.0
-appVersion: "16.1.0"
+appVersion: "16.2.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -11,7 +11,7 @@ containers:
   api:
     image:
       repository: mojaloop/central-ledger
-      tag: v16.1.0
+      tag: v16.2.0
       pullPolicy: IfNotPresent
       command: '["node", "src/api/index.js"]'
     service:

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -17,7 +17,7 @@ centralledger-service:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v16.1.0
+        tag: v16.2.0
         pullPolicy: IfNotPresent
         command: '["node", "src/api/index.js"]'
       service:
@@ -196,7 +196,7 @@ centralledger-handler-transfer-prepare:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v16.1.0
+        tag: v16.2.0
         pullPolicy: IfNotPresent
         command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
       service:
@@ -385,7 +385,7 @@ centralledger-handler-transfer-position:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v16.1.0
+        tag: v16.2.0
         pullPolicy: IfNotPresent
         command: '["node", "src/handlers/index.js", "handler", "--position"]'
       service:
@@ -571,7 +571,7 @@ centralledger-handler-transfer-get:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v16.1.0
+        tag: v16.2.0
         pullPolicy: IfNotPresent
         command: '["node", "src/handlers/index.js", "handler", "--get"]'
       service:
@@ -757,7 +757,7 @@ centralledger-handler-transfer-fulfil:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v16.1.0
+        tag: v16.2.0
         pullPolicy: IfNotPresent
         command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
       service:
@@ -943,7 +943,7 @@ centralledger-handler-timeout:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v16.1.0
+        tag: v16.2.0
         pullPolicy: IfNotPresent
         command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
       service:
@@ -1134,7 +1134,7 @@ centralledger-handler-admin-transfer:
     api:
       image:
         repository: mojaloop/central-ledger
-        tag: v16.1.0
+        tag: v16.2.0
         pullPolicy: IfNotPresent
         command: '["node", "src/handlers/index.js", "handler", "--admin"]'
       service:

--- a/mojaloop-bulk/Chart.yaml
+++ b/mojaloop-bulk/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Bulk Helm chart for Kubernetes
 name: mojaloop-bulk
 version: 15.0.0
-appVersion: "bulk-api-adapter: v14.1.0; central-ledger: v16.1.0"
+appVersion: "bulk-api-adapter: v14.1.0; central-ledger: v16.2.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop-bulk/values.yaml
+++ b/mojaloop-bulk/values.yaml
@@ -297,7 +297,7 @@ bulk-centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v16.1.0
+          tag: v16.2.0
           pullPolicy: IfNotPresent
           command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
         service:
@@ -470,7 +470,7 @@ bulk-centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v16.1.0
+          tag: v16.2.0
           pullPolicy: IfNotPresent
           command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
         service:
@@ -640,7 +640,7 @@ bulk-centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v16.1.0
+          tag: v16.2.0
           pullPolicy: IfNotPresent
           command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
         service:
@@ -810,7 +810,7 @@ bulk-centralledger:
       api:
         image:
           repository: mojaloop/central-ledger
-          tag: v16.1.0
+          tag: v16.2.0
           pullPolicy: IfNotPresent
           command: '["node", "src/handlers/index.js", "handler", "--bulkget"]'
         service:

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 14.1.0
-appVersion: "ml-api-adapter: v14.0.0; central-ledger: v16.1.0; account-lookup-service: v13.0.0; quoting-service: v15.0.2; central-settlement: v14.0.0; central-event-processor: v12.0.0; bulk-api-adapter: v14.1.0; email-notifier: v12.0.0; als-oracle-pathfinder: v12.0.0; transaction-requests-service: v14.0.1; simulator: v12.0.0; mojaloop-simulator: v13.0.0; sdk-scheme-adapter: v18.0.2; thirdparty-sdk: v15.1.0; ml-testing-toolkit: v15.0.0; ml-testing-toolkit-ui: v15.0.0;"
+appVersion: "ml-api-adapter: v14.0.0; central-ledger: v16.2.0; account-lookup-service: v13.0.0; quoting-service: v15.0.2; central-settlement: v14.0.0; central-event-processor: v12.0.0; bulk-api-adapter: v14.1.0; email-notifier: v12.0.0; als-oracle-pathfinder: v12.0.0; transaction-requests-service: v14.0.1; simulator: v12.0.0; mojaloop-simulator: v13.0.0; sdk-scheme-adapter: v18.0.2; thirdparty-sdk: v15.1.0; ml-testing-toolkit: v15.0.0; ml-testing-toolkit-ui: v15.0.0;"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -7631,7 +7631,7 @@ ml-ttk-posthook-setup:
     weight: -5
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
-    testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/v14.1.0-snapshot.0.zip
+    testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/v14.1.0-snapshot.1.zip
     testCasesPathInZip: &ttkGitPathSetup testing-toolkit-test-cases-14.1.0-snapshot.1/collections/hub/provisioning
     ttkBackendURL: http://$release_name-ml-testing-toolkit-backend:5050
   parameters:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -7632,7 +7632,7 @@ ml-ttk-posthook-setup:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/v14.1.0-snapshot.0.zip
-    testCasesPathInZip: &ttkGitPathSetup testing-toolkit-test-cases-14.1.0-snapshot.0/collections/hub/provisioning
+    testCasesPathInZip: &ttkGitPathSetup testing-toolkit-test-cases-14.1.0-snapshot.1/collections/hub/provisioning
     ttkBackendURL: http://$release_name-ml-testing-toolkit-backend:5050
   parameters:
     <<: *simNames
@@ -7645,7 +7645,7 @@ ml-ttk-posthook-tests:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: &ttkGitPathGP testing-toolkit-test-cases-14.1.0-snapshot.0/collections/hub/golden_path
+    testCasesPathInZip: &ttkGitPathGP testing-toolkit-test-cases-14.1.0-snapshot.1/collections/hub/golden_path
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
     ttkBackendURL: http://$release_name-ml-testing-toolkit-backend:5050
@@ -7788,7 +7788,7 @@ ml-ttk-test-val-bulk:
     testCasesZipUrl: *ttkGitUrl
     # testCasesPathInZip: *ttkGitPathGP
     # testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/refs/heads/release/v14.0.0.zip
-    testCasesPathInZip: testing-toolkit-test-cases-14.1.0-snapshot.0/collections/hub/other_tests/bulk_transfers
+    testCasesPathInZip: testing-toolkit-test-cases-14.1.0-snapshot.1/collections/hub/other_tests/bulk_transfers
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
@@ -7828,7 +7828,7 @@ ml-ttk-test-setup-tp:
     testCasesZipUrl: *ttkGitUrl
     # testCasesPathInZip: *ttkGitPathGP
     # testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/refs/heads/release/v14.0.0.zip
-    testCasesPathInZip: testing-toolkit-test-cases-14.1.0-snapshot.0/collections/hub/provisioning_thirdparty
+    testCasesPathInZip: testing-toolkit-test-cases-14.1.0-snapshot.1/collections/hub/provisioning_thirdparty
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
@@ -7868,7 +7868,7 @@ ml-ttk-test-val-tp:
     testCasesZipUrl: *ttkGitUrl
     # testCasesPathInZip: *ttkGitPathGP
     # testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/refs/heads/release/v14.0.0.zip
-    testCasesPathInZip: testing-toolkit-test-cases-14.1.0-snapshot.0/collections/hub/thirdparty
+    testCasesPathInZip: testing-toolkit-test-cases-14.1.0-snapshot.1/collections/hub/thirdparty
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -25,7 +25,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v16.1.0
+            tag: v16.2.0
             pullPolicy: IfNotPresent
             command: '["node", "src/api/index.js"]'
           service:
@@ -212,7 +212,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v16.1.0
+            tag: v16.2.0
             pullPolicy: IfNotPresent
             command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
           service:
@@ -409,7 +409,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v16.1.0
+            tag: v16.2.0
             pullPolicy: IfNotPresent
             command: '["node", "src/handlers/index.js", "handler", "--admin"]'
           service:
@@ -603,7 +603,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v16.1.0
+            tag: v16.2.0
             pullPolicy: IfNotPresent
             command: '["node", "src/handlers/index.js", "handler", "--position"]'
           service:
@@ -797,7 +797,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v16.1.0
+            tag: v16.2.0
             pullPolicy: IfNotPresent
             command: '["node", "src/handlers/index.js", "handler", "--get"]'
           service:
@@ -991,7 +991,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v16.1.0
+            tag: v16.2.0
             pullPolicy: IfNotPresent
             command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
           service:
@@ -1185,7 +1185,7 @@ central:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v16.1.0
+            tag: v16.2.0
             pullPolicy: IfNotPresent
             command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
           service:
@@ -6625,7 +6625,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v16.1.0
+            tag: v16.2.0
             pullPolicy: IfNotPresent
             command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
           service:
@@ -6797,7 +6797,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v16.1.0
+            tag: v16.2.0
             pullPolicy: IfNotPresent
             command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
           service:
@@ -6966,7 +6966,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v16.1.0
+            tag: v16.2.0
             pullPolicy: IfNotPresent
             command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
           service:
@@ -7135,7 +7135,7 @@ mojaloop-bulk:
         api:
           image:
             repository: mojaloop/central-ledger
-            tag: v16.1.0
+            tag: v16.2.0
             pullPolicy: IfNotPresent
             command: '["node", "src/handlers/index.js", "handler", "--bulkget"]'
           service:


### PR DESCRIPTION
chore(mojaloop/#2801): bump bulk images for bulk negative transfer scenarios - [https://github.com/mojaloop/project/issues/2801](https://github.com/mojaloop/project/issues/2801)
- upgraded central-ledger from v16.1.0 to v16.2.0
- upgraded testing-toolkit-test-cases from v14.1.0-snapshot.0 to v14.1.0-snapshot.1 in mojaloop/values.yaml config

Tested with snapshot of https://github.com/mojaloop/testing-toolkit-test-cases/pull/81