### PR TITLE
chore: bump and validate sdk-scheme-adapter api-svc

### DIFF
--- a/mojaloop-simulator/Chart.yaml
+++ b/mojaloop-simulator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: "Helm Chart for the Mojaloop (SDK-based) Simulator"
 name: mojaloop-simulator
-version: 14.0.0
-appVersion: "sdk-scheme-adapter: v18.0.2; mojaloop-simulator: v13.0.1; thirdparty-sdk: v15.1.0"
+version: 14.1.0
+appVersion: "sdk-scheme-adapter: v20.0.0-bulk-snapshot.20; mojaloop-simulator: v13.0.1; thirdparty-sdk: v15.1.0"

--- a/mojaloop-simulator/templates/deployment.yaml
+++ b/mojaloop-simulator/templates/deployment.yaml
@@ -72,6 +72,7 @@ spec:
       - name: scheme-adapter
         image: "{{ $config.config.schemeAdapter.image.repository }}:{{ $config.config.schemeAdapter.image.tag }}"
         imagePullPolicy: {{ $config.config.schemeAdapter.image.pullPolicy }}
+        command: {{ $config.config.schemeAdapter.image.command }}
         ports:
           - name: inboundapi
             containerPort: {{ $config.config.schemeAdapter.env.INBOUND_LISTEN_PORT }}

--- a/mojaloop-simulator/values.yaml
+++ b/mojaloop-simulator/values.yaml
@@ -274,8 +274,9 @@ defaults: &defaults
           publicKey: ''
       image:
         repository: mojaloop/sdk-scheme-adapter
-        tag: v18.0.2
+        tag: v20.0.0-bulk-snapshot.20
         pullPolicy: IfNotPresent
+        command: '[ "yarn", "start:api-svc" ]'
       <<: *defaultProbes
 
       # These will be supplied directly to the init containers array in the deployment for the
@@ -438,6 +439,10 @@ defaults: &defaults
         # The fulfilment will be generated from the provided ILP packet, and must hash to the provided condition.
         ALLOW_TRANSFER_WITHOUT_QUOTE: false
         RESOURCE_VERSIONS: transfers=1.1,quotes=1.0
+
+        ENABLE_FSPIOP_EVENT_HANDLER: false
+        ENABLE_BACKEND_EVENT_HANDLER: false
+
     backend:
       image:
         repository: mojaloop/mojaloop-simulator

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
-version: 14.0.0
-appVersion: "ml-api-adapter: v14.0.0; central-ledger: v15.1.2.1; account-lookup-service: v13.0.0; quoting-service: v15.0.2; central-settlement: v15.0.0; central-event-processor: v12.0.0; bulk-api-adapter: v13.0.1; email-notifier: v12.0.0; als-oracle-pathfinder: v12.0.0; transaction-requests-service: v14.0.1; simulator: v12.0.0; mojaloop-simulator: v13.0.1; sdk-scheme-adapter: v18.0.2; thirdparty-sdk: v15.1.0; ml-testing-toolkit: v15.0.0; ml-testing-toolkit-ui: v15.0.0;"
+version: 14.1.0
+appVersion: "ml-api-adapter: v14.0.0; central-ledger: v15.1.2.1; account-lookup-service: v13.0.0; quoting-service: v15.0.2; central-settlement: v15.0.0; central-event-processor: v12.0.0; bulk-api-adapter: v13.0.1; email-notifier: v12.0.0; als-oracle-pathfinder: v12.0.0; transaction-requests-service: v14.0.1; simulator: v12.0.0; mojaloop-simulator: v13.0.1; sdk-scheme-adapter: v20.0.0-bulk-snapshot.20; thirdparty-sdk: v15.1.0; ml-testing-toolkit: v15.0.0; ml-testing-toolkit-ui: v15.0.0;"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop/requirements.yaml
+++ b/mojaloop/requirements.yaml
@@ -21,7 +21,7 @@ dependencies:
   repository: "file://../simulator"
   condition: simulator.enabled
 - name: mojaloop-simulator
-  version: 14.0.0
+  version: 14.1.0
   repository: "file://../mojaloop-simulator"
   condition: mojaloop-simulator.enabled
 - name: mojaloop-bulk

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -5895,8 +5895,9 @@ mojaloop-simulator:
             publicKey: ''
         image:
           repository: mojaloop/sdk-scheme-adapter
-          tag: v18.0.2
+          tag: v20.0.0-bulk-snapshot.20
           pullPolicy: IfNotPresent
+          command: '[ "yarn", "start:api-svc" ]'
         <<: *defaultProbes
 
         # These will be supplied directly to the init containers array in the deployment for the
@@ -6040,6 +6041,8 @@ mojaloop-simulator:
           RESERVE_NOTIFICATION: false
           RESOURCE_VERSIONS: transfers=1.1,quotes=1.1,participants=1.1,parties=1.1,transactionRequests=1.1
 
+          ENABLE_FSPIOP_EVENT_HANDLER: false
+          ENABLE_BACKEND_EVENT_HANDLER: false
 
       backend:
         image:

--- a/thirdparty/Chart.yaml
+++ b/thirdparty/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thirdparty
 version: 2.0.0
 description: Third Party API Support for Mojaloop
-appVersion: "1.0.0"
+appVersion: "1.1.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -24,7 +24,7 @@ dependencies:
     condition: tp-api-svc.enabled
   - name: mojaloop-simulator
     alias: thirdparty-simulator
-    version: 14.0.0
+    version: 14.1.0
     repository: "file://../mojaloop-simulator"
     condition: mojaloop-simulator.enabled
 maintainers:

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -40,7 +40,7 @@ In addition to enabling the above charts, a few options must be configured to al
 For the `mojaloop/mojaloop` helm chart, enable the following in your `values.yaml`:
 
 ```yaml
-... 
+...
 account-lookup-service:
   account-lookup-service:
     config:
@@ -102,9 +102,9 @@ Or alternatively add `--set` for each of the above parameters on the install com
 ```bash
 helm install ... \
   # enabled Thirdparty setup
-  --set ml-ttk-test-setup-tk.tests.enabled=true \
+  --set ml-ttk-test-setup-tp.tests.enabled=true \
   # enabled Thirdparty validation tests
-  --set ml-ttk-test-val-tk.tests.enabled=true
+  --set ml-ttk-test-val-tp.tests.enabled=true
 ```
 
 2. Run Tests

--- a/thirdparty/values.yaml
+++ b/thirdparty/values.yaml
@@ -1326,8 +1326,9 @@ thirdparty-simulator:
             publicKey: ''
         image:
           repository: mojaloop/sdk-scheme-adapter
-          tag: v18.0.2
+          tag: v20.0.0-bulk-snapshot.20
           pullPolicy: IfNotPresent
+          command: '[ "yarn", "start:api-svc" ]'
         <<: *defaultProbes
 
         # These will be supplied directly to the init containers array in the deployment for the
@@ -1472,6 +1473,8 @@ thirdparty-simulator:
           RESERVE_NOTIFICATION: false
           RESOURCE_VERSIONS: transfers=1.1,quotes=1.1,participants=1.1,parties=1.1,transactionRequests=1.1
 
+          ENABLE_FSPIOP_EVENT_HANDLER: false
+          ENABLE_BACKEND_EVENT_HANDLER: false
       backend:
         image:
           repository: mojaloop/mojaloop-simulator


### PR DESCRIPTION
Passing it as a yaml array wasn't working. I'm guessing you need to loop through it in the template but decided to keep it as such since the other `command` prompts in the template expect a string.

Tested on moja3.
```
--------------------FINAL REPORT--------------------

Test Suite:GP Tests
Environment:Development
┌───────────────────────────────────────────────────┐
│                      SUMMARY                      │
├───────────────────┬───────────────────────────────┤
│ Total assertions  │ 2634                          │
├───────────────────┼───────────────────────────────┤
│ Passed assertions │ 2634                          │
├───────────────────┼───────────────────────────────┤
│ Failed assertions │ 0                             │
├───────────────────┼───────────────────────────────┤
│ Total requests    │ 598                           │
├───────────────────┼───────────────────────────────┤
│ Total test cases  │ 130                           │
├───────────────────┼───────────────────────────────┤
│ Passed percentage │ 100.00%                       │
├───────────────────┼───────────────────────────────┤
│ Started time      │ Fri, 07 Oct 2022 02:38:57 GMT │
├───────────────────┼───────────────────────────────┤
│ Completed time    │ Fri, 07 Oct 2022 02:42:08 GMT │
├───────────────────┼───────────────────────────────┤
│ Runtime duration  │ 191116 ms                     │
└───────────────────┴───────────────────────────────┘

--------------------FINAL REPORT--------------------

Test Suite:Bulk Tests
Environment:Development
┌───────────────────────────────────────────────────┐
│                      SUMMARY                      │
├───────────────────┬───────────────────────────────┤
│ Total assertions  │ 183                           │
├───────────────────┼───────────────────────────────┤
│ Passed assertions │ 183                           │
├───────────────────┼───────────────────────────────┤
│ Failed assertions │ 0                             │
├───────────────────┼───────────────────────────────┤
│ Total requests    │ 17                            │
├───────────────────┼───────────────────────────────┤
│ Total test cases  │ 4                             │
├───────────────────┼───────────────────────────────┤
│ Passed percentage │ 100.00%                       │
├───────────────────┼───────────────────────────────┤
│ Started time      │ Fri, 07 Oct 2022 02:42:22 GMT │
├───────────────────┼───────────────────────────────┤
│ Completed time    │ Fri, 07 Oct 2022 02:42:48 GMT │
├───────────────────┼───────────────────────────────┤
│ Runtime duration  │ 25455 ms                      │
└───────────────────┴───────────────────────────────┘
TTK-Assertion-Report-multi-2022-10-07T02:42:48.011Z.html was generated
Terminate with exit code 0


--------------------FINAL REPORT--------------------

Test Suite:Thirdparty Tests
Environment:Development
┌───────────────────────────────────────────────────┐
│                      SUMMARY                      │
├───────────────────┬───────────────────────────────┤
│ Total assertions  │ 21                            │
├───────────────────┼───────────────────────────────┤
│ Passed assertions │ 21                            │
├───────────────────┼───────────────────────────────┤
│ Failed assertions │ 0                             │
├───────────────────┼───────────────────────────────┤
│ Total requests    │ 20                            │
├───────────────────┼───────────────────────────────┤
│ Total test cases  │ 8                             │
├───────────────────┼───────────────────────────────┤
│ Passed percentage │ 100.00%                       │
├───────────────────┼───────────────────────────────┤
│ Started time      │ Fri, 07 Oct 2022 02:44:12 GMT │
├───────────────────┼───────────────────────────────┤
│ Completed time    │ Fri, 07 Oct 2022 02:44:21 GMT │
├───────────────────┼───────────────────────────────┤
│ Runtime duration  │ 9017 ms                       │
└───────────────────┴───────────────────────────────┘
```