### PR TITLE
chore: updated package.sh with default repo URL

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-LOCAL_HELM_MOJALOOP_REPO_URI=${HELM_MOJALOOP_REPO_URI:-'https://docs.mojaloop.io/helm/repo'}
+LOCAL_HELM_MOJALOOP_REPO_URI=${HELM_MOJALOOP_REPO_URI:-'https://mojaloop.github.io/helm/repo'}
 
 #
 # Script to Package all charts, and create an index.yaml in ./repo directory


### PR DESCRIPTION
- default repo URL in package.sh now points to github.io