### PR TITLE
fix: exit code for test container

### DIFF
--- a/ml-testing-toolkit-cli/templates/_helpers.tpl
+++ b/ml-testing-toolkit-cli/templates/_helpers.tpl
@@ -90,7 +90,6 @@ containers:
     mkdir tmp_test_cases;
     unzip -d tmp_test_cases -o downloaded-test-collections.zip;
     npm run cli -- -c cli-default-config.json -e cli-testcase-environment.json -i tmp_test_cases/{{ .Values.config.testCasesPathInZip }} -u {{ .Values.config.ttkBackendURL | replace "$release_name" .Release.Name }} --report-format html {{- if .Values.config.awsS3BucketName }} --report-target s3://{{ .Values.config.awsS3BucketName }}/{{ .Values.config.awsS3FilePath }}/report.html {{- end }} --report-auto-filename-enable true {{- if .Values.configCreds.SLACK_WEBHOOK_URL }} --slack-webhook-url $SLACK_WEBHOOK_URL {{- end }} --extra-summary-information="Test Suite:{{ .Values.config.testSuiteName }},Environment:{{ .Values.config.environmentName }}" {{- if .Values.config.saveReport }} --save-report true {{- end }} {{- if .Values.config.reportName }} --report-name {{ .Values.config.reportName }} {{- end }} {{- if .Values.config.saveReportBaseUrl }} --save-report-base-url {{ .Values.config.saveReportBaseUrl }} {{- end }};
-    echo "Done";
   envFrom:
   - secretRef:
       name: {{ template "ml-testing-toolkit-cli.fullname" . }}-aws-creds


### PR DESCRIPTION
The exit code for test container is set always to success(0) because of the echo statement at the end.