### PR TITLE
feat(mojaloop/2867): post /bulkTransfers from Switch to PayeeFSP to use Switch as fspiop-source

### DIFF
--- a/.changelog/release-v14.1.0.md
+++ b/.changelog/release-v14.1.0.md
@@ -29,7 +29,7 @@ Date | Revision | Description
 4. quoting-service: **v15.0.2**
 5. central-settlement: **v15.0.0**
 6. central-event-processor: **v12.0.0**
-7. bulk-api-adapter: v14.0.0 -> **v14.1.1** ([Compare](https://github.com/mojaloop/bulk-api-adapter/compare/v14.0.0...v14.1.1))
+7. bulk-api-adapter: v14.0.0 -> **v14.2.0** ([Compare](https://github.com/mojaloop/bulk-api-adapter/compare/v14.0.0...v14.2.0))
 8. email-notifier: **v12.0.0**
 9. als-oracle-pathfinder: **v12.0.0**
 10. transaction-requests-service: **v14.0.1**
@@ -58,7 +58,7 @@ Date | Revision | Description
 4. quoting-service - https://github.com/mojaloop/quoting-service/releases/tag/v15.0.2
 5. central-settlement- https://github.com/mojaloop/central-settlement/releases/tag/v15.0.0
 6. central-event-processor - https://github.com/mojaloop/central-event-processor/releases/tag/v12.0.0
-7. bulk-api-adapter - https://github.com/mojaloop/bulk-api-adapter/releases/tag/v14.1.1
+7. bulk-api-adapter - https://github.com/mojaloop/bulk-api-adapter/releases/tag/v14.2.0
 8. email-notifier - https://github.com/mojaloop/email-notifier/releases/tag/v12.0.0
 9. als-oracle-pathfinder - https://github.com/mojaloop/als-oracle-pathfinder/releases/tag/v12.0.0
 10. transaction-requests-service - https://github.com/mojaloop/transaction-requests-service/releases/tag/v14.0.1

--- a/bulk-api-adapter/Chart.yaml
+++ b/bulk-api-adapter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: bulk-api-adapter Helm chart for Kubernetes
 name: bulk-api-adapter
 version: 12.1.0
-appVersion: "14.1.1"
+appVersion: "14.2.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/chart-handler-notification/Chart.yaml
+++ b/bulk-api-adapter/chart-handler-notification/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: bulk-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: bulk-api-adapter-handler-notification
 version: 12.1.0
-appVersion: "14.1.1"
+appVersion: "14.2.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/chart-handler-notification/configs/default.json
+++ b/bulk-api-adapter/chart-handler-notification/configs/default.json
@@ -17,6 +17,11 @@
   "ENDPOINT_SECURITY": {
     "TLS": {
       "rejectUnauthorized": {{ .Values.config.security.callback.rejectUnauthorized }}
+    },
+    "JWS": {
+      "JWS_SIGN": {{ .Values.config.endpointSecurity.jwsSign }},
+      "FSPIOP_SOURCE_TO_SIGN": {{ .Values.config.endpointSecurity.fspiopSourceSigningName | quote }},
+      "JWS_SIGNING_KEY_PATH": "secrets/jwsSigningKey.key"
     }
   },
   "MAX_FULFIL_TIMEOUT_DURATION_SECONDS": 300,

--- a/bulk-api-adapter/chart-handler-notification/templates/deployment.yaml
+++ b/bulk-api-adapter/chart-handler-notification/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+        {{- if .Values.config.endpointSecurity.jwsSign }}
+        checksum/secret-jws: {{ include (print $.Template.BasePath "/secret-jws.yaml") . | sha256sum }}
+        {{- end }}
       {{- if .Values.metrics.enabled }}
         prometheus.io/port: "{{ .Values.service.internalPort }}"
         prometheus.io/scrape: "true"
@@ -83,6 +86,10 @@ spec:
           volumeMounts:
             - name: {{ template "bulk-api-adapter-handler-notification.fullname" . }}-config-volume
               mountPath: /opt/app/config
+            {{- if .Values.config.endpointSecurity.jwsSign }}
+            - name: jws-signing-key
+              mountPath: /opt/app/secrets
+            {{- end }}
           env:
             - name: LOG_LEVEL
               value: {{ .Values.config.log_level }}
@@ -107,3 +114,8 @@ spec:
             items:
             - key: default.json
               path: default.json
+        {{- if .Values.config.endpointSecurity.jwsSign }}
+        - name: jws-signing-key
+          secret:
+            secretName: {{ template "bulk-api-adapter-handler-notification.fullname" . }}-jws-signing-key
+        {{- end }}

--- a/bulk-api-adapter/chart-handler-notification/templates/secret-jws.yaml
+++ b/bulk-api-adapter/chart-handler-notification/templates/secret-jws.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.config.endpointSecurity.jwsSign }}
+{{- if (not .Values.config.endpointSecurity.jwsSigningKey) }}
+  {{- fail "JWS signing enabled but no jwsSigningKey provided. You will need to supply a JWS signing key in string form .Values.endpointSecurity.jwsSigningKey." }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "bulk-api-adapter-handler-notification.fullname" . }}-jws-signing-key
+  labels:
+    app.kubernetes.io/name: {{ include "bulk-api-adapter-handler-notification.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+type: Opaque
+data:
+  jwsSigningKey.key: {{ .Values.config.endpointSecurity.jwsSigningKey | b64enc }}
+{{- end }}

--- a/bulk-api-adapter/chart-handler-notification/values.yaml
+++ b/bulk-api-adapter/chart-handler-notification/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/bulk-api-adapter
-  tag: v14.1.1
+  tag: v14.2.0
   command: '["node", "src/handlers/index.js", "handler", "--notification"]'
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.
@@ -109,6 +109,24 @@ config:
 
   ## MongoDB Configuration for Object Store
   objstore_uri: 'mongodb://$mongodbUsername:$mongodbPassword@$release_name-centralledger-obj:27017/$mongodbDatabase'
+
+  # Parameters for JWS signing requests
+  endpointSecurity:
+    jwsSign: false
+    fspiopSourceSigningName: 'switch'
+    jwsSigningKey:
+      # To generate this key:
+      # Private:
+      # ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key
+      # Public:
+      # openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub
+      # Should look like:
+      # -----BEGIN RSA PRIVATE KEY-----
+      # MIIJKQIBAAKCAgEAxfqaZivMPd4MpdBHu0jVMf3MSuSdkSMHn+sNJdDQfl+x4R5R
+      # ..
+      # ..
+      # mBynFpdjO0D3PnLKjnBDn1vFAfANOwVpGXCw5mn+484A/SIXYebWruFd03g4
+      # -----END RSA PRIVATE KEY-----
 
 service:
   type: ClusterIP

--- a/bulk-api-adapter/chart-service/Chart.yaml
+++ b/bulk-api-adapter/chart-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: bulk-api-adapter API component Helm chart for Kubernetes
 name: bulk-api-adapter-service
 version: 12.1.0
-appVersion: "14.1.1"
+appVersion: "14.2.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/chart-service/configs/default.json
+++ b/bulk-api-adapter/chart-service/configs/default.json
@@ -17,6 +17,11 @@
   "ENDPOINT_SECURITY": {
     "TLS": {
       "rejectUnauthorized": {{ .Values.config.security.callback.rejectUnauthorized }}
+    },
+    "JWS": {
+      "JWS_SIGN": false,
+      "FSPIOP_SOURCE_TO_SIGN": "switch",
+      "JWS_SIGNING_KEY_PATH": "secrets/jwsSigningKey.key"
     }
   },
   "MAX_FULFIL_TIMEOUT_DURATION_SECONDS": 300,

--- a/bulk-api-adapter/chart-service/values.yaml
+++ b/bulk-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: mojaloop/bulk-api-adapter
-  tag: v14.1.1
+  tag: v14.2.0
   command: '["node", "src/api/index.js"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bulk-api-adapter/values.yaml
+++ b/bulk-api-adapter/values.yaml
@@ -12,7 +12,7 @@ bulk-api-adapter-service:
   replicaCount: 1
   image:
     repository: mojaloop/bulk-api-adapter
-    tag: v14.1.1
+    tag: v14.2.0
     command: '["node", "src/api/index.js"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -179,7 +179,7 @@ bulk-api-adapter-handler-notification:
   replicaCount: 1
   image:
     repository: mojaloop/bulk-api-adapter
-    tag: v14.1.1
+    tag: v14.2.0
     command: '["node", "src/handlers/index.js", "handler", "--notification"]'
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/mojaloop-bulk/Chart.yaml
+++ b/mojaloop-bulk/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mojaloop Bulk Helm chart for Kubernetes
 name: mojaloop-bulk
 version: 14.1.0
-appVersion: "bulk-api-adapter: v14.1.1; central-ledger: v16.3.0"
+appVersion: "bulk-api-adapter: v14.2.0; central-ledger: v16.3.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop-bulk/values.yaml
+++ b/mojaloop-bulk/values.yaml
@@ -13,7 +13,7 @@ bulk-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/bulk-api-adapter
-      tag: v14.1.1
+      tag: v14.2.0
       command: '["node", "src/api/index.js"]'
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
@@ -180,7 +180,7 @@ bulk-api-adapter:
     replicaCount: 1
     image:
       repository: mojaloop/bulk-api-adapter
-      tag: v14.1.1
+      tag: v14.2.0
       command: '["node", "src/handlers/index.js", "handler", "--notification"]'
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 14.1.0
-appVersion: "ml-api-adapter: v14.0.0; central-ledger: v15.1.2.1; account-lookup-service: v13.0.0; quoting-service: v15.0.2; central-settlement: v15.0.0; central-event-processor: v12.0.0; bulk-api-adapter: v14.1.1; email-notifier: v12.0.0; als-oracle-pathfinder: v12.0.0; transaction-requests-service: v14.0.1; simulator: v12.0.0; mojaloop-simulator: v13.0.1; sdk-scheme-adapter: v21.4.0; thirdparty-sdk: v15.1.0; ml-testing-toolkit: v15.2.0; ml-testing-toolkit-ui: v15.0.1;"
+appVersion: "ml-api-adapter: v14.0.0; central-ledger: v15.1.2.1; account-lookup-service: v13.0.0; quoting-service: v15.0.2; central-settlement: v15.0.0; central-event-processor: v12.0.0; bulk-api-adapter: v14.2.0; email-notifier: v12.0.0; als-oracle-pathfinder: v12.0.0; transaction-requests-service: v14.0.1; simulator: v12.0.0; mojaloop-simulator: v13.0.1; sdk-scheme-adapter: v21.4.0; thirdparty-sdk: v15.1.0; ml-testing-toolkit: v15.2.0; ml-testing-toolkit-ui: v15.0.1;"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:


### PR DESCRIPTION
- upgraded bulk-api-adapter from v14.1.1 to v14.2.0 for mojaloop/project#2867
- added JWS config to ENDPOINT_SECURITY default.json for bulk-api-adapters helm charts
- added endpointSecurity config to bulk-api-adapter notification handler config
- added secret-jws template to bulk-api-adapter notification handler
- added volume mounts to bulk-api-adapter notification handler deployment template