### PR TITLE
feat(mojaloop/#3023): sdk bulk CICD functional tests

### DIFF
--- a/mojaloop-ttk-simulators/chart-sim1/values.yaml
+++ b/mojaloop-ttk-simulators/chart-sim1/values.yaml
@@ -100,7 +100,7 @@ ml-testing-toolkit:
         ]
       }
       # TODO: Change the following links to release version instead of master branch
-      rules_response__default.json: 'https://raw.githubusercontent.com/mojaloop/testing-toolkit-test-cases/mvp/bulk-sdk/rules/sdk-bulk/response_rules.json'
+      rules_response__default.json: 'https://raw.githubusercontent.com/mojaloop/sdk-scheme-adapter/master/test/func/config/ttk-ttksim1/spec_files/rules_response/default.json'
       api_definitions__mojaloop_simulator_sim_1.4__api_spec.yaml: 'https://raw.githubusercontent.com/mojaloop/sdk-scheme-adapter/master/test/func/config/ttk-ttksim1/spec_files/api_definitions/mojaloop_simulator_sim_1.4/api_spec.yaml'
       api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__api_spec.yaml: 'https://raw.githubusercontent.com/mojaloop/sdk-scheme-adapter/master/test/func/config/ttk-ttksim1/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/api_spec.yaml'
       api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__callback_map.json: 'https://raw.githubusercontent.com/mojaloop/sdk-scheme-adapter/master/test/func/config/ttk-ttksim1/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/callback_map.json'

--- a/mojaloop-ttk-simulators/chart-sim2/values.yaml
+++ b/mojaloop-ttk-simulators/chart-sim2/values.yaml
@@ -91,7 +91,7 @@ ml-testing-toolkit:
           }
         ]
       }
-      rules_response__default.json: 'https://raw.githubusercontent.com/mojaloop/testing-toolkit-test-cases/master/rules/sdk-bulk/response_rules.json'
+      rules_response__default.json: 'https://raw.githubusercontent.com/mojaloop/sdk-scheme-adapter/master/test/func/config/ttk-ttksim2/spec_files/rules_response/default.json'
       api_definitions__mojaloop_simulator_sim_1.4__api_spec.yaml: 'https://raw.githubusercontent.com/mojaloop/sdk-scheme-adapter/master/test/func/config/ttk-ttksim2/spec_files/api_definitions/mojaloop_simulator_sim_1.4/api_spec.yaml'
       api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__api_spec.yaml: 'https://raw.githubusercontent.com/mojaloop/sdk-scheme-adapter/master/test/func/config/ttk-ttksim2/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/api_spec.yaml'
       api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__callback_map.json: 'https://raw.githubusercontent.com/mojaloop/sdk-scheme-adapter/master/test/func/config/ttk-ttksim2/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/callback_map.json'

--- a/mojaloop-ttk-simulators/chart-sim3/values.yaml
+++ b/mojaloop-ttk-simulators/chart-sim3/values.yaml
@@ -91,7 +91,7 @@ ml-testing-toolkit:
           }
         ]
       }
-      rules_response__default.json: 'https://raw.githubusercontent.com/mojaloop/testing-toolkit-test-cases/master/rules/sdk-bulk/response_rules.json'
+      rules_response__default.json: 'https://raw.githubusercontent.com/mojaloop/sdk-scheme-adapter/master/test/func/config/ttk-ttksim3/spec_files/rules_response/default.json'
       api_definitions__mojaloop_simulator_sim_1.4__api_spec.yaml: 'https://raw.githubusercontent.com/mojaloop/sdk-scheme-adapter/master/test/func/config/ttk-ttksim3/spec_files/api_definitions/mojaloop_simulator_sim_1.4/api_spec.yaml'
       api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__api_spec.yaml: 'https://raw.githubusercontent.com/mojaloop/sdk-scheme-adapter/master/test/func/config/ttk-ttksim3/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/api_spec.yaml'
       api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__callback_map.json: 'https://raw.githubusercontent.com/mojaloop/sdk-scheme-adapter/master/test/func/config/ttk-ttksim3/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/callback_map.json'

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -5525,9 +5525,9 @@ transaction-requests-service:
     # limits:
     #  cpu: 100m
     #  memory: 128Mi
-  # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
 
 thirdparty:
   enabled: false
@@ -7132,9 +7132,7 @@ mojaloop-ttk-simulators:
               host: 'ttksim1.local'
 
         config:
-          ## TODO: Update the below line once the rules have been migrated to https://github.com/mojaloop/sdk-scheme-adapter 
-          rules_response__default.json: 'https://github.com/mojaloop/testing-toolkit-test-cases/raw/v14.1.0/rules/sdk-bulk/response_rules.json'
-          # rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v21.4.0/test/func/config/ttk-ttksim1/spec_files/rules_response/default.json'
+          rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v21.4.0/test/func/config/ttk-ttksim1/spec_files/rules_response/default.json'
           api_definitions__mojaloop_simulator_sim_1.4__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v21.4.0/test/func/config/ttk-ttksim1/spec_files/api_definitions/mojaloop_simulator_sim_1.4/api_spec.yaml'
           api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v21.4.0/test/func/config/ttk-ttksim1/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/api_spec.yaml'
           api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v21.4.0/test/func/config/ttk-ttksim1/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/callback_map.json'
@@ -7191,9 +7189,7 @@ mojaloop-ttk-simulators:
             adminApi:
               host: 'ttksim2.local'
         config:
-          ## TODO: Update the below line once the rules have been migrated to https://github.com/mojaloop/sdk-scheme-adapter 
-          rules_response__default.json: 'https://github.com/mojaloop/testing-toolkit-test-cases/raw/v14.1.0/rules/sdk-bulk/response_rules.json'
-          # rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v21.4.0/test/func/config/ttk-ttksim2/spec_files/rules_response/default.json'
+          rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v21.4.0/test/func/config/ttk-ttksim2/spec_files/rules_response/default.json'
           api_definitions__mojaloop_simulator_sim_1.4__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v21.4.0/test/func/config/ttk-ttksim2/spec_files/api_definitions/mojaloop_simulator_sim_1.4/api_spec.yaml'
           api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v21.4.0/test/func/config/ttk-ttksim2/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/api_spec.yaml'
           api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v21.4.0/test/func/config/ttk-ttksim2/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/callback_map.json'
@@ -7220,9 +7216,7 @@ mojaloop-ttk-simulators:
             adminApi:
               host: 'ttksim3.local'
         config:
-          ## TODO: Update the below line once the rules have been migrated to https://github.com/mojaloop/sdk-scheme-adapter 
-          rules_response__default.json: 'https://github.com/mojaloop/testing-toolkit-test-cases/raw/v14.1.0/rules/sdk-bulk/response_rules.json'
-          # rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v21.4.0/test/func/config/ttk-ttksim3/spec_files/rules_response/default.json'
+          rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v21.4.0/test/func/config/ttk-ttksim3/spec_files/rules_response/default.json'
           api_definitions__mojaloop_simulator_sim_1.4__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v21.4.0/test/func/config/ttk-ttksim3/spec_files/api_definitions/mojaloop_simulator_sim_1.4/api_spec.yaml'
           api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v21.4.0/test/func/config/ttk-ttksim3/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/api_spec.yaml'
           api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v21.4.0/test/func/config/ttk-ttksim3/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/callback_map.json'
@@ -7235,7 +7229,6 @@ mojaloop-ttk-simulators:
               host: 'ttksim3.local'
         config:
           API_BASE_URL: 'http://ttksim3.local'
-
 
 mojaloop-bulk:
   enabled: false


### PR DESCRIPTION
feat(mojaloop/#3023): sdk bulk CICD functional tests - https://github.com/mojaloop/project/issues/3023
- updated `rules_response_default.json` for TTK Sims 1,2 & 3 in mojaloop/values.yaml
- updated `rules_response_default.json` for TTK Sims 1,2 & 3 in each of the default chart-sim# values.yaml
- fixed formatting with mojaloop/values.yaml

Notes:
- The `rules_response_default.json` changes are a result of moving (and consolidating) the Rules from [testing-toolkit-test-cases](https://github.com/mojaloop/testing-toolkit-test-cases/pull/101) repo to the SDK-Scheme-Adapter repo.