### PR TITLE
feat(mojaloop/#3399): add initial als grafana dashboard [skip ci]

### DIFF
--- a/monitoring/dashboards/mojaloop/dashboard-account-lookup-service.json
+++ b/monitoring/dashboards/mojaloop/dashboard-account-lookup-service.json
@@ -1,0 +1,1390 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.2"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 10,
+      "title": "Participant Resource",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_ing_getParticipantsByTypeAndID_sum[30s]) / irate(moja_als_ing_getParticipantsByTypeAndID_count[30s])",
+          "instant": false,
+          "legendFormat": "getParticipantsByTypeAndID",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_ing_putParticipantsByTypeAndID_sum[30s]) / irate(moja_als_ing_putParticipantsByTypeAndID_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putParticipantsByTypeAndID",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_ing_postParticipantsbyTypeAndID_sum[30s]) / irate(moja_als_ing_postParticipantsbyTypeAndID_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "postParticipantsbyTypeAndID",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_ing_deleteParticipantsByTypeAndID_sum[30s]) / irate(moja_als_ing_deleteParticipantsByTypeAndID_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "deleteParticipantsByTypeAndID",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_ing_getParticipantsByTypeIdAndSubID_sum[30s]) / irate(moja_als_ing_getParticipantsByTypeIdAndSubID_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "getParticipantsByTypeIdAndSubID",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_ing_putParticipantsByTypeIDAndSubID_sum[30s]) / irate(moja_als_ing_putParticipantsByTypeIDAndSubID_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putParticipantsByTypeIDAndSubID",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_ing_postParticipantsByTypeIDAndSubID_sum[30s]) / irate(moja_als_ing_postParticipantsByTypeIDAndSubID_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "postParticipantsByTypeIDAndSubID",
+          "range": true,
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_ing_deleteParticipantsByTypeIDAndSubID_sum[30s]) / irate(moja_als_ing_deleteParticipantsByTypeIDAndSubID_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "deleteParticipantsByTypeIDAndSubID",
+          "range": true,
+          "refId": "H"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_ing_putParticipantsErrorByTypeAndID_sum[30s]) / irate(moja_als_ing_putParticipantsErrorByTypeAndID_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putParticipantsErrorByTypeAndID",
+          "range": true,
+          "refId": "I"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_ing_putParticipantsErrorByTypeIDAndSubID_sum[30s]) / irate(moja_als_ing_putParticipantsErrorByTypeIDAndSubID_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putParticipantsErrorByTypeIDAndSubID",
+          "range": true,
+          "refId": "J"
+        }
+      ],
+      "title": "Participant Handlers Ingress - Processing Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_ing_getParticipantsByTypeAndID_count[30s])) by (success)",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "getParticipantsByTypeAndID success:{{success}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_ing_putParticipantsByTypeAndID_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putParticipantsByTypeAndID success:{{success}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_ing_postParticipantsbyTypeAndID_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "postParticipantsbyTypeAndID success:{{success}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_ing_deleteParticipantsByTypeAndID_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "deleteParticipantsByTypeAndID success:{{success}}",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_ing_getParticipantsByTypeIdAndSubID_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "getParticipantsByTypeIdAndSubID success:{{success}}",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_ing_putParticipantsByTypeIDAndSubID_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putParticipantsByTypeIDAndSubID success:{{success}}",
+          "range": true,
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_ing_postParticipantsByTypeIDAndSubID_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "postParticipantsByTypeIDAndSubID success:{{success}}",
+          "range": true,
+          "refId": "H"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_ing_deleteParticipantsByTypeIDAndSubID_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "deleteParticipantsByTypeIDAndSubID success:{{success}}",
+          "range": true,
+          "refId": "I"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_ing_putParticipantsErrorByTypeAndID_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putParticipantsErrorByTypeAndID success:{{success}}",
+          "range": true,
+          "refId": "J"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_ing_putParticipantsErrorByTypeIDAndSubID_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putParticipantsErrorByTypeIDAndSubID success:{{success}}",
+          "range": true,
+          "refId": "K"
+        }
+      ],
+      "title": "Participant Handler Ingress - Processing Per Second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_getParticipantsByTypeAndID_sum[30s]) / irate(moja_als_getParticipantsByTypeAndID_count[30s])",
+          "instant": false,
+          "legendFormat": "getParticipantsByTypeAndID",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_putParticipantsByTypeAndID_sum[30s]) / irate(moja_als_putParticipantsByTypeAndID_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putParticipantsByTypeAndID",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_putParticipantsErrorByTypeAndID_sum[30s]) / irate(moja_als_putParticipantsErrorByTypeAndID_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putParticipantsErrorByTypeAndID",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_postParticipants_sum[30s]) / irate(moja_als_postParticipants_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "postParticipants",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_postParticipantsBatch_sum[30s]) / irate(moja_als_postParticipantsBatch_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "postParticipantsBatch",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_deleteParticipants_sum[30s]) / irate(moja_als_deleteParticipants_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "deleteParticipants",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "Participant Domain - Processing Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_getParticipantsByTypeAndID_count[30s])) by (success)",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "getParticipantsByTypeAndID success:{{success}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_putParticipantsByTypeAndID_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putParticipantsByTypeAndID success:{{success}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_putParticipantsErrorByTypeAndID_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putParticipantsErrorByTypeAndID success:{{success}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_postParticipants_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "postParticipants success:{{success}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_postParticipantsBatch_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "postParticipantsBatch success:{{success}}",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_postParticipantsBatch_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "deleteParticipants success:{{success}}",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "Participants Domain - Processing Per Second",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 9,
+      "title": "Party Resource",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_ing_getPartiesByTypeAndID_sum[30s]) / irate(moja_als_ing_getPartiesByTypeAndID_count[30s])",
+          "instant": false,
+          "legendFormat": "getPartiesByTypeAndID",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_ing_putPartiesByTypeAndID_sum[30s]) / irate(moja_als_ing_putPartiesByTypeAndID_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putPartiesByTypeAndID",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_ing_getPartiesByTypeIDAndSubID_sum[30s]) / irate(moja_als_ing_getPartiesByTypeIDAndSubID_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "getPartiesByTypeIDAndSubID",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_ing_putPartiesByTypeIDAndSubID_sum[30s]) / irate(moja_als_ing_putPartiesByTypeIDAndSubID_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putPartiesByTypeIDAndSubID",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_ing_putPartiesErrorByTypeAndID_sum[30s]) / irate(moja_als_ing_putPartiesErrorByTypeAndID_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putPartiesErrorByTypeAndID",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_ing_putPartiesErrorByTypeIDAndSubID_sum[30s]) / irate(moja_als_ing_putPartiesErrorByTypeIDAndSubID_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putPartiesErrorByTypeIDAndSubID",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "Party Handlers Ingress - Processing Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_ing_getPartiesByTypeAndID_count[30s])) by (success)",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "getPartiesByTypeAndID success:{{success}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_ing_putPartiesByTypeAndID_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putPartiesByTypeAndID success:{{success}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_ing_getPartiesByTypeIDAndSubID_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "getPartiesByTypeIDAndSubID success:{{success}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_ing_putPartiesByTypeIDAndSubID_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putPartiesByTypeIDAndSubID success:{{success}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_ing_putPartiesErrorByTypeAndID_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": " putPartiesErrorByTypeAndID success:{{success}}",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_ing_putPartiesErrorByTypeIDAndSubID_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putPartiesErrorByTypeIDAndSubID success:{{success}}",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "Party Handler Ingress - Processing Per Second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_getPartiesByTypeAndID_sum[30s]) / irate(moja_als_getPartiesByTypeAndID_count[30s])",
+          "instant": false,
+          "legendFormat": "getPartiesByTypeAndID",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_putPartiesByTypeAndID_sum[30s]) / irate(moja_als_putPartiesByTypeAndID_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putPartiesByTypeAndID",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(moja_als_puttPartiesErrorByTypeAndID_sum[30s]) / irate(moja_als_ing_puttPartiesErrorByTypeAndID_count[30s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "puttPartiesErrorByTypeAndID",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Party Domain - Processing Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_getPartiesByTypeAndID_count[30s])) by (success)",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "getPartiesByTypeAndID success:{{success}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_putPartiesByTypeAndID_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "putPartiesByTypeAndID success:{{success}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(moja_als_puttPartiesErrorByTypeAndID_count[30s])) by (success)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "puttPartiesErrorByTypeAndID success:{{success}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Party Domain - Processing Per Second",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "dashboard-account-lookup-service",
+  "uid": "a0bc6ab1-e6f8-4cd3-a173-89b9ae692807",
+  "version": 3,
+  "weekStart": ""
+}


### PR DESCRIPTION
feat(mojaloop/#3399): add initial als grafana dashboard - https://github.com/mojaloop/project/issues/3399

- Add initial grafana dashboard focusing solely on parties/participant ingress and domain logic performance
![dashboard-account-lookup-service-Dashboards-Grafana (1)](https://github.com/mojaloop/helm/assets/5932442/5018dbc6-82c5-4bf2-babc-64c5ca9e1926)

