### PR TITLE
feat(mojaloop/#2352): update and standardise helm charts to use netwo…

### DIFF
--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -5645,7 +5645,7 @@ thirdparty:
       ports:
         externalPort: 4004
         internalPort: 4004
-
+    
     ingress:
       ## @param ingress.enabled Enable ingress record generation for %%MAIN_CONTAINER_NAME%%
       ##
@@ -8358,7 +8358,7 @@ ml-testing-toolkit:
           host: testing-toolkit.local
     config:
       user_config.json: {
-        "DEFAULT_ENVIRONMENT_FILE_NAME": "hub-k8s-default-environment.json"
+        "DEFAULT_ENVIRONMENT_FILE_NAME": "hub-k8s-default-environment.json" 
       }
       ## We can specify the files and folders here those we want to override in the TTK `spec_files` directory.
       ## For example, you can specify user_config.json, system_config.json ...etc
@@ -8673,8 +8673,8 @@ ml-ttk-posthook-tests:
   #   AWS_REGION: 'us-west-2'
   #   SLACK_WEBHOOK_URL: 'slack_inbound_webhook'
 
-      ## Optionally specify the config file defaults for TTK CLI
-      ## You should specify at least mode here
+  ## Optionally specify the config file defaults for TTK CLI
+  ## You should specify at least mode here
   # configFileDefaults: {
   #   "mode": "outbound",
   #   "reportFormat": "html",
@@ -8722,8 +8722,8 @@ ml-ttk-cronjob-tests:
   #   AWS_REGION: 'us-west-2'
   #   SLACK_WEBHOOK_URL: 'slack_inbound_webhook'
 
-      ## Optionally specify the config file defaults for TTK CLI
-      ## You should specify at least mode here
+  ## Optionally specify the config file defaults for TTK CLI
+  ## You should specify at least mode here
   # configFileDefaults: {
   #   "mode": "outbound",
   #   "reportFormat": "html",
@@ -8776,8 +8776,8 @@ ml-ttk-test-val-gp:
   #   AWS_REGION: 'us-west-2'
   #   SLACK_WEBHOOK_URL: 'slack_inbound_webhook'
 
-      ## Optionally specify the config file defaults for TTK CLI
-      ## You should specify at least mode here
+  ## Optionally specify the config file defaults for TTK CLI
+  ## You should specify at least mode here
   # configFileDefaults: {
   #   "mode": "outbound",
   #   "reportFormat": "html",


### PR DESCRIPTION
…rking v1 (#508)

feat(mojaloop/#2352): update and standardise helm charts to use networking v1 - mojaloop/project#2352

# Notes

This PR is re-created from #506 which includes some fixes based on tests on k8s v1.24

# Changes:

## Update the Chart.yaml's and standardise all charts to helm v3 (API v2)
    - move any dependencies in the requirements.yaml to Charts.yaml
    - update the apiVersion for helm in all the Charts.yaml to 2.0
    - add the common dependency to each chart that already has an ingress
    - remove all requirements.lock 
    - update maintainers in chart.yaml to include tomd@crosslaketech.com
    - bump chart versions 

## Update the ingress and networking API to v1 and standardise where possible 
   -  if the chart has an ingress template the chart  is not on the exclusion list (see below) => the ingress template is updated to be a clone of the bitnami example (a version of what already exists in the charts repo)
   - updates the values files for the new ingress settings
   - ensure the updated values files have the correct hostname for the ingress
   - checks for paths and extra paths correctly allowed for (i.e. all charts with extraPaths or extraHosts are on e
   - ensure the updated values files have the correct port number for the ingress
    - update config/default.json files for values.ingress.api.host or similar to use .Values.ingress.hostname
    - _helper.tpl's updated to use correct ingress APIs and remove redundant ingress logic and templates

## General Maintenance
    - Fixed lint issue
    - Removed forensicloggingsidecar, centralenduserregistry, kube-system from lint scripts since they are no longer supported
    - Updated Maintainers list for each chart

## Exclusion list of charts
- i.e. these charts are not yet standardised to the new ingress modeled on the bitnami example :
- Any existing ingress in these charts has been updated "in place" rather than replaced with the newer standardised bitnami modeled chart.
- So the ingress.yaml, config/*json, _helper.tpls , values.yaml files etc have been updated to use the latest ingress but they remain non-standard compared to the rest of the code-base.
- "finance-portal-settlement-management",
- "finance-portal",
- ~"thirdparty"~,
- ~"thirdparty/chart-tp-api-svc"~,
- ~"thirdparty/chart-consent-oracle"~,
- ~"thirdparty/chart-auth-svc"~,
- ~"mojaloop-simulator"~,
- "keycloak",
- "monitoring",
- "monitoring/promfana",
- "monitoring/elk",
- "ml-testing-toolkit/chart-keycloak",
- "ml-testing-toolkit/chart-backend",
- "ml-testing-toolkit/chart-frontend",
- "ml-testing-toolkit/chart-connection-manager-backend",
- "ml-testing-toolkit/chart-connection-manager-frontend"

Co-authored-by: tdaly61 <tdaly61@gmail.com>
Co-authored-by: Sam <10507686+elnyry-sam-k@users.noreply.github.com>