### PR TITLE
feat(mojaloop/#2909): update Helm deployment init-containers with mongodb dependencies

### DIFF
--- a/account-lookup-service/chart-admin/values.yaml
+++ b/account-lookup-service/chart-admin/values.yaml
@@ -199,7 +199,7 @@ init:
     enabled: true
     name: wait-for-mysql
     repository: mysql
-    tag: latest
+    tag: 8.0.30
     pullPolicy: IfNotPresent
     command: "until mysql -h $db_host -P $db_port -u $db_user --password=$db_password $db_database -e 'select version()' ; do echo waiting for MySQL; sleep 2; done;"
   migration:

--- a/account-lookup-service/chart-service/values.yaml
+++ b/account-lookup-service/chart-service/values.yaml
@@ -200,7 +200,7 @@ init:
     enabled: true
     name: wait-for-mysql
     repository: mysql
-    tag: latest
+    tag: 8.0.30
     pullPolicy: IfNotPresent
     command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 

--- a/account-lookup-service/values.yaml
+++ b/account-lookup-service/values.yaml
@@ -139,7 +139,7 @@ account-lookup-service:
       enabled: true
       name: wait-for-mysql
       repository: mysql
-      tag: latest
+      tag: 8.0.30
       pullPolicy: IfNotPresent
       command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -320,7 +320,7 @@ account-lookup-service-admin:
     mysql:
       name: wait-for-mysql
       repository: mysql
-      tag: latest
+      tag: 8.0.30
       pullPolicy: IfNotPresent
       command: "until mysql -h $db_host -P $db_port -u $db_user --password=$db_password $db_database -e 'select version()' ; do echo waiting for MySQL; sleep 2; done;"
     migration:
@@ -524,7 +524,7 @@ als-oracle-pathfinder:
     waitForMysql:
       name: wait-for-mysql
       repository: mysql
-      tag: latest
+      tag: 8.0.30
       pullPolicy: IfNotPresent
       command: "until mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database   -e 'select version()' ; do echo waiting for MySQL; sleep 2; done;"
     initMysql:
@@ -543,7 +543,7 @@ als-oracle-pathfinder:
     populateMysql:
       name: populate-mysql-tables
       repository: mysql
-      tag: latest
+      tag: 8.0.30
       pullPolicy: IfNotPresent
       command: "echo 'Nothing configured to be populated. Continuing...';"
   service:

--- a/als-oracle-pathfinder/values.yaml
+++ b/als-oracle-pathfinder/values.yaml
@@ -199,7 +199,7 @@ init:
   waitForMysql:
     name: wait-for-mysql
     repository: mysql
-    tag: latest
+    tag: 8.0.30
     pullPolicy: IfNotPresent
     command: "until mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database   -e 'select version()' ; do echo waiting for MySQL; sleep 2; done;"
   initMysql:
@@ -221,7 +221,7 @@ init:
     enabled: true
     name: populate-mysql-tables
     repository: mysql
-    tag: latest
+    tag: 8.0.30
     pullPolicy: IfNotPresent
     command: "echo 'Nothing configured to be populated. Continuing...';"
 service:

--- a/bulk-api-adapter/chart-handler-notification/values.yaml
+++ b/bulk-api-adapter/chart-handler-notification/values.yaml
@@ -31,7 +31,7 @@ init:
   kafka:
     name: wait-for-kafka
     repository: solsson/kafka
-    tag: latest
+    tag: 2.8.1
     pullPolicy: IfNotPresent
     command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
     env: {}

--- a/bulk-api-adapter/chart-handler-notification/values.yaml
+++ b/bulk-api-adapter/chart-handler-notification/values.yaml
@@ -44,9 +44,9 @@ init:
   mongodb:
     name: wait-for-mongodb
     repository: bitnami/mongodb
-    tag: latest
+    tag: 6.0.1
     pullPolicy: IfNotPresent
-    command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+    command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
 readinessProbe:
   enabled: true

--- a/bulk-api-adapter/chart-service/values.yaml
+++ b/bulk-api-adapter/chart-service/values.yaml
@@ -31,7 +31,7 @@ init:
   kafka:
     name: wait-for-kafka
     repository: solsson/kafka
-    tag: latest
+    tag: 2.8.1
     pullPolicy: IfNotPresent
     command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
     env: {}

--- a/bulk-api-adapter/chart-service/values.yaml
+++ b/bulk-api-adapter/chart-service/values.yaml
@@ -44,9 +44,9 @@ init:
   mongodb:
     name: wait-for-mongodb
     repository: bitnami/mongodb
-    tag: latest
+    tag: 6.0.1
     pullPolicy: IfNotPresent
-    command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+    command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
 readinessProbe:
   enabled: true

--- a/bulk-api-adapter/values.yaml
+++ b/bulk-api-adapter/values.yaml
@@ -40,9 +40,9 @@ bulk-api-adapter-service:
     mongodb:
       name: wait-for-mongodb
       repository: bitnami/mongodb
-      tag: latest
+      tag: 6.0.1
       pullPolicy: IfNotPresent
-      command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+      command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
   readinessProbe:
     enabled: true
@@ -180,9 +180,9 @@ bulk-api-adapter-handler-notification:
     mongodb:
       name: wait-for-mongodb
       repository: bitnami/mongodb
-      tag: latest
+      tag: 6.0.1
       pullPolicy: IfNotPresent
-      objstore_uri: 'mongodb://$mongodbUsername:$mongodbPassword@$release_name-centralledger-obj:27017/$mongodbDatabase'
+      command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
   readinessProbe:
     enabled: true

--- a/bulk-api-adapter/values.yaml
+++ b/bulk-api-adapter/values.yaml
@@ -27,7 +27,7 @@ bulk-api-adapter-service:
     kafka:
       name: wait-for-kafka
       repository: solsson/kafka
-      tag: latest
+      tag: 2.8.1
       pullPolicy: IfNotPresent
       command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
       env: {}
@@ -167,7 +167,7 @@ bulk-api-adapter-handler-notification:
     kafka:
       name: wait-for-kafka
       repository: solsson/kafka
-      tag: latest
+      tag: 2.8.1
       pullPolicy: IfNotPresent
       command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
       env: {}

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
@@ -136,9 +136,9 @@ init:
   mongodb:
     name: wait-for-mongodb
     repository: bitnami/mongodb
-    tag: latest
+    tag: 6.0.1
     pullPolicy: IfNotPresent
-    command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+    command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
 service:
   type: ClusterIP

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
@@ -112,7 +112,7 @@ init:
   kafka:
     name: wait-for-kafka
     repository: solsson/kafka
-    tag: latest
+    tag: 2.8.1
     pullPolicy: IfNotPresent
     command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
     env: {}
@@ -130,7 +130,7 @@ init:
   mysql:
     name: wait-for-mysql
     repository: mysql
-    tag: latest
+    tag: 8.0.30
     pullPolicy: IfNotPresent
     command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
   mongodb:

--- a/bulk-centralledger/chart-handler-bulk-transfer-get/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-get/values.yaml
@@ -136,9 +136,9 @@ init:
   mongodb:
     name: wait-for-mongodb
     repository: bitnami/mongodb
-    tag: latest
+    tag: 6.0.1
     pullPolicy: IfNotPresent
-    command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+    command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
 service:
   type: ClusterIP

--- a/bulk-centralledger/chart-handler-bulk-transfer-get/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-get/values.yaml
@@ -112,7 +112,7 @@ init:
   kafka:
     name: wait-for-kafka
     repository: solsson/kafka
-    tag: latest
+    tag: 2.8.1
     pullPolicy: IfNotPresent
     command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
     env: {}
@@ -130,7 +130,7 @@ init:
   mysql:
     name: wait-for-mysql
     repository: mysql
-    tag: latest
+    tag: 8.0.30
     pullPolicy: IfNotPresent
     command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
   mongodb:

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
@@ -139,9 +139,9 @@ init:
   mongodb:
     name: wait-for-mongodb
     repository: bitnami/mongodb
-    tag: latest
+    tag: 6.0.1
     pullPolicy: IfNotPresent
-    command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+    command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
 service:
   type: ClusterIP

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
@@ -115,7 +115,7 @@ init:
   kafka:
     name: wait-for-kafka
     repository: solsson/kafka
-    tag: latest
+    tag: 2.8.1
     pullPolicy: IfNotPresent
     command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
     env: {}
@@ -133,7 +133,7 @@ init:
   mysql:
     name: wait-for-mysql
     repository: mysql
-    tag: latest
+    tag: 8.0.30
     pullPolicy: IfNotPresent
     command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
   mongodb:

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
@@ -149,9 +149,9 @@ init:
   mongodb:
     name: wait-for-mongodb
     repository: bitnami/mongodb
-    tag: latest
+    tag: 6.0.1
     pullPolicy: IfNotPresent
-    command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+    command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
 service:
   type: ClusterIP

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
@@ -125,7 +125,7 @@ init:
   kafka:
     name: wait-for-kafka
     repository: solsson/kafka
-    tag: latest
+    tag: 2.8.1
     pullPolicy: IfNotPresent
     command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
     env: {}
@@ -143,7 +143,7 @@ init:
   mysql:
     name: wait-for-mysql
     repository: mysql
-    tag: latest
+    tag: 8.0.30
     pullPolicy: IfNotPresent
     command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
   mongodb:

--- a/bulk-centralledger/values.yaml
+++ b/bulk-centralledger/values.yaml
@@ -110,7 +110,7 @@ cl-handler-bulk-transfer-prepare:
     kafka:
       name: wait-for-kafka
       repository: solsson/kafka
-      tag: latest
+      tag: 2.8.1
       pullPolicy: IfNotPresent
       command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
       env: {}
@@ -128,7 +128,7 @@ cl-handler-bulk-transfer-prepare:
     mysql:
       name: wait-for-mysql
       repository: mysql
-      tag: latest
+      tag: 8.0.30
       pullPolicy: IfNotPresent
       command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
     mongodb:
@@ -292,7 +292,7 @@ cl-handler-bulk-transfer-fulfil:
     kafka:
       name: wait-for-kafka
       repository: solsson/kafka
-      tag: latest
+      tag: 2.8.1
       pullPolicy: IfNotPresent
       command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
       env: {}
@@ -310,7 +310,7 @@ cl-handler-bulk-transfer-fulfil:
     mysql:
       name: wait-for-mysql
       repository: mysql
-      tag: latest
+      tag: 8.0.30
       pullPolicy: IfNotPresent
       command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
     mongodb:
@@ -474,7 +474,7 @@ cl-handler-bulk-transfer-processing:
     kafka:
       name: wait-for-kafka
       repository: solsson/kafka
-      tag: latest
+      tag: 2.8.1
       pullPolicy: IfNotPresent
       command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
       env: {}
@@ -492,7 +492,7 @@ cl-handler-bulk-transfer-processing:
     mysql:
       name: wait-for-mysql
       repository: mysql
-      tag: latest
+      tag: 8.0.30
       pullPolicy: IfNotPresent
       command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
     mongodb:
@@ -655,7 +655,7 @@ cl-handler-bulk-transfer-get:
     kafka:
       name: wait-for-kafka
       repository: solsson/kafka
-      tag: latest
+      tag: 2.8.1
       pullPolicy: IfNotPresent
       command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
       env: {}
@@ -673,7 +673,7 @@ cl-handler-bulk-transfer-get:
     mysql:
       name: wait-for-mysql
       repository: mysql
-      tag: latest
+      tag: 8.0.30
       pullPolicy: IfNotPresent
       command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
     mongodb:

--- a/bulk-centralledger/values.yaml
+++ b/bulk-centralledger/values.yaml
@@ -134,9 +134,9 @@ cl-handler-bulk-transfer-prepare:
     mongodb:
       name: wait-for-mongodb
       repository: bitnami/mongodb
-      tag: latest
+      tag: 6.0.1
       pullPolicy: IfNotPresent
-      command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+      command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
   service:
     type: ClusterIP
@@ -316,9 +316,9 @@ cl-handler-bulk-transfer-fulfil:
     mongodb:
       name: wait-for-mongodb
       repository: bitnami/mongodb
-      tag: latest
+      tag: 6.0.1
       pullPolicy: IfNotPresent
-      command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+      command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
   service:
     type: ClusterIP
@@ -498,9 +498,9 @@ cl-handler-bulk-transfer-processing:
     mongodb:
       name: wait-for-mongodb
       repository: bitnami/mongodb
-      tag: latest
+      tag: 6.0.1
       pullPolicy: IfNotPresent
-      command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+      command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
   service:
     type: ClusterIP
@@ -679,9 +679,9 @@ cl-handler-bulk-transfer-get:
     mongodb:
       name: wait-for-mongodb
       repository: bitnami/mongodb
-      tag: latest
+      tag: 6.0.1
       pullPolicy: IfNotPresent
-      command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+      command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
   service:
     type: ClusterIP

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -3227,9 +3227,9 @@ centraleventprocessor:
     mongodb:
       name: wait-for-mongodb
       repository: bitnami/mongodb
-      tag: latest
+      tag: 6.0.1
       pullPolicy: IfNotPresent
-      command: "mongo mongodb://$mongo_host:$mongo_port --eval \"db.adminCommand('ping')\""
+      command: "mongosh mongodb://$mongo_host:$mongo_port --eval \"db.adminCommand('ping')\""
 
   service:
     name: central-event-processor

--- a/central/values.yaml
+++ b/central/values.yaml
@@ -128,7 +128,7 @@ centralledger:
       mysql:
         name: wait-for-mysql
         repository: mysql
-        tag: latest
+        tag: 8.0.30
         pullPolicy: IfNotPresent
         command: "until mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database   -e 'select version()' ; do echo waiting for MySQL; sleep 2; done;"
       migration:
@@ -304,7 +304,7 @@ centralledger:
       kafka:
         name: wait-for-kafka
         repository: solsson/kafka
-        tag: latest
+        tag: 2.8.1
         pullPolicy: IfNotPresent
         command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
         env: {}
@@ -322,7 +322,7 @@ centralledger:
       mysql:
         name: wait-for-mysql
         repository: mysql
-        tag: latest
+        tag: 8.0.30
         pullPolicy: IfNotPresent
         command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -489,7 +489,7 @@ centralledger:
       kafka:
         name: wait-for-kafka
         repository: solsson/kafka
-        tag: latest
+        tag: 2.8.1
         pullPolicy: IfNotPresent
         command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
         env: {}
@@ -507,7 +507,7 @@ centralledger:
       mysql:
         name: wait-for-mysql
         repository: mysql
-        tag: latest
+        tag: 8.0.30
         pullPolicy: IfNotPresent
         command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -674,7 +674,7 @@ centralledger:
       kafka:
         name: wait-for-kafka
         repository: solsson/kafka
-        tag: latest
+        tag: 2.8.1
         pullPolicy: IfNotPresent
         command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
         env: {}
@@ -692,7 +692,7 @@ centralledger:
       mysql:
         name: wait-for-mysql
         repository: mysql
-        tag: latest
+        tag: 8.0.30
         pullPolicy: IfNotPresent
         command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -859,7 +859,7 @@ centralledger:
       kafka:
         name: wait-for-kafka
         repository: solsson/kafka
-        tag: latest
+        tag: 2.8.1
         pullPolicy: IfNotPresent
         command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
         env: {}
@@ -877,7 +877,7 @@ centralledger:
       mysql:
         name: wait-for-mysql
         repository: mysql
-        tag: latest
+        tag: 8.0.30
         pullPolicy: IfNotPresent
         command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -1049,7 +1049,7 @@ centralledger:
       kafka:
         name: wait-for-kafka
         repository: solsson/kafka
-        tag: latest
+        tag: 2.8.1
         pullPolicy: IfNotPresent
         command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
         env: {}
@@ -1067,7 +1067,7 @@ centralledger:
       mysql:
         name: wait-for-mysql
         repository: mysql
-        tag: latest
+        tag: 8.0.30
         pullPolicy: IfNotPresent
         command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -1234,7 +1234,7 @@ centralledger:
       kafka:
         name: wait-for-kafka
         repository: solsson/kafka
-        tag: latest
+        tag: 2.8.1
         pullPolicy: IfNotPresent
         command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
         env: {}
@@ -1252,7 +1252,7 @@ centralledger:
       mysql:
         name: wait-for-mysql
         repository: mysql
-        tag: latest
+        tag: 8.0.30
         pullPolicy: IfNotPresent
         command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -2160,7 +2160,7 @@ centralsettlement:
       mysql:
         name: wait-for-mysql
         repository: mysql
-        tag: latest
+        tag: 8.0.30
         pullPolicy: IfNotPresent
         command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -2450,13 +2450,13 @@ centralsettlement:
       mysql:
         name: wait-for-mysql
         repository: mysql
-        tag: latest
+        tag: 8.0.30
         pullPolicy: IfNotPresent
         command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
       kafka:
           name: wait-for-kafka
           repository: solsson/kafka
-          tag: latest
+          tag: 2.8.1
           pullPolicy: IfNotPresent
           command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
           env: {}
@@ -2747,13 +2747,13 @@ centralsettlement:
       mysql:
         name: wait-for-mysql
         repository: mysql
-        tag: latest
+        tag: 8.0.30
         pullPolicy: IfNotPresent
         command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
       kafka:
           name: wait-for-kafka
           repository: solsson/kafka
-          tag: latest
+          tag: 2.8.1
           pullPolicy: IfNotPresent
           command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
           env: {}
@@ -3133,13 +3133,13 @@ centralsettlement:
       mysql:
         name: wait-for-mysql
         repository: mysql
-        tag: latest
+        tag: 8.0.30
         pullPolicy: IfNotPresent
         command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
       kafka:
           name: wait-for-kafka
           repository: solsson/kafka
-          tag: latest
+          tag: 2.8.1
           pullPolicy: IfNotPresent
           command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
           env: {}
@@ -3214,7 +3214,7 @@ centraleventprocessor:
     kafka:
       name: wait-for-kafka
       repository: solsson/kafka
-      tag: latest
+      tag: 2.8.1
       pullPolicy: IfNotPresent
       command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
       env: {}

--- a/centraleventprocessor/values.yaml
+++ b/centraleventprocessor/values.yaml
@@ -43,9 +43,9 @@ init:
   mongodb:
     name: wait-for-mongodb
     repository: bitnami/mongodb
-    tag: latest
+    tag: 6.0.1
     pullPolicy: IfNotPresent
-    command: "mongo mongodb://$mongo_host:$mongo_port --eval \"db.adminCommand('ping')\""
+    command: "mongosh mongodb://$mongo_host:$mongo_port --eval \"db.adminCommand('ping')\""
 
 service:
   name: central-event-processor

--- a/centraleventprocessor/values.yaml
+++ b/centraleventprocessor/values.yaml
@@ -30,7 +30,7 @@ init:
   kafka:
     name: wait-for-kafka
     repository: solsson/kafka
-    tag: latest
+    tag: 2.8.1
     pullPolicy: IfNotPresent
     command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
     env: {}

--- a/centralledger/chart-handler-admin-transfer/values.yaml
+++ b/centralledger/chart-handler-admin-transfer/values.yaml
@@ -157,7 +157,7 @@ init:
   kafka:
     name: wait-for-kafka
     repository: solsson/kafka
-    tag: latest
+    tag: 2.8.1
     pullPolicy: IfNotPresent
     command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
     env: {}
@@ -175,7 +175,7 @@ init:
   mysql:
     name: wait-for-mysql
     repository: mysql
-    tag: latest
+    tag: 8.0.30
     pullPolicy: IfNotPresent
     command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 

--- a/centralledger/chart-handler-timeout/values.yaml
+++ b/centralledger/chart-handler-timeout/values.yaml
@@ -162,7 +162,7 @@ init:
   kafka:
     name: wait-for-kafka
     repository: solsson/kafka
-    tag: latest
+    tag: 2.8.1
     pullPolicy: IfNotPresent
     command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
     env: {}
@@ -180,7 +180,7 @@ init:
   mysql:
     name: wait-for-mysql
     repository: mysql
-    tag: latest
+    tag: 8.0.30
     pullPolicy: IfNotPresent
     command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 

--- a/centralledger/chart-handler-transfer-fulfil/values.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/values.yaml
@@ -157,7 +157,7 @@ init:
   kafka:
     name: wait-for-kafka
     repository: solsson/kafka
-    tag: latest
+    tag: 2.8.1
     pullPolicy: IfNotPresent
     command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
     env: {}
@@ -175,7 +175,7 @@ init:
   mysql:
     name: wait-for-mysql
     repository: mysql
-    tag: latest
+    tag: 8.0.30
     pullPolicy: IfNotPresent
     command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 

--- a/centralledger/chart-handler-transfer-get/values.yaml
+++ b/centralledger/chart-handler-transfer-get/values.yaml
@@ -157,7 +157,7 @@ init:
   kafka:
     name: wait-for-kafka
     repository: solsson/kafka
-    tag: latest
+    tag: 2.8.1
     pullPolicy: IfNotPresent
     command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
     env: {}
@@ -175,7 +175,7 @@ init:
   mysql:
     name: wait-for-mysql
     repository: mysql
-    tag: latest
+    tag: 8.0.30
     pullPolicy: IfNotPresent
     command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 

--- a/centralledger/chart-handler-transfer-position/values.yaml
+++ b/centralledger/chart-handler-transfer-position/values.yaml
@@ -157,7 +157,7 @@ init:
   kafka:
     name: wait-for-kafka
     repository: solsson/kafka
-    tag: latest
+    tag: 2.8.1
     pullPolicy: IfNotPresent
     command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
     env: {}
@@ -175,7 +175,7 @@ init:
   mysql:
     name: wait-for-mysql
     repository: mysql
-    tag: latest
+    tag: 8.0.30
     pullPolicy: IfNotPresent
     command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 

--- a/centralledger/chart-handler-transfer-prepare/values.yaml
+++ b/centralledger/chart-handler-transfer-prepare/values.yaml
@@ -160,7 +160,7 @@ init:
   kafka:
     name: wait-for-kafka
     repository: solsson/kafka
-    tag: latest
+    tag: 2.8.1
     pullPolicy: IfNotPresent
     command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
     env: {}
@@ -178,7 +178,7 @@ init:
   mysql:
     name: wait-for-mysql
     repository: mysql
-    tag: latest
+    tag: 8.0.30
     pullPolicy: IfNotPresent
     command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -164,7 +164,7 @@ init:
   mysql:
     name: wait-for-mysql
     repository: mysql
-    tag: latest
+    tag: 8.0.30
     pullPolicy: IfNotPresent
     command: "until mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database   -e 'select version()' ; do echo waiting for MySQL; sleep 2; done;"
   migration:

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -124,7 +124,7 @@ centralledger-service:
     mysql:
       name: wait-for-mysql
       repository: mysql
-      tag: latest
+      tag: 8.0.30
       pullPolicy: IfNotPresent
       command: "until mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database   -e 'select version()' ; do echo waiting for MySQL; sleep 2; done;"
     migration:
@@ -301,7 +301,7 @@ centralledger-handler-transfer-prepare:
     kafka:
       name: wait-for-kafka
       repository: solsson/kafka
-      tag: latest
+      tag: 2.8.1
       pullPolicy: IfNotPresent
       command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
       env: {}
@@ -319,7 +319,7 @@ centralledger-handler-transfer-prepare:
     mysql:
       name: wait-for-mysql
       repository: mysql
-      tag: latest
+      tag: 8.0.30
       pullPolicy: IfNotPresent
       command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -487,7 +487,7 @@ centralledger-handler-transfer-position:
     kafka:
       name: wait-for-kafka
       repository: solsson/kafka
-      tag: latest
+      tag: 2.8.1
       pullPolicy: IfNotPresent
       command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
       env: {}
@@ -505,7 +505,7 @@ centralledger-handler-transfer-position:
     mysql:
       name: wait-for-mysql
       repository: mysql
-      tag: latest
+      tag: 8.0.30
       pullPolicy: IfNotPresent
       command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -673,7 +673,7 @@ centralledger-handler-transfer-get:
     kafka:
       name: wait-for-kafka
       repository: solsson/kafka
-      tag: latest
+      tag: 2.8.1
       pullPolicy: IfNotPresent
       command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
       env: {}
@@ -691,7 +691,7 @@ centralledger-handler-transfer-get:
     mysql:
       name: wait-for-mysql
       repository: mysql
-      tag: latest
+      tag: 8.0.30
       pullPolicy: IfNotPresent
       command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -859,7 +859,7 @@ centralledger-handler-transfer-fulfil:
     kafka:
       name: wait-for-kafka
       repository: solsson/kafka
-      tag: latest
+      tag: 2.8.1
       pullPolicy: IfNotPresent
       command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
       env: {}
@@ -877,7 +877,7 @@ centralledger-handler-transfer-fulfil:
     mysql:
       name: wait-for-mysql
       repository: mysql
-      tag: latest
+      tag: 8.0.30
       pullPolicy: IfNotPresent
       command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -1050,7 +1050,7 @@ centralledger-handler-timeout:
     kafka:
       name: wait-for-kafka
       repository: solsson/kafka
-      tag: latest
+      tag: 2.8.1
       pullPolicy: IfNotPresent
       command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
       env: {}
@@ -1068,7 +1068,7 @@ centralledger-handler-timeout:
     mysql:
       name: wait-for-mysql
       repository: mysql
-      tag: latest
+      tag: 8.0.30
       pullPolicy: IfNotPresent
       command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -1236,7 +1236,7 @@ centralledger-handler-admin-transfer:
     kafka:
       name: wait-for-kafka
       repository: solsson/kafka
-      tag: latest
+      tag: 2.8.1
       pullPolicy: IfNotPresent
       command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
       env: {}
@@ -1254,7 +1254,7 @@ centralledger-handler-admin-transfer:
     mysql:
       name: wait-for-mysql
       repository: mysql
-      tag: latest
+      tag: 8.0.30
       pullPolicy: IfNotPresent
       command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 

--- a/centralsettlement/chart-service/values.yaml
+++ b/centralsettlement/chart-service/values.yaml
@@ -296,13 +296,13 @@ init:
   mysql:
     name: wait-for-mysql
     repository: mysql
-    tag: latest
+    tag: 8.0.30
     pullPolicy: IfNotPresent
     command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
   kafka:
       name: wait-for-kafka
       repository: solsson/kafka
-      tag: latest
+      tag: 2.8.1
       pullPolicy: IfNotPresent
       command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
       env: {}

--- a/centralsettlement/values.yaml
+++ b/centralsettlement/values.yaml
@@ -236,7 +236,7 @@ centralsettlement-service:
     mysql:
       name: wait-for-mysql
       repository: mysql
-      tag: latest
+      tag: 8.0.30
       pullPolicy: IfNotPresent
       command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -527,13 +527,13 @@ centralsettlement-handler-deferredsettlement:
     mysql:
       name: wait-for-mysql
       repository: mysql
-      tag: latest
+      tag: 8.0.30
       pullPolicy: IfNotPresent
       command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
     kafka:
         name: wait-for-kafka
         repository: solsson/kafka
-        tag: latest
+        tag: 2.8.1
         pullPolicy: IfNotPresent
         command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
         env: {}
@@ -823,13 +823,13 @@ centralsettlement-handler-grosssettlement:
     mysql:
       name: wait-for-mysql
       repository: mysql
-      tag: latest
+      tag: 8.0.30
       pullPolicy: IfNotPresent
       command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
     kafka:
         name: wait-for-kafka
         repository: solsson/kafka
-        tag: latest
+        tag: 2.8.1
         pullPolicy: IfNotPresent
         command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
         env: {}
@@ -1209,13 +1209,13 @@ centralsettlement-handler-rules:
     mysql:
       name: wait-for-mysql
       repository: mysql
-      tag: latest
+      tag: 8.0.30
       pullPolicy: IfNotPresent
       command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
     kafka:
         name: wait-for-kafka
         repository: solsson/kafka
-        tag: latest
+        tag: 2.8.1
         pullPolicy: IfNotPresent
         command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
         env: {}

--- a/emailnotifier/values.yaml
+++ b/emailnotifier/values.yaml
@@ -29,7 +29,7 @@ init:
   kafka:
     name: wait-for-kafka
     repository: solsson/kafka
-    tag: latest
+    tag: 2.8.1
     pullPolicy: IfNotPresent
     command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
     env: {}

--- a/eventstreamprocessor/values.yaml
+++ b/eventstreamprocessor/values.yaml
@@ -29,7 +29,7 @@ init:
   kafka:
     name: wait-for-kafka
     repository: solsson/kafka
-    tag: latest
+    tag: 2.8.1
     pullPolicy: IfNotPresent
     command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
     env: {}

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -60,7 +60,7 @@ init:
   image:
     name: wait-for-kafka
     repository: solsson/kafka
-    tag: latest
+    tag: 2.8.1
     pullPolicy: IfNotPresent
     command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
     env: {}

--- a/ml-api-adapter/chart-service/values.yaml
+++ b/ml-api-adapter/chart-service/values.yaml
@@ -60,7 +60,7 @@ init:
   image:
     name: wait-for-kafka
     repository: solsson/kafka
-    tag: latest
+    tag: 2.8.1
     pullPolicy: IfNotPresent
     command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
     env: {}

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -59,7 +59,7 @@ ml-api-adapter-service:
     image:
       name: wait-for-kafka
       repository: solsson/kafka
-      tag: latest
+      tag: 2.8.1
       pullPolicy: IfNotPresent
       command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
       env: {}

--- a/mojaloop-bulk/values.yaml
+++ b/mojaloop-bulk/values.yaml
@@ -28,7 +28,7 @@ bulk-api-adapter:
       kafka:
         name: wait-for-kafka
         repository: solsson/kafka
-        tag: latest
+        tag: 2.8.1
         pullPolicy: IfNotPresent
         command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
         env: {}
@@ -168,7 +168,7 @@ bulk-api-adapter:
       kafka:
         name: wait-for-kafka
         repository: solsson/kafka
-        tag: latest
+        tag: 2.8.1
         pullPolicy: IfNotPresent
         command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
         env: {}
@@ -381,7 +381,7 @@ bulk-centralledger:
       kafka:
         name: wait-for-kafka
         repository: solsson/kafka
-        tag: latest
+        tag: 2.8.1
         pullPolicy: IfNotPresent
         command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
         env: {}
@@ -399,7 +399,7 @@ bulk-centralledger:
       mysql:
         name: wait-for-mysql
         repository: mysql
-        tag: latest
+        tag: 8.0.30
         pullPolicy: IfNotPresent
         command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
       mongodb:
@@ -551,7 +551,7 @@ bulk-centralledger:
       kafka:
         name: wait-for-kafka
         repository: solsson/kafka
-        tag: latest
+        tag: 2.8.1
         pullPolicy: IfNotPresent
         command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
         env: {}
@@ -569,7 +569,7 @@ bulk-centralledger:
       mysql:
         name: wait-for-mysql
         repository: mysql
-        tag: latest
+        tag: 8.0.30
         pullPolicy: IfNotPresent
         command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
       mongodb:
@@ -721,7 +721,7 @@ bulk-centralledger:
       kafka:
         name: wait-for-kafka
         repository: solsson/kafka
-        tag: latest
+        tag: 2.8.1
         pullPolicy: IfNotPresent
         command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
         env: {}
@@ -739,7 +739,7 @@ bulk-centralledger:
       mysql:
         name: wait-for-mysql
         repository: mysql
-        tag: latest
+        tag: 8.0.30
         pullPolicy: IfNotPresent
         command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
       mongodb:
@@ -891,7 +891,7 @@ bulk-centralledger:
       kafka:
         name: wait-for-kafka
         repository: solsson/kafka
-        tag: latest
+        tag: 2.8.1
         pullPolicy: IfNotPresent
         command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
         env: {}
@@ -909,7 +909,7 @@ bulk-centralledger:
       mysql:
         name: wait-for-mysql
         repository: mysql
-        tag: latest
+        tag: 8.0.30
         pullPolicy: IfNotPresent
         command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
       mongodb:

--- a/mojaloop-bulk/values.yaml
+++ b/mojaloop-bulk/values.yaml
@@ -41,9 +41,9 @@ bulk-api-adapter:
       mongodb:
         name: wait-for-mongodb
         repository: bitnami/mongodb
-        tag: latest
+        tag: 6.0.1
         pullPolicy: IfNotPresent
-        command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+        command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
     readinessProbe:
       enabled: true
@@ -181,9 +181,9 @@ bulk-api-adapter:
       mongodb:
         name: wait-for-mongodb
         repository: bitnami/mongodb
-        tag: latest
+        tag: 6.0.1
         pullPolicy: IfNotPresent
-        command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+        command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
     readinessProbe:
       enabled: true
@@ -405,9 +405,9 @@ bulk-centralledger:
       mongodb:
         name: wait-for-mongodb
         repository: bitnami/mongodb
-        tag: latest
+        tag: 6.0.1
         pullPolicy: IfNotPresent
-        command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+        command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
     service:
       type: ClusterIP
@@ -575,9 +575,9 @@ bulk-centralledger:
       mongodb:
         name: wait-for-mongodb
         repository: bitnami/mongodb
-        tag: latest
+        tag: 6.0.1
         pullPolicy: IfNotPresent
-        command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+        command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
     service:
       type: ClusterIP
@@ -745,9 +745,9 @@ bulk-centralledger:
       mongodb:
         name: wait-for-mongodb
         repository: bitnami/mongodb
-        tag: latest
+        tag: 6.0.1
         pullPolicy: IfNotPresent
-        command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+        command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
     service:
       type: ClusterIP
@@ -915,9 +915,9 @@ bulk-centralledger:
       mongodb:
         name: wait-for-mongodb
         repository: bitnami/mongodb
-        tag: latest
+        tag: 6.0.1
         pullPolicy: IfNotPresent
-        command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+        command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
     service:
       type: ClusterIP

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -140,7 +140,7 @@ central:
         mysql:
           name: wait-for-mysql
           repository: mysql
-          tag: latest
+          tag: 8.0.30
           pullPolicy: IfNotPresent
           command: "until mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database   -e 'select version()' ; do echo waiting for MySQL; sleep 2; done;"
         migration:
@@ -325,7 +325,7 @@ central:
         kafka:
           name: wait-for-kafka
           repository: solsson/kafka
-          tag: latest
+          tag: 2.8.1
           pullPolicy: IfNotPresent
           command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
           env: {}
@@ -343,7 +343,7 @@ central:
         mysql:
           name: wait-for-mysql
           repository: mysql
-          tag: latest
+          tag: 8.0.30
           pullPolicy: IfNotPresent
           command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -519,7 +519,7 @@ central:
         kafka:
           name: wait-for-kafka
           repository: solsson/kafka
-          tag: latest
+          tag: 2.8.1
           pullPolicy: IfNotPresent
           command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
           env: {}
@@ -537,7 +537,7 @@ central:
         mysql:
           name: wait-for-mysql
           repository: mysql
-          tag: latest
+          tag: 8.0.30
           pullPolicy: IfNotPresent
           command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -713,7 +713,7 @@ central:
         kafka:
           name: wait-for-kafka
           repository: solsson/kafka
-          tag: latest
+          tag: 2.8.1
           pullPolicy: IfNotPresent
           command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
           env: {}
@@ -731,7 +731,7 @@ central:
         mysql:
           name: wait-for-mysql
           repository: mysql
-          tag: latest
+          tag: 8.0.30
           pullPolicy: IfNotPresent
           command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -907,7 +907,7 @@ central:
         kafka:
           name: wait-for-kafka
           repository: solsson/kafka
-          tag: latest
+          tag: 2.8.1
           pullPolicy: IfNotPresent
           command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
           env: {}
@@ -925,7 +925,7 @@ central:
         mysql:
           name: wait-for-mysql
           repository: mysql
-          tag: latest
+          tag: 8.0.30
           pullPolicy: IfNotPresent
           command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -1101,7 +1101,7 @@ central:
         kafka:
           name: wait-for-kafka
           repository: solsson/kafka
-          tag: latest
+          tag: 2.8.1
           pullPolicy: IfNotPresent
           command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
           env: {}
@@ -1119,7 +1119,7 @@ central:
         mysql:
           name: wait-for-mysql
           repository: mysql
-          tag: latest
+          tag: 8.0.30
           pullPolicy: IfNotPresent
           command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -1300,7 +1300,7 @@ central:
         kafka:
           name: wait-for-kafka
           repository: solsson/kafka
-          tag: latest
+          tag: 2.8.1
           pullPolicy: IfNotPresent
           command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
           env: {}
@@ -1318,7 +1318,7 @@ central:
         mysql:
           name: wait-for-mysql
           repository: mysql
-          tag: latest
+          tag: 8.0.30
           pullPolicy: IfNotPresent
           command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -2058,7 +2058,7 @@ central:
         mysql:
           name: wait-for-mysql
           repository: mysql
-          tag: latest
+          tag: 8.0.30
           pullPolicy: IfNotPresent
           command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -2348,13 +2348,13 @@ central:
         mysql:
           name: wait-for-mysql
           repository: mysql
-          tag: latest
+          tag: 8.0.30
           pullPolicy: IfNotPresent
           command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
         kafka:
             name: wait-for-kafka
             repository: solsson/kafka
-            tag: latest
+            tag: 2.8.1
             pullPolicy: IfNotPresent
             command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
             env: {}
@@ -2645,13 +2645,13 @@ central:
         mysql:
           name: wait-for-mysql
           repository: mysql
-          tag: latest
+          tag: 8.0.30
           pullPolicy: IfNotPresent
           command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
         kafka:
             name: wait-for-kafka
             repository: solsson/kafka
-            tag: latest
+            tag: 2.8.1
             pullPolicy: IfNotPresent
             command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
             env: {}
@@ -3032,13 +3032,13 @@ central:
         mysql:
           name: wait-for-mysql
           repository: mysql
-          tag: latest
+          tag: 8.0.30
           pullPolicy: IfNotPresent
           command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
         kafka:
             name: wait-for-kafka
             repository: solsson/kafka
-            tag: latest
+            tag: 2.8.1
             pullPolicy: IfNotPresent
             command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
             env: {}
@@ -3106,7 +3106,7 @@ central:
       kafka:
         name: wait-for-kafka
         repository: solsson/kafka
-        tag: latest
+        tag: 2.8.1
         pullPolicy: IfNotPresent
         command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
         env: {}
@@ -3328,7 +3328,7 @@ ml-api-adapter:
       image:
         name: wait-for-kafka
         repository: solsson/kafka
-        tag: latest
+        tag: 2.8.1
         pullPolicy: IfNotPresent
         command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
         env: {}
@@ -3646,7 +3646,7 @@ emailnotifier:
     kafka:
       name: wait-for-kafka
       repository: solsson/kafka
-      tag: latest
+      tag: 2.8.1
       pullPolicy: IfNotPresent
       command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
       env: {}
@@ -3936,7 +3936,7 @@ account-lookup-service:
         enabled: true
         name: wait-for-mysql
         repository: mysql
-        tag: latest
+        tag: 8.0.30
         pullPolicy: IfNotPresent
         command: "until mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database   -e 'select * from oracleEndpoint;' ; do echo waiting for MySQL; sleep 2; done;"
 
@@ -4155,7 +4155,7 @@ account-lookup-service:
       mysql:
         name: wait-for-mysql
         repository: mysql
-        tag: latest
+        tag: 8.0.30
         pullPolicy: IfNotPresent
         command: "until mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database   -e 'select version()' ; do echo waiting for MySQL; sleep 2; done;"
 
@@ -4361,7 +4361,7 @@ account-lookup-service:
       waitForMysql:
         name: wait-for-mysql
         repository: mysql
-        tag: latest
+        tag: 8.0.30
         pullPolicy: IfNotPresent
         command: "until mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database   -e 'select version()' ; do echo waiting for MySQL; sleep 2; done;"
       initMysql:
@@ -4383,7 +4383,7 @@ account-lookup-service:
         enabled: true
         name: populate-mysql-tables
         repository: mysql
-        tag: latest
+        tag: 8.0.30
         pullPolicy: IfNotPresent
         command: "echo 'Nothing configured to be populated. Continuing...';"
     service:
@@ -4714,7 +4714,7 @@ quoting-service:
     mysql:
       name: wait-for-mysql
       repository: mysql
-      tag: latest
+      tag: 8.0.30
       pullPolicy: IfNotPresent
       command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 
@@ -6366,7 +6366,7 @@ mojaloop-bulk:
         kafka:
           name: wait-for-kafka
           repository: solsson/kafka
-          tag: latest
+          tag: 2.8.1
           pullPolicy: IfNotPresent
           command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
           env: {}
@@ -6501,7 +6501,7 @@ mojaloop-bulk:
         kafka:
           name: wait-for-kafka
           repository: solsson/kafka
-          tag: latest
+          tag: 2.8.1
           pullPolicy: IfNotPresent
           command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
           env: {}
@@ -6708,7 +6708,7 @@ mojaloop-bulk:
         kafka:
           name: wait-for-kafka
           repository: solsson/kafka
-          tag: latest
+          tag: 2.8.1
           pullPolicy: IfNotPresent
           command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
           env: {}
@@ -6726,7 +6726,7 @@ mojaloop-bulk:
         mysql:
           name: wait-for-mysql
           repository: mysql
-          tag: latest
+          tag: 8.0.30
           pullPolicy: IfNotPresent
           command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
         mongodb:
@@ -6877,7 +6877,7 @@ mojaloop-bulk:
         kafka:
           name: wait-for-kafka
           repository: solsson/kafka
-          tag: latest
+          tag: 2.8.1
           pullPolicy: IfNotPresent
           command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
           env: {}
@@ -6895,7 +6895,7 @@ mojaloop-bulk:
         mysql:
           name: wait-for-mysql
           repository: mysql
-          tag: latest
+          tag: 8.0.30
           pullPolicy: IfNotPresent
           command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
         mongodb:
@@ -7046,7 +7046,7 @@ mojaloop-bulk:
         kafka:
           name: wait-for-kafka
           repository: solsson/kafka
-          tag: latest
+          tag: 2.8.1
           pullPolicy: IfNotPresent
           command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
           env: {}
@@ -7064,7 +7064,7 @@ mojaloop-bulk:
         mysql:
           name: wait-for-mysql
           repository: mysql
-          tag: latest
+          tag: 8.0.30
           pullPolicy: IfNotPresent
           command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
         mongodb:
@@ -7215,7 +7215,7 @@ mojaloop-bulk:
         kafka:
           name: wait-for-kafka
           repository: solsson/kafka
-          tag: latest
+          tag: 2.8.1
           pullPolicy: IfNotPresent
           command: "until ./bin/kafka-broker-api-versions.sh --bootstrap-server $kafka_host:$kafka_port; do echo waiting for Kafka; sleep 2; done;"
           env: {}
@@ -7233,7 +7233,7 @@ mojaloop-bulk:
         mysql:
           name: wait-for-mysql
           repository: mysql
-          tag: latest
+          tag: 8.0.30
           pullPolicy: IfNotPresent
           command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
         mongodb:

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -3119,9 +3119,9 @@ central:
       mongodb:
         name: wait-for-mongodb
         repository: bitnami/mongodb
-        tag: latest
+        tag: 6.0.1
         pullPolicy: IfNotPresent
-        command: "mongo mongodb://$mongo_host:$mongo_port --eval \"db.adminCommand('ping')\""
+        command: "mongosh mongodb://$mongo_host:$mongo_port --eval \"db.adminCommand('ping')\""
 
     service:
       name: central-event-processor
@@ -6379,9 +6379,9 @@ mojaloop-bulk:
         mongodb:
           name: wait-for-mongodb
           repository: bitnami/mongodb
-          tag: latest
+          tag: 6.0.1
           pullPolicy: IfNotPresent
-          command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+          command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
       readinessProbe:
         enabled: true
@@ -6514,9 +6514,9 @@ mojaloop-bulk:
         mongodb:
           name: wait-for-mongodb
           repository: bitnami/mongodb
-          tag: latest
+          tag: 6.0.1
           pullPolicy: IfNotPresent
-          command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+          command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
       readinessProbe:
         enabled: true
@@ -6732,9 +6732,9 @@ mojaloop-bulk:
         mongodb:
           name: wait-for-mongodb
           repository: bitnami/mongodb
-          tag: latest
+          tag: 6.0.1
           pullPolicy: IfNotPresent
-          command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+          command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
       service:
         type: ClusterIP
@@ -6901,9 +6901,9 @@ mojaloop-bulk:
         mongodb:
           name: wait-for-mongodb
           repository: bitnami/mongodb
-          tag: latest
+          tag: 6.0.1
           pullPolicy: IfNotPresent
-          command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+          command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
       service:
         type: ClusterIP
@@ -7070,9 +7070,9 @@ mojaloop-bulk:
         mongodb:
           name: wait-for-mongodb
           repository: bitnami/mongodb
-          tag: latest
+          tag: 6.0.1
           pullPolicy: IfNotPresent
-          command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+          command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
       service:
         type: ClusterIP
@@ -7239,9 +7239,9 @@ mojaloop-bulk:
         mongodb:
           name: wait-for-mongodb
           repository: bitnami/mongodb
-          tag: latest
+          tag: 6.0.1
           pullPolicy: IfNotPresent
-          command: "mongo $mongouri --eval \"db.adminCommand('ping')\""
+          command: "mongosh $mongouri --eval \"db.adminCommand('ping')\""
 
       service:
         type: ClusterIP

--- a/quoting-service/values.yaml
+++ b/quoting-service/values.yaml
@@ -156,7 +156,7 @@ init:
   mysql:
     name: wait-for-mysql
     repository: mysql
-    tag: latest
+    tag: 8.0.30
     pullPolicy: IfNotPresent
     command: "until result=$(mysql -h $db_host -P $db_port -u $db_user --password=$db_password  $db_database -ss -N -e 'select is_locked from migration_lock;') && eval 'echo is_locked=$result' && if [ -z $result ]; then false; fi && if [ $result -ne 0 ]; then false; fi; do echo waiting for MySQL; sleep 2; done;"
 


### PR DESCRIPTION
feat(mojaloop/[#2909](https://github.com/mdebarros/helm/issues/2909)): Update Helm deployment init-containers with mongodb dependencies to use v6.x mongodb container [#2909](https://github.com/mdebarros/helm/issues/2909) - https://github.com/mojaloop/project/issues/2909
- includes updates for all init-containers that are dependant on mongodb "latest"
  - updated tag from 'latest' to '6.0.1'
  - updated 'mongo' command to 'mongosh'
- includes updates for all init-containers that are dependant on mysql "latest"
  - updated tag from 'latest' to '8.0.30'
- includes updates for all init-containers that are dependant on kafka "latest"
  - updated tag from 'latest' to '2.8.1'
- Added revision update to v14.0.0 release notes