### PR TITLE
chore: fixes to main chart application versions [skip ci]

### DIFF
--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
 version: 15.1.0
-appVersion: "ml-api-adapter: v14.0.0; central-ledger: v17.0.3; account-lookup-service: v13.0.0; quoting-service: v15.0.2; central-settlement: v15.0.0; bulk-api-adapter: v15.0.3; transaction-requests-service: v14.0.1; simulator: v12.0.0; mojaloop-simulator: v14.0.1; sdk-scheme-adapter: v23.0.1; auth-service: v14.0.0; consent-oracle: v0.2.0; thirdparty-sdk: v13.0.2; ml-testing-toolkit: v16.0.1; ml-testing-toolkit-ui: v15.2.1;"
+appVersion: "ml-api-adapter: v14.0.0; central-ledger: v17.0.3; account-lookup-service: v14.0.0; quoting-service: v15.0.2; central-settlement: v15.0.0; bulk-api-adapter: v15.0.3; transaction-requests-service: v14.0.1; simulator: v12.0.0; mojaloop-simulator: v14.0.1; sdk-scheme-adapter: v23.0.1; auth-service: v14.0.0; consent-oracle: v0.2.0; thirdparty-sdk: v13.0.2; ml-testing-toolkit: v16.1.1; ml-testing-toolkit-ui: v15.4.0;"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:


### PR DESCRIPTION
- fixes for miss-aligned versions in mojaloop/chart.yaml