### PR TITLE
feat(mojaloop/##3599): add support for custom annot to helm chart depl

### DIFF
--- a/centralledger/chart-service/templates/deployment.yaml
+++ b/centralledger/chart-service/templates/deployment.yaml
@@ -25,6 +25,14 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        # Custom Pod annotations
+        {{- if .Values.pod.annotations }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.pod.annotations "context" $ ) | nindent 4 }}
+        {{- end }}
+        # Common annotations
+        {{- if .Values.commonAnnotations }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+        {{- end }}
       {{- if .Values.metrics.enabled }}
         prometheus.io/port: "{{ .Values.service.internalPort }}"
         prometheus.io/scrape: "true"

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -282,6 +282,11 @@ initContainers: |
       - name: '{{ template "account-lookup-service-admin.fullname" . }}-config-volume'
         mountPath: /opt/app/config
 
+pod:
+  ## @param pod.annotations Additional custom annotations for %%MAIN_CONTAINER_NAME%% pod(s)
+  ##
+  # annotations: {}
+
 service:
   internalPort: 3001
   ## @param service.type %%MAIN_CONTAINER_NAME%% service type

--- a/ml-testing-toolkit/chart-backend/templates/statefulset.yaml
+++ b/ml-testing-toolkit/chart-backend/templates/statefulset.yaml
@@ -23,6 +23,14 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+        # Custom Pod annotations
+        {{- if .Values.pod.annotations }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.pod.annotations "context" $ ) | nindent 4 }}
+        {{- end }}
+        # Common annotations
+        {{- if .Values.commonAnnotations }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+        {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "ml-testing-toolkit-backend.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}

--- a/ml-testing-toolkit/chart-backend/values.yaml
+++ b/ml-testing-toolkit/chart-backend/values.yaml
@@ -366,6 +366,11 @@ initContainers: [] # We want to disable init-containers as there is no need
 #       - name: DB_DATABASE
 #         value: '{{ .Values.config.mongodb.database }}'
 
+pod:
+  ## @param pod.annotations Additional custom annotations for %%MAIN_CONTAINER_NAME%% pod(s)
+  ##
+  annotations: {}
+
 service:
   ## @param service.type %%MAIN_CONTAINER_NAME%% service type
   ##


### PR DESCRIPTION
feat(mojaloop/##3599): add support for custom annot to helm chart depl - https://github.com/mojaloop/project/issues/3599
- added custom pod annotations to - centralledger chart-service - ml-testing-toolkit chart-backend