### PR TITLE
example/poc-argocd-test

### DIFF
--- a/ml-testing-toolkit-cli/templates/job.yaml
+++ b/ml-testing-toolkit-cli/templates/job.yaml
@@ -14,18 +14,23 @@ spec:
       backoffLimit: {{ .Values.backoffLimit }}
       restartPolicy: {{ .Values.restartPolicy }}
       {{- include "ml-testing-toolkit-cli.jobtemplate" . | nindent 6 }}
-{{- else if not .Values.tests.enabled }}
+{{- end }}
+{{- if .Values.job.enabled }} // added job definition to values.yaml
 apiVersion: {{ template "ml-testing-toolkit-cli.apiVersion.Job" . }}
 kind: Job
 metadata:
   name: {{ template "ml-testing-toolkit-cli.fullname" . }}
-  {{- if .Values.postInstallHook.enabled }}
   annotations:
+    {{- if .Values.postInstallHook.enabled }}
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": {{ .Values.postInstallHook.weight | quote }}
     "helm.sh/hook-delete-policy": {{ .Values.postInstallHook.deletePolicy }}
-  {{- end }}
+    {{- end }}
+    // Add custom annotations, and updated the values.yaml
 spec:
+  {{- if .Values.job.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished }} // this would need to be added
+  {{- end }}
   backoffLimit: {{ .Values.backoffLimit }}
   restartPolicy: {{ .Values.restartPolicy }}
   {{- include "ml-testing-toolkit-cli.jobtemplate" . | indent 2 }}

--- a/ml-testing-toolkit-cli/templates/job.yaml
+++ b/ml-testing-toolkit-cli/templates/job.yaml
@@ -27,6 +27,9 @@ metadata:
     "helm.sh/hook-delete-policy": {{ .Values.postInstallHook.deletePolicy }}
     {{- end }}
     ## Add custom annotations, and updated the values.yaml
+    ## Example ArgoCD annotations that would be injected via the custom annotations (ref: https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/#hook-deletion-policies):
+    # argocd.argoproj.io/hook: PostSync
+    # argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
   {{- if .Values.job.ttlSecondsAfterFinished }}
   ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished }} ## this would need to be added

--- a/ml-testing-toolkit-cli/templates/job.yaml
+++ b/ml-testing-toolkit-cli/templates/job.yaml
@@ -19,7 +19,11 @@ spec:
 apiVersion: {{ template "ml-testing-toolkit-cli.apiVersion.Job" . }}
 kind: Job
 metadata:
+  {{- if .Values.job.generateName }} ## add support for random name generation
+  generateName: {{ template "ml-testing-toolkit-cli.fullname" . }}-
+  {{- else }}
   name: {{ template "ml-testing-toolkit-cli.fullname" . }}
+  {{- end }}
   annotations:
     {{- if .Values.postInstallHook.enabled }}
     "helm.sh/hook": post-install
@@ -29,7 +33,6 @@ metadata:
     ## Add custom annotations, and updated the values.yaml
     ## Example ArgoCD annotations that would be injected via the custom annotations (ref: https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/#hook-deletion-policies):
     # argocd.argoproj.io/hook: PostSync
-    # argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
   {{- if .Values.job.ttlSecondsAfterFinished }}
   ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished }} ## this would need to be added

--- a/ml-testing-toolkit-cli/templates/job.yaml
+++ b/ml-testing-toolkit-cli/templates/job.yaml
@@ -19,7 +19,7 @@ spec:
 apiVersion: {{ template "ml-testing-toolkit-cli.apiVersion.Job" . }}
 kind: Job
 metadata:
-  {{- if .Values.job.generateName }} ## add support for random name generation
+  {{- if .Values.job.generateNameEnabled }} ## add support for random name generation, value: true/false
   generateName: {{ template "ml-testing-toolkit-cli.fullname" . }}-
   {{- else }}
   name: {{ template "ml-testing-toolkit-cli.fullname" . }}

--- a/ml-testing-toolkit-cli/templates/job.yaml
+++ b/ml-testing-toolkit-cli/templates/job.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: {{ .Values.restartPolicy }}
       {{- include "ml-testing-toolkit-cli.jobtemplate" . | nindent 6 }}
 {{- end }}
-{{- if .Values.job.enabled }} // added job definition to values.yaml
+{{- if .Values.job.enabled }} ## added job definition to values.yaml
 apiVersion: {{ template "ml-testing-toolkit-cli.apiVersion.Job" . }}
 kind: Job
 metadata:
@@ -26,10 +26,10 @@ metadata:
     "helm.sh/hook-weight": {{ .Values.postInstallHook.weight | quote }}
     "helm.sh/hook-delete-policy": {{ .Values.postInstallHook.deletePolicy }}
     {{- end }}
-    // Add custom annotations, and updated the values.yaml
+    ## Add custom annotations, and updated the values.yaml
 spec:
   {{- if .Values.job.ttlSecondsAfterFinished }}
-  ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished }} // this would need to be added
+  ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished }} ## this would need to be added
   {{- end }}
   backoffLimit: {{ .Values.backoffLimit }}
   restartPolicy: {{ .Values.restartPolicy }}


### PR DESCRIPTION
Update [ml-testing-toolkit-cli](https://github.com/mojaloop/helm/tree/example/poc-argocd-test/ml-testing-toolkit-cli) helm chart - job.yaml with changes:
1. Changed Job to have its own if statement, by checking `.Values.job.*`
2. Moved Helm hook annotations if-statement inside of the annotation blocked
3. Added support for custom annotations
4. Added support for setting ttlSecondsAfterFinished if it has been set in the main .Values.job.ttlSecondsAfterFinished

The config changes would then need to be applied to the main [mojaloop/values.yaml](https://github.com/mojaloop/helm/blob/example/poc-argocd-test/mojaloop/values.yaml) config for:
- ml-ttk-posthook-setup - [mojaloop/Chart.yml#L95](https://github.com/mojaloop/helm/blob/example/poc-argocd-test/mojaloop/Chart.yaml#L95), [mojaloop/values.yaml#L13145](https://github.com/mojaloop/helm/blob/example/poc-argocd-test/mojaloop/values.yaml#L13145)
- ml-ttk-posthook-tests - [mojaloop/Chart.yml#L100](https://github.com/mojaloop/helm/blob/example/poc-argocd-test/mojaloop/Chart.yaml#L100), [mojaloop/values.yaml#L13158](https://github.com/mojaloop/helm/blob/example/poc-argocd-test/mojaloop/values.yaml#L13158)

And we may need to add a new Job for `ml-ttk-posthook-cleanup` (currently not configured).

