### PR TITLE
feat(mojaloop/#3361): reset liquidity

### DIFF
--- a/.changelog/release-v15.0.1.md
+++ b/.changelog/release-v15.0.1.md
@@ -19,7 +19,6 @@ Refer to full feature and bug fix list below for more info; and testing improvem
 ## 1. New Features
 
 1. **mojaloop/#3361** Reset Liquidity - Add CRON Job to reset ([helm/pull/?](https://github.com/mojaloop/helm/pull/?)), closes [mojaloop/#3361](https://github.com/mojaloop/project/issues/3361)
-...
 
 ## 2. Bug Fixes
 

--- a/.changelog/release-v15.0.1.md
+++ b/.changelog/release-v15.0.1.md
@@ -8,6 +8,8 @@ Date | Revision | Description
 - For *BREAKING CHANGES*, please review the section `#5` "Breaking Changes" below.
 - For *KNOWN ISSUES*, please review the section `#8` "Known Issues" below.
 
+This is a patch release for [v15.0.0 Release](./release-v15.0.0.md).
+
 ## 0. Summary
 
 Major updates with this release include:

--- a/.changelog/release-v15.0.1.md
+++ b/.changelog/release-v15.0.1.md
@@ -1,0 +1,161 @@
+# Helm Release Notes
+
+Date | Revision | Description
+---------|----------|---------
+ 2023-06-08 | 0 | Initial draft
+  |  |
+
+- For *BREAKING CHANGES*, please review the section `#5` "Breaking Changes" below.
+- For *KNOWN ISSUES*, please review the section `#8` "Known Issues" below.
+
+## 0. Summary
+
+Major updates with this release include:
+
+1. TBD
+
+Refer to full feature and bug fix list below for more info; and testing improvements listed separately.
+
+## 1. New Features
+
+1. **mojaloop/#3361** Reset Liquidity - Add CRON Job to reset ([helm/pull/?](https://github.com/mojaloop/helm/pull/?)), closes [mojaloop/#3361](https://github.com/mojaloop/project/issues/3361)
+...
+
+## 2. Bug Fixes
+
+N/A.
+
+## 3. Application versions
+
+1. ml-api-adapter: [v14.0.0](https://github.com/mojaloop/ml-api-adapter/releases/tag/v14.0.0)
+2. central-ledger: [v17.0.3](https://github.com/mojaloop/central-ledger/releases/tag/v17.0.3)
+3. account-lookup-service: [v14.0.0](https://github.com/mojaloop/account-lookup-service/releases/tag/v14.0.0)
+4. quoting-service: [v15.0.2](https://github.com/mojaloop/quoting-service/releases/tag/v15.0.2)
+5. central-settlement: [v15.0.0](https://github.com/mojaloop/central-settlement/releases/tag/v15.0.0)
+6. bulk-api-adapter: [v15.0.3](https://github.com/mojaloop/bulk-api-adapter/releases/tag/v15.0.3)
+7. central-event-processor: [v12.0.0](https://github.com/mojaloop/central-event-processor/releases/tag/v12.0.0) *(Refer to section 5. BREAKING CHANGES)*
+8. email-notifier: [v12.0.0](https://github.com/mojaloop/email-notifier/releases/tag/v12.0.0) *(Refer to section 5. BREAKING CHANGES)*
+9. als-oracle-pathfinder: [v12.0.0](https://github.com/mojaloop/als-oracle-pathfinder/releases/tag/v12.0.0)
+10. transaction-requests-service: [v14.0.1](https://github.com/mojaloop/transaction-requests-service/releases/tag/v14.0.1)
+11. finance-portal-ui: [v10.4.3](https://github.com/mojaloop/finance-portal-ui/releases/tag/v10.4.3) *(DEPRECATED)*
+12. finance-portal-backend-service: [v15.0.2](https://github.com/mojaloop/finance-portal-backend-service/releases/tag/v15.0.2) *(DEPRECATED)*
+13. settlement-management: [v11.0.0](https://github.com/mojaloop/settlement-management/releases/tag/v11.0.0) *(DEPRECATED)*
+14. operator-settlement: [v11.0.0](https://github.com/mojaloop/operator-settlement/releases/tag/v11.0.0) *(DEPRECATED)*
+15. event-sidecar: [v12.0.0](https://github.com/mojaloop/event-sidecar/releases/tag/v12.0.0)
+16. event-stream-processor: [v12.0.0-snapshot.7](https://github.com/mojaloop/event-stream-processor/releases/v12.0.0-snapshot.7)
+17. simulator: [12.0.0](https://github.com/mojaloop/simulator/releases/tag/v12.0.0)
+18. mojaloop-simulator: [v14.0.1](https://github.com/mojaloop/mojaloop-simulator/releases/tag/v14.0.1)
+19. sdk-scheme-adapter: [v22.0.1](https://github.com/mojaloop/sdk-scheme-adapter/releases/tag/v22.0.1)
+20. ml-testing-toolkit: [v16.1.1](https://github.com/mojaloop/ml-testing-toolkit/releases/tag/v16.1.1)
+21. ml-testing-toolkit-ui: [v15.3.0](https://github.com/mojaloop/ml-testing-toolkit-ui/releases/tag/v15.3.0)
+22. ml-testing-toolkit-client-lib: [v1.2.0](https://github.com/mojaloop/ml-testing-toolkit-client-lib/releases/tag/v1.2.0)
+23. auth-service: [v14.0.0](https://github.com/mojaloop/auth-service/releases/tag/v14.0.0)
+24. als-consent-oracle: [v0.2.0](https://github.com/mojaloop/als-consent-oracle/releases/tag/v0.2.0)
+25. thirdparty-api-svc: [v13.0.2](https://github.com/mojaloop/thirdparty-api-svc/releases/tag/v13.0.2)
+26. thirdparty-sdk: [v15.1.0](https://github.com/mojaloop/thirdparty-sdk/releases/tag/v15.1.0)
+
+## 4. API Versions
+
+This release supports the following versions of the [Mojaloop family of APIs](https://docs.mojaloop.io/api):
+
+| API         | Supported Versions                                                                                                                                    | Notes |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
+| FSPIOP      | [v1.1](https://docs.mojaloop.io/api/fspiop/v1.1/api-definition.html), [v1.0](https://docs.mojaloop.io/api/fspiop/v1.0/api-definition.html) |       |
+| Settlements | [v2.0](https://docs.mojaloop.io/api/settlement)                                                                                            |       |
+| Admin       | [v1.0](https://docs.mojaloop.io/api/administration/central-ledger-api.html)                                                                |       |
+| Oracle      | [v1.0](https://docs.mojaloop.io/legacy/api/als-oracle-api-specification.html)                                                              |       |
+| Thirdparty  | [v1.0](https://docs.mojaloop.io/api/thirdparty)                                                                                           |       |
+
+## 5. Breaking changes
+
+N/A
+
+## 6. Deprecations
+
+The following components have been deprecated from the packaged Mojaloop Helm chart release and have been with [Business Operation Framework (BOF)](https://github.com/mojaloop/business-operations-framework-docs), which can be deployed by the official [BoF Helm Chart](https://github.com/mojaloop/charts/tree/master/mojaloop/bof):
+
+- [finance-portal](https://github.com/mojaloop/helm/tree/master/finance-portal) Helm Chart
+  - [finance-portal-ui](https://github.com/mojaloop/finance-portal-ui/releases/tag/v10.4.3)
+  - [finance-portal-backend-service](https://github.com/mojaloop/finance-portal-backend-service/releases/tag/v15.0.2)
+- [finance-portal-settlement-management](https://github.com/mojaloop/helm/tree/master/finance-portal-settlement-management) Helm Chart
+  - [settlement-management](https://github.com/mojaloop/settlement-management/releases/tag/v11.0.0)
+  - [operator-settlement](https://github.com/mojaloop/operator-settlement/releases/tag/v11.0.0)
+
+> *Note these Helm Chart are still available for deployment in the [Mojaloop Helm Repo (http://mojaloop.io/helm/repo/)](http://mojaloop.io/helm/repo/index.yaml).*
+
+This is due to the underlying services having been deprecated by the Micro-Services provided by the [Business Operation Framework (BOF)](https://github.com/mojaloop/business-operations-framework-docs) for Financial Management and Reporting.
+
+More information can be found here:
+
+- https://github.com/mojaloop/business-operations-framework-docs.
+
+[BOF Helm charts](https://github.com/mojaloop/charts/tree/master/mojaloop/bof) to deploy the [Business Operation Framework](https://github.com/mojaloop/business-operations-framework-docs) can be found here:
+
+- https://github.com/mojaloop/charts/tree/master/mojaloop/bof
+
+## 7. Testing notes
+
+1. This release has been validated against the following dependency Test Matrix:
+
+    | Dependency | Version |  Notes   |
+    | ---------- | ------- | --- |
+    | Kubernetes | v1.26.4 | [AWS EKS](https://aws.amazon.com/eks/), [AWS EKS Supported Version Notes](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)  |
+    | containerd  |  v1.6.19  |  |
+    | Nginx Ingress Controller | [helm-ingress-nginx-4.7.0](https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.7.0) / [ingress-controller-v1.8.0](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.8.0) |     |
+    |  Amazon Linux   |  v2   |     |
+    |  MySQL   |  bitnami/mysql:8.0.32-debian-11-r0   |     |
+    |  Kafka   |  bitnami/kafka:3.3.1-debian-11-r1   |     |
+    |  Redis   |  bitnami/redis:7.0.5-debian-11-r7   |     |
+    |  MongoDB   |  bitnami/mongodb:6.0.2-debian-11-r11   |     |
+    |  Testing Toolkit Test Cases   |  [v15.0.0](https://github.com/mojaloop/testing-toolkit-test-cases/releases/tag/v15.0.0)   |     |
+    |  example-mojaloop-backend   |  v15.0.0   |  [README](../example-mojaloop-backend/README.md)   |
+
+2. It is recommended that all Mojaloop deployments are verified using the [Mojaloop Testing Toolkit](https://docs.mojaloop.io/documentation/mojaloop-technical-overview/ml-testing-toolkit/). More information can be found in the [Mojaloop Deployment Guide](https://docs.mojaloop.io/documentation/deployment-guide).
+
+3. The [testing-toolkit-test-cases for v15.0.0](https://github.com/mojaloop/testing-toolkit-test-cases/releases/tag/v15.0.0) Golden Path collections expects:
+    - the Quoting service operating mode to be set quoting-service.config.simple_routing_mode_enabled=true (in helm mojaloop/values.yaml under quoting-service config). If this is incorrectly configured, it will result in several failures in the quoting-service tests (7 expected failures). If this is disabled, ensure that you update the corresponding test-case environment variable parameter **SIMPLE_ROUTING_MODE_ENABLED** ( in helm mojaloop/values.yaml ml-testing-toolkit -> extraEnvironments.hub-k8s-default-environment.json.inputValues) to match.
+    - the **on-us transfers** (in mojaloop/values.yaml "enable_on_us_transfers: false" under centralledger-handler-transfer-prepare -> config and  cl-handler-bulk-transfer-prepare -> config) configuration to be disabled. The test-case environment variable parameter (**ON_US_TRANSFERS_ENABLED** (in helm mojaloop/values.yaml ml-testing-toolkit -> extraEnvironments.hub-k8s-default-environment.json.inputValues), the same name used on postman collections) must similarly match this value.
+
+4. Simulators
+    - We recommend using Testing Toolkit instead of Postman which is better suited for the async nature of the Mojaloop API specification (see above)
+    - [Mojaloop-Simulator](https://github.com/mojaloop/mojaloop-simulator) is enabled by default (six instances used for single transfers usually and three more specific to bulk).
+    - Ensure that correct Postman Scripts are used if you wish to test against the Mojaloop-Simulators:
+        - Setup Mojaloop Hub: [MojaloopHub_Setup](https://github.com/mojaloop/postman/blob/v12.0.0/MojaloopHub_Setup.postman_collection.json)
+        - Setup Mojaloop Simulators for testing : [MojaloopSims_Onboarding](https://github.com/mojaloop/postman/blob/v12.0.0/MojaloopSims_Onboarding.postman_collection.json)
+        - Golden path tests: [Golden_Path_Mojaloop](https://github.com/mojaloop/postman/blob/v12.0.0/Golden_Path_Mojaloop.postman_collection.json)
+    - Legacy Simulators are still required and deployed by default; disabling this will cause issues since there is Account Lookup directory mocking functionality in this service.
+
+5. Thirdparty Testing Toolkit Test Collections are not repeatable. Please refer to the following issue for more information [#2717 - Thirdparty TTK Test-Collection is not repeatable](https://github.com/mojaloop/project/issues/2717). It is possible to manually cleanup persistent data to re-run the test if required.
+
+6. Bulk API Helm Tests
+
+    Refer to the [Testing Deployments](../README.md#testing-deployments) section in the main README for detailed information on how to enable bulk-api-adapter tests.
+
+7. Thirdparty API Helm Tests
+
+    Refer to [thirdparty/README.md#validating-and-testing-the-3p-api](../thirdparty/README.md#validating-and-testing-the-3p-api) on how to enabled and execute Thirdparty verification tests.
+
+8. Testing the new Bulk functionality (sdk-scheme-adapter)
+
+    For details regarding deployment and validation of simulators needed for bulk (for adoption provided in sdk-scheme-adapter) refer to [deploying Mojaloop TTK simulators](../mojaloop-ttk-simulators/README.md).
+
+## 8. Known Issues
+
+1. [#2119 - Idempotency for duplicate quote request](https://github.com/mojaloop/project/issues/2119)
+2. [#2322 - Helm install failing with with "medium to large" release names](https://github.com/mojaloop/project/issues/2322)
+3. [#2317 - Mojaloop Helm deployments are not compatible when deployed to ARM-arch based hosts](https://github.com/mojaloop/project/issues/2317)
+4. [#2892 - Disabled DFSP showing getParty info](https://github.com/mojaloop/project/issues/2892)
+5. [#2435 - Quoting-Service is incorrectly handling failed responses to FSPs when forwarding requests](https://github.com/mojaloop/project/issues/2435)
+6. Test issues causing instability/intermitant failures on Test Case Results
+    1. [#2717 - Thirdparty TTK Test-Collection is not repeatable](https://github.com/mojaloop/project/issues/2717)
+    2. [#2845 - QA: Replace Legacy-Simulator as a NORESPONSE_SIMPAYEE in Testing-Toolkit Goden Path Test-Suite](https://github.com/mojaloop/project/issues/2845)
+    3. [#3027 - QA: Mojaloop Helm v14.1.0 Release - Bulk Tests fail on first run](https://github.com/mojaloop/project/issues/3027)
+    4. [#2925 - Helm Test Intermittent failure with 'Generic ID not found](https://github.com/mojaloop/project/issues/2925)
+    5. [#3164 - GP Tests fail intermitantly when upgrading a release from v14.1.1 to v15 due to WS issues between TTK and SDKs](https://github.com/mojaloop/project/issues/3164)
+
+## 9. Contributors
+
+- Organizations: BMGF, CrossLake, InFiTX
+- Individuals: @chris-me-law , @dfry , @elnyry-sam-k , @kirgene , @kleyow , @PaulGregoryBaker , @mdebarros , @sri-miriyala , @tdaly61 , @vijayg10
+
+*Note: companies are in alphabetical order, individuals are in no particular order.*

--- a/.changelog/release-v15.0.1.md
+++ b/.changelog/release-v15.0.1.md
@@ -150,11 +150,11 @@ More information can be found here:
     2. [#2845 - QA: Replace Legacy-Simulator as a NORESPONSE_SIMPAYEE in Testing-Toolkit Goden Path Test-Suite](https://github.com/mojaloop/project/issues/2845)
     3. [#3027 - QA: Mojaloop Helm v14.1.0 Release - Bulk Tests fail on first run](https://github.com/mojaloop/project/issues/3027)
     4. [#2925 - Helm Test Intermittent failure with 'Generic ID not found](https://github.com/mojaloop/project/issues/2925)
-    5. [#3164 - GP Tests fail intermittently when upgrading a release from v14.1.1 to v15 due to WS issues between TTK and SDKs](https://github.com/mojaloop/project/issues/3164)
+    5. [#3164 - GP Tests fail intermitantly when upgrading a release from v14.1.1 to v15 due to WS issues between TTK and SDKs](https://github.com/mojaloop/project/issues/3164)
 
 ## 9. Contributors
 
-- Organizations: BMGF, CrossLake, InFiTX
+- Organizations: BMGF, InFiTX
 - Individuals: @chris-me-law , @dfry , @elnyry-sam-k , @PaulGregoryBaker , @mdebarros , @vijayg10
 
 *Note: companies are in alphabetical order, individuals are in no particular order.*

--- a/.changelog/release-v15.0.1.md
+++ b/.changelog/release-v15.0.1.md
@@ -8,13 +8,11 @@ Date | Revision | Description
 - For *BREAKING CHANGES*, please review the section `#5` "Breaking Changes" below.
 - For *KNOWN ISSUES*, please review the section `#8` "Known Issues" below.
 
-This is a patch release for [v15.0.0 Release](./release-v15.0.0.md).
-
 ## 0. Summary
 
-Major updates with this release include:
+Minor parch release for [v15.0.0 Release](./release-v15.0.0.md) includes:
 
-1. TBD
+1. CronJob for cleanup scripts to ensure that liquidity is reset. This should allow daily cron-jobs to run indefinitely.
 
 Refer to full feature and bug fix list below for more info; and testing improvements listed separately.
 

--- a/.changelog/release-v15.0.1.md
+++ b/.changelog/release-v15.0.1.md
@@ -155,6 +155,6 @@ More information can be found here:
 ## 9. Contributors
 
 - Organizations: BMGF, CrossLake, InFiTX
-- Individuals: @chris-me-law , @dfry , @elnyry-sam-k , @kirgene , @kleyow , @PaulGregoryBaker , @mdebarros , @sri-miriyala , @tdaly61 , @vijayg10
+- Individuals: @chris-me-law , @dfry , @elnyry-sam-k , @PaulGregoryBaker , @mdebarros , @vijayg10
 
 *Note: companies are in alphabetical order, individuals are in no particular order.*

--- a/.changelog/release-v15.0.1.md
+++ b/.changelog/release-v15.0.1.md
@@ -150,7 +150,7 @@ More information can be found here:
     2. [#2845 - QA: Replace Legacy-Simulator as a NORESPONSE_SIMPAYEE in Testing-Toolkit Goden Path Test-Suite](https://github.com/mojaloop/project/issues/2845)
     3. [#3027 - QA: Mojaloop Helm v14.1.0 Release - Bulk Tests fail on first run](https://github.com/mojaloop/project/issues/3027)
     4. [#2925 - Helm Test Intermittent failure with 'Generic ID not found](https://github.com/mojaloop/project/issues/2925)
-    5. [#3164 - GP Tests fail intermitantly when upgrading a release from v14.1.1 to v15 due to WS issues between TTK and SDKs](https://github.com/mojaloop/project/issues/3164)
+    5. [#3164 - GP Tests fail intermittently when upgrading a release from v14.1.1 to v15 due to WS issues between TTK and SDKs](https://github.com/mojaloop/project/issues/3164)
 
 ## 9. Contributors
 

--- a/ml-testing-toolkit-cli/Chart.yaml
+++ b/ml-testing-toolkit-cli/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: ml-testing-toolkit-cli Helm chart for Kubernetes
 name: ml-testing-toolkit-cli
-version: 15.3.0
+version: 15.3.1
 appVersion: "v1.2.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png

--- a/ml-testing-toolkit-cli/templates/_helpers.tpl
+++ b/ml-testing-toolkit-cli/templates/_helpers.tpl
@@ -79,17 +79,14 @@ containers:
 - name: {{ .Chart.Name }}
   image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
   imagePullPolicy: {{ .Values.image.pullPolicy }}
-  {{- if .Values.image.imagePullSecrets }}
+  {{- if .Values.image.pullSecrets }}
   imagePullSecrets:
-  {{ toYaml .Values.image.imagePullSecrets | indent 10 }}
+  {{ toYaml .Values.image.pullSecrets | indent 10 }}
   {{- end }}
   command: ["/bin/sh", "-c"]
   args:
-  - echo "Downloading the test collection...";
-    wget {{ .Values.config.testCasesZipUrl }} -O downloaded-test-collections.zip;
-    mkdir tmp_test_cases;
-    unzip -d tmp_test_cases -o downloaded-test-collections.zip;
-    npm run cli -- -c cli-default-config.json -e cli-testcase-environment.json -i tmp_test_cases/{{ .Values.config.testCasesPathInZip }} -u {{ .Values.config.ttkBackendURL | replace "$release_name" .Release.Name }} --report-format html {{- if .Values.config.awsS3BucketName }} --report-target s3://{{ .Values.config.awsS3BucketName }}/{{ .Values.config.awsS3FilePath }}/report.html {{- end }} --report-auto-filename-enable true {{- if .Values.configCreds.SLACK_WEBHOOK_URL }} --slack-webhook-url $SLACK_WEBHOOK_URL {{- end }} --extra-summary-information="Test Suite:{{ .Values.config.testSuiteName }},Environment:{{ .Values.config.environmentName }}" {{- if .Values.config.saveReport }} --save-report true {{- end }} {{- if .Values.config.reportName }} --report-name {{ .Values.config.reportName }} {{- end }} {{- if .Values.config.saveReportBaseUrl }} --save-report-base-url {{ .Values.config.saveReportBaseUrl }} {{- end }};
+  - |
+    {{- include "common.tplvalues.render" (dict "value" .Values.script "context" $) | nindent 12 }}
   envFrom:
   - secretRef:
       name: {{ template "ml-testing-toolkit-cli.fullname" . }}-aws-creds

--- a/ml-testing-toolkit-cli/templates/job.yaml
+++ b/ml-testing-toolkit-cli/templates/job.yaml
@@ -5,11 +5,14 @@ metadata:
   name: {{ template "ml-testing-toolkit-cli.fullname" . }}
 spec:
   schedule: {{ .Values.scheduling.cronSchedule | quote }}
-  successfulJobsHistoryLimit: 7
-  failedJobsHistoryLimit: 7
+  suspend: {{ .Values.scheduling.suspend }}
+  successfulJobsHistoryLimit: {{ .Values.scheduling.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.scheduling.failedJobsHistoryLimit }}
+  timeZone: {{ .Values.scheduling.timeZone | quote }}
   jobTemplate:
     spec:
-      backoffLimit: 0
+      backoffLimit: {{ .Values.backoffLimit }}
+      restartPolicy: {{ .Values.restartPolicy }}
       {{- include "ml-testing-toolkit-cli.jobtemplate" . | nindent 6 }}
 {{- else if not .Values.tests.enabled }}
 apiVersion: {{ template "ml-testing-toolkit-cli.apiVersion.Job" . }}
@@ -23,6 +26,7 @@ metadata:
     "helm.sh/hook-delete-policy": {{ .Values.postInstallHook.deletePolicy }}
   {{- end }}
 spec:
-  backoffLimit: 0
+  backoffLimit: {{ .Values.backoffLimit }}
+  restartPolicy: {{ .Values.restartPolicy }}
   {{- include "ml-testing-toolkit-cli.jobtemplate" . | indent 2 }}
 {{- end }}

--- a/ml-testing-toolkit-cli/templates/tests/ttk-runner.yaml
+++ b/ml-testing-toolkit-cli/templates/tests/ttk-runner.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/hook-weight: {{ .Values.tests.weight | quote }}
     helm.sh/hook-delete-policy: {{ .Values.tests.deletePolicy }}
 spec:
-  restartPolicy: Never
+  restartPolicy: {{ .Values.restartPolicy }}
   {{- include "ml-testing-toolkit-cli.template.containers" . | nindent 2 -}}
   {{- include "ml-testing-toolkit-cli.template.volumes" . | nindent 2 -}}
 {{- end}}

--- a/ml-testing-toolkit-cli/values.yaml
+++ b/ml-testing-toolkit-cli/values.yaml
@@ -5,16 +5,70 @@ replicaCount: 1
 image:
   repository: mojaloop/ml-testing-toolkit-client-lib
   tag: v1.2.0
-## Optionally specify an array of imagePullSecrets.
-## Secrets must be manually created in the namespace.
-## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
-##
-#  imagePullSecrets:
-#    - name: myregistrykey
   pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  pullSecrets: []
+
+## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/job/#handling-pod-and-container-failures
+backoffLimit: 0
+restartPolicy: Never
+
+## Bash script for TTK CLI
+script: |
+    echo "Downloading the test collection...";
+    wget {{ .Values.config.testCasesZipUrl }} -O downloaded-test-collections.zip;
+    mkdir tmp_test_cases;
+    unzip -d tmp_test_cases -o downloaded-test-collections.zip;
+    npm run cli -- \
+      -c cli-default-config.json \
+      -e cli-testcase-environment.json \
+      -i tmp_test_cases/{{ .Values.config.testCasesPathInZip }} \
+      -u {{ .Values.config.ttkBackendURL | replace "$release_name" .Release.Name }} \
+      --report-format html \
+      {{- if .Values.config.awsS3BucketName }}
+      --report-target s3://{{ .Values.config.awsS3BucketName }}/{{ .Values.config.awsS3FilePath }}/report.html \
+      {{- end }}
+      --report-auto-filename-enable true \
+      {{- if .Values.configCreds.SLACK_WEBHOOK_URL }}
+      --slack-webhook-url $SLACK_WEBHOOK_URL \
+      {{- end }}
+      --extra-summary-information="Test Suite:{{ .Values.config.testSuiteName }},Environment:{{ .Values.config.environmentName }}" \
+      {{- if .Values.config.saveReport }}
+      --save-report true \
+      {{- end }}
+      {{- if .Values.config.reportName }}
+      --report-name {{ .Values.config.reportName }} \
+      {{- end }}
+      {{- if .Values.config.saveReportBaseUrl }}
+      --save-report-base-url {{ .Values.config.saveReportBaseUrl }}
+      {{- end }};
+    {{- if .Values.config.allowFailures }}
+    export TEST_RUNNER_EXIT_CODE="$?"
+    echo "Test Runner finished with exit code: $TEST_RUNNER_EXIT_CODE"
+    echo "Config 'allowFailures' is '{{ .Values.config.allowFailures }}', exiting with '0' exit code!";
+    exit 0;
+    {{- else }}
+    export TEST_RUNNER_EXIT_CODE="$?";
+    echo "Test Runner finished with exit code: $TEST_RUNNER_EXIT_CODE";
+    exit $TEST_RUNNER_EXIT_CODE;
+    {{- end }}
 
 scheduling:
   enabled: false
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-suspension
+  ## You can suspend execution of Jobs for a CronJob, by setting this field to true. The field defaults to false.
+  suspend: false
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#jobs-history-limits
+  successfulJobsHistoryLimit: 7
+  failedJobsHistoryLimit: 7
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones
+  timeZone: 'Etc/UTC'
   ## Note: First Cronjob may fail as the Hub setup & Sim onboarding may not be completed. These must be run either via Post-hooks or via running `Helm test`.
   ## cronSchedule format as follows:
   ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#example
@@ -53,6 +107,10 @@ config:
   environmentName: Development
   saveReport: false
   saveReportBaseUrl: "testing-toolkit.local"
+  ## `allowFailures` configures this TTK CLI Test Runner to return failure exit-codes to the terminal,
+  ## by default this is `false` - which means that any consecutive Helm tests will not be executed by Helm.
+  ## If this is set to `true` - it will allow all Helm tests to be executed regardless of any failures.
+  allowFailures: false
 
 ## Optionally you can specify some parameters here and the references in the environment file like the format '$param_<Param Name>' will be replaced with their values specified here
 parameters: {}

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
-version: 15.0.0
+version: 15.0.1
 appVersion: "ml-api-adapter: v14.0.0; central-ledger: v17.0.3; account-lookup-service: v13.0.0; quoting-service: v15.0.2; central-settlement: v15.0.0; bulk-api-adapter: v15.0.3; transaction-requests-service: v14.0.1; simulator: v12.0.0; mojaloop-simulator: v14.0.1; sdk-scheme-adapter: v22.0.1; auth-service: v14.0.0; consent-oracle: v0.2.0; thirdparty-sdk: v13.0.2; ml-testing-toolkit: v16.0.1; ml-testing-toolkit-ui: v15.2.1;"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
@@ -50,50 +50,6 @@ dependencies:
     version: 13.0.0
     repository: "file://../transaction-requests-service"
     condition: transaction-requests-service.enabled
-  - name: ml-testing-toolkit
-    version: 16.2.0
-    repository: "file://../ml-testing-toolkit"
-    condition: ml-testing-toolkit.enabled
-  - name: ml-testing-toolkit-cli
-    alias: ml-ttk-test-setup
-    version: 15.3.0
-    repository: "file://../ml-testing-toolkit-cli"
-    condition: ml-ttk-test-setup.tests.enabled
-  - name: ml-testing-toolkit-cli
-    alias: ml-ttk-test-val-gp
-    version: 15.3.0
-    repository: "file://../ml-testing-toolkit-cli"
-    condition: ml-ttk-test-val-gp.tests.enabled
-  - name: ml-testing-toolkit-cli
-    alias: ml-ttk-test-val-bulk
-    version: 15.3.0
-    repository: "file://../ml-testing-toolkit-cli"
-    condition: ml-ttk-test-val-bulk.tests.enabled
-  - name: ml-testing-toolkit-cli
-    alias: ml-ttk-test-setup-tp
-    version: 15.3.0
-    repository: "file://../ml-testing-toolkit-cli"
-    condition: ml-ttk-test-setup-tp.tests.enabled
-  - name: ml-testing-toolkit-cli
-    alias: ml-ttk-test-val-tp
-    version: 15.3.0
-    repository: "file://../ml-testing-toolkit-cli"
-    condition: ml-ttk-test-val-tp.tests.enabled
-  - name: ml-testing-toolkit-cli
-    alias: ml-ttk-posthook-setup
-    version: 15.3.0
-    repository: "file://../ml-testing-toolkit-cli"
-    condition: ml-ttk-posthook-setup.postInstallHook.enabled
-  - name: ml-testing-toolkit-cli
-    alias: ml-ttk-posthook-tests
-    version: 15.3.0
-    repository: "file://../ml-testing-toolkit-cli"
-    condition: ml-ttk-posthook-tests.postInstallHook.enabled
-  - name: ml-testing-toolkit-cli
-    alias: ml-ttk-cronjob-tests
-    version: 15.3.0
-    repository: "file://../ml-testing-toolkit-cli"
-    condition: ml-ttk-cronjob-tests.scheduling.enabled
   - name: thirdparty
     version: 3.0.0
     repository: "file://../thirdparty"
@@ -102,23 +58,72 @@ dependencies:
     version: 1.3.0
     repository: "file://../mojaloop-ttk-simulators"
     condition: mojaloop-ttk-simulators.enabled
-  - name: ml-testing-toolkit-cli
-    alias: ml-ttk-test-setup-sdk-bulk
-    version: 15.3.0
-    repository: "file://../ml-testing-toolkit-cli"
-    condition: ml-ttk-test-setup-sdk-bulk.tests.enabled
-  - name: ml-testing-toolkit-cli
-    alias: ml-ttk-test-val-sdk-bulk
-    version: 15.3.0
-    repository: "file://../ml-testing-toolkit-cli"
-    condition: ml-ttk-test-val-sdk-bulk.tests.enabled
-  - name: ml-testing-toolkit-cli
-    alias: ml-ttk-test-cleanup
-    version: 15.3.0
-    repository: "file://../ml-testing-toolkit-cli"
-    condition: ml-ttk-test-cleanup.tests.enabled
   - name: common
     repository: https://mojaloop.github.io/charts/repo
     version: 2.0.0
     tags:
       - moja-common
+  - name: ml-testing-toolkit
+    version: 16.2.0
+    repository: "file://../ml-testing-toolkit"
+    condition: ml-testing-toolkit.enabled
+  - name: ml-testing-toolkit-cli
+    alias: ml-ttk-test-setup
+    version: 15.3.1
+    repository: "file://../ml-testing-toolkit-cli"
+    condition: ml-ttk-test-setup.tests.enabled
+  - name: ml-testing-toolkit-cli
+    alias: ml-ttk-test-val-gp
+    version: 15.3.1
+    repository: "file://../ml-testing-toolkit-cli"
+    condition: ml-ttk-test-val-gp.tests.enabled
+  - name: ml-testing-toolkit-cli
+    alias: ml-ttk-test-val-bulk
+    version: 15.3.1
+    repository: "file://../ml-testing-toolkit-cli"
+    condition: ml-ttk-test-val-bulk.tests.enabled
+  - name: ml-testing-toolkit-cli
+    alias: ml-ttk-test-setup-tp
+    version: 15.3.1
+    repository: "file://../ml-testing-toolkit-cli"
+    condition: ml-ttk-test-setup-tp.tests.enabled
+  - name: ml-testing-toolkit-cli
+    alias: ml-ttk-test-val-tp
+    version: 15.3.1
+    repository: "file://../ml-testing-toolkit-cli"
+    condition: ml-ttk-test-val-tp.tests.enabled
+  - name: ml-testing-toolkit-cli
+    alias: ml-ttk-posthook-setup
+    version: 15.3.1
+    repository: "file://../ml-testing-toolkit-cli"
+    condition: ml-ttk-posthook-setup.postInstallHook.enabled
+  - name: ml-testing-toolkit-cli
+    alias: ml-ttk-posthook-tests
+    version: 15.3.1
+    repository: "file://../ml-testing-toolkit-cli"
+    condition: ml-ttk-posthook-tests.postInstallHook.enabled
+  - name: ml-testing-toolkit-cli
+    alias: ml-ttk-cronjob-tests
+    version: 15.3.1
+    repository: "file://../ml-testing-toolkit-cli"
+    condition: ml-ttk-cronjob-tests.scheduling.enabled
+  - name: ml-testing-toolkit-cli
+    alias: ml-ttk-cronjob-cleanup
+    version: 15.3.1
+    repository: "file://../ml-testing-toolkit-cli"
+    condition: ml-ttk-cronjob-cleanup.scheduling.enabled
+  - name: ml-testing-toolkit-cli
+    alias: ml-ttk-test-setup-sdk-bulk
+    version: 15.3.1
+    repository: "file://../ml-testing-toolkit-cli"
+    condition: ml-ttk-test-setup-sdk-bulk.tests.enabled
+  - name: ml-testing-toolkit-cli
+    alias: ml-ttk-test-val-sdk-bulk
+    version: 15.3.1
+    repository: "file://../ml-testing-toolkit-cli"
+    condition: ml-ttk-test-val-sdk-bulk.tests.enabled
+  - name: ml-testing-toolkit-cli
+    alias: ml-ttk-test-cleanup
+    version: 15.3.1
+    repository: "file://../ml-testing-toolkit-cli"
+    condition: ml-ttk-test-cleanup.tests.enabled

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -13214,6 +13214,62 @@ ml-ttk-cronjob-tests:
     ttkBackendURL: http://$release_name-ml-testing-toolkit-backend:5050
     testSuiteName: GP Tests
     environmentName: Development
+    saveReport: true
+    saveReportBaseUrl: "testing-toolkit.local"
+    reportName: cronjob_tests
+
+  # configCreds:
+  #   AWS_ACCESS_KEY_ID: 'some_aws_access_key'
+  #   AWS_SECRET_ACCESS_KEY: 'some_aws_secret_key'
+  #   AWS_REGION: 'us-west-2'
+  #   SLACK_WEBHOOK_URL: 'slack_inbound_webhook'
+
+  ## Optionally specify the config file defaults for TTK CLI
+  ## You should specify at least mode here
+  # configFileDefaults: {
+  #   "mode": "outbound",
+  #   "reportFormat": "html",
+  #   "baseURL": "",
+  #   "reportTarget": "",
+  #   "reportAutoFilenameEnable": true,
+  #   "slackWebhookUrl": "",
+  #   "slackPassedImage": "",
+  #   "slackFailedImage": ""
+  # }
+  configFileDefaults: {"mode": "outbound"}
+  parameters:
+    <<: *simNames
+  testCaseEnvironmentFile: *ttkInputValues
+
+ml-ttk-cronjob-cleanup:
+  scheduling:
+    enabled: false
+    ## Note: First Cronjob may fail as the Hub setup & Sim onboarding may not be completed. These must be run either via Post-hooks or via running `Helm test`.
+    ## cronSchedule format as follows:
+    ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#example
+    ## ┌───────────── minute (0 - 59)
+    ## │ ┌───────────── hour (0 - 23)
+    ## │ │ ┌───────────── day of the month (1 - 31)
+    ## │ │ │ ┌───────────── month (1 - 12)
+    ## │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday;
+    ## │ │ │ │ │                                   7 is also Sunday on some systems)
+    ## │ │ │ │ │
+    ## │ │ │ │ │
+    ## * * * * *
+    cronSchedule: '15 8 * * *'
+  config:
+    ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
+    testCasesZipUrl: *ttkGitUrl
+    testCasesPathInZip: &ttkGitPathCleanup testing-toolkit-test-cases-15.0.0/collections/hub/cleanup
+    # testCasesPathInZip: *ttkGitPathGP
+    # awsS3BucketName: aws-s3-bucket-name
+    # awsS3FilePath: ttk-tests/reports
+    ttkBackendURL: http://$release_name-ml-testing-toolkit-backend:5050
+    testSuiteName: GP Cleanup
+    environmentName: Development
+    saveReport: true
+    saveReportBaseUrl: "testing-toolkit.local"
+    reportName: cronjob_cleanup
 
   # configCreds:
   #   AWS_ACCESS_KEY_ID: 'some_aws_access_key'
@@ -13252,6 +13308,10 @@ ml-ttk-test-setup:
     saveReport: true
     saveReportBaseUrl: "testing-toolkit.local"
     reportName: standard_provisioning_collection
+    ## `allowFailures` configures this TTK CLI Test Runner to return failure exit-codes to the terminal,
+    ## by default this is `false` - which means that any consecutive Helm tests will not be executed by Helm.
+    ## If this is set to `true` - it will allow all Helm tests to be executed regardless of any failures.
+    allowFailures: false
 
   parameters:
     <<: *simNames
@@ -13274,6 +13334,10 @@ ml-ttk-test-val-gp:
     saveReport: true
     saveReportBaseUrl: "testing-toolkit.local"
     reportName: gp_tests
+    ## `allowFailures` configures this TTK CLI Test Runner to return failure exit-codes to the terminal,
+    ## by default this is `false` - which means that any consecutive Helm tests will not be executed by Helm.
+    ## If this is set to `true` - it will allow all Helm tests to be executed regardless of any failures.
+    allowFailures: false
 
   # configCreds:
   #   AWS_ACCESS_KEY_ID: 'some_aws_access_key'
@@ -13315,6 +13379,10 @@ ml-ttk-test-val-bulk:
     saveReport: true
     saveReportBaseUrl: "testing-toolkit.local"
     reportName: bulk_tests
+    ## `allowFailures` configures this TTK CLI Test Runner to return failure exit-codes to the terminal,
+    ## by default this is `false` - which means that any consecutive Helm tests will not be executed by Helm.
+    ## If this is set to `true` - it will allow all Helm tests to be executed regardless of any failures.
+    allowFailures: false
 
   # configCreds:
   #   AWS_ACCESS_KEY_ID: 'some_aws_access_key'
@@ -13356,6 +13424,10 @@ ml-ttk-test-setup-tp:
     saveReport: true
     saveReportBaseUrl: "testing-toolkit.local"
     reportName: thirdparty_provisioning_collection
+    ## `allowFailures` configures this TTK CLI Test Runner to return failure exit-codes to the terminal,
+    ## by default this is `false` - which means that any consecutive Helm tests will not be executed by Helm.
+    ## If this is set to `true` - it will allow all Helm tests to be executed regardless of any failures.
+    allowFailures: false
 
   # configCreds:
   #   AWS_ACCESS_KEY_ID: 'some_aws_access_key'
@@ -13397,6 +13469,10 @@ ml-ttk-test-val-tp:
     saveReport: true
     saveReportBaseUrl: "testing-toolkit.local"
     reportName: thirdparty_tests
+    ## `allowFailures` configures this TTK CLI Test Runner to return failure exit-codes to the terminal,
+    ## by default this is `false` - which means that any consecutive Helm tests will not be executed by Helm.
+    ## If this is set to `true` - it will allow all Helm tests to be executed regardless of any failures.
+    allowFailures: false
 
   # configCreds:
   #   AWS_ACCESS_KEY_ID: 'some_aws_access_key'
@@ -13438,6 +13514,10 @@ ml-ttk-test-setup-sdk-bulk:
     saveReport: true
     saveReportBaseUrl: "testing-toolkit.local"
     reportName: sdk_bulk_provisioning_collection
+    ## `allowFailures` configures this TTK CLI Test Runner to return failure exit-codes to the terminal,
+    ## by default this is `false` - which means that any consecutive Helm tests will not be executed by Helm.
+    ## If this is set to `true` - it will allow all Helm tests to be executed regardless of any failures.
+    allowFailures: false
 
   # configCreds:
   #   AWS_ACCESS_KEY_ID: 'some_aws_access_key'
@@ -13479,6 +13559,10 @@ ml-ttk-test-val-sdk-bulk:
     saveReport: true
     saveReportBaseUrl: "testing-toolkit.local"
     reportName: sdk_bulk_tests
+    ## `allowFailures` configures this TTK CLI Test Runner to return failure exit-codes to the terminal,
+    ## by default this is `false` - which means that any consecutive Helm tests will not be executed by Helm.
+    ## If this is set to `true` - it will allow all Helm tests to be executed regardless of any failures.
+    allowFailures: false
 
   # configCreds:
   #   AWS_ACCESS_KEY_ID: 'some_aws_access_key'
@@ -13510,7 +13594,7 @@ ml-ttk-test-cleanup:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: testing-toolkit-test-cases-15.0.0/collections/hub/cleanup
+    testCasesPathInZip: *ttkGitPathCleanup
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
@@ -13520,6 +13604,10 @@ ml-ttk-test-cleanup:
     saveReport: false
     saveReportBaseUrl: "testing-toolkit.local"
     reportName: post_cleanup
+    ## `allowFailures` configures this TTK CLI Test Runner to return failure exit-codes to the terminal,
+    ## by default this is `false` - which means that any consecutive Helm tests will not be executed by Helm.
+    ## If this is set to `true` - it will allow all Helm tests to be executed regardless of any failures.
+    allowFailures: false
 
   # configCreds:
   #   AWS_ACCESS_KEY_ID: 'some_aws_access_key'


### PR DESCRIPTION
feat(mojaloop/#3361): reset liquidity - https://github.com/mojaloop/project/issues/3361
- added`'ml-ttk-cronjob-cleanup` cron-job to main Mojaloop Helm chart
- made some improvements to the `ml-testing-toolkit-cli`
     - parameterized: `restartPolicy`, `backoffLimit`, `successfulJobsHistoryLimit`, `failedJobsHistoryLimit`
     - added cronJob configs for `suspend`, `timeZone` 
     - fixed `imagePullSecrets` --> `pullSecrets` for consistency 
     - moved command arguments to parameterized `script` value configuration to allow for configuration flexibility. 
     - added support to configure `allowFailures` which allows for Helm Test failures to be ignored if set to `true`
- minor chart bump to `ml-testing-toolkit-cli` and `mojaloop` helm charts for patch release
- added initial release notes for v15.0.1 release.