### PR TITLE
docs: update release-v14.1.0 notes [skip ci]

### DIFF
--- a/.changelog/release-v14.1.0.md
+++ b/.changelog/release-v14.1.0.md
@@ -167,6 +167,7 @@ More information can be found here:
     1. [#2717 - Thirdparty TTK Test-Collection is not repeatable](https://github.com/mojaloop/project/issues/2717)
     2. [#2845 - QA: Replace Legacy-Simulator as a NORESPONSE_SIMPAYEE in Testing-Toolkit Goden Path Test-Suite](https://github.com/mojaloop/project/issues/2845)
     3. [#2846 - QA: Mojaloop TTK GP Test Collections to reset available liquidity after each run](https://github.com/mojaloop/project/issues/2846)
+    4. [#3027 - QA: Mojaloop Helm v14.1.0 Release - Bulk Tests fail on first run](https://github.com/mojaloop/project/issues/3027)
 
 ## 9. Contributors
 


### PR DESCRIPTION
docs: update release-v14.1.0 notes [skip ci]
- added Known issue 10.4. [#3027 - QA: Mojaloop Helm v14.1.0 Release - Bulk Tests fail on first run](https://github.com/mojaloop/project/issues/3027)