### PR TITLE
fix: hard coded pull secret in mojaloop simulator chart

### DIFF
--- a/mojaloop-simulator/Chart.yaml
+++ b/mojaloop-simulator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: "Helm Chart for the Mojaloop (SDK-based) Simulator"
 name: mojaloop-simulator
-version: 15.2.0
+version: 15.2.1
 appVersion: "sdk-scheme-adapter: v23.4.0; mojaloop-simulator: v15.0.0; thirdparty-sdk: v15.1.1"
 dependencies:
   - name: common

--- a/mojaloop-simulator/templates/deployment.yaml
+++ b/mojaloop-simulator/templates/deployment.yaml
@@ -93,6 +93,10 @@ spec:
       - name: scheme-adapter
         image: "{{ $config.config.schemeAdapter.image.repository }}:{{ $config.config.schemeAdapter.image.tag }}"
         imagePullPolicy: {{ $config.config.schemeAdapter.image.pullPolicy }}
+        {{- if .config.config.imagePullSecrets }}
+        imagePullSecrets:
+        {{ toYaml .config.config.imagePullSecrets | indent 10 }}
+        {{- end }}
         command: {{ $config.config.schemeAdapter.image.command }}
         ports:
           - name: inboundapi
@@ -148,8 +152,6 @@ spec:
         {{- end }}
         resources:
 {{ toYaml $config.config.schemeAdapter.resources | indent 10 }}
-      imagePullSecrets:
-        - name: {{ $config.config.imagePullSecretName }}
     {{- with $config.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -191,6 +193,10 @@ spec:
       - name: backend
         image: "{{ $config.config.backend.image.repository }}:{{ $config.config.backend.image.tag }}"
         imagePullPolicy: {{ $config.config.backend.image.pullPolicy }}
+        {{- if .config.config.imagePullSecrets }}
+        imagePullSecrets:
+        {{ toYaml .config.config.imagePullSecrets | indent 10 }}
+        {{- end }}
         ports:
           - name: simapi
             containerPort: 3000 # these are hard-coded in the service
@@ -245,8 +251,6 @@ spec:
       - name: {{ $prefix }}rules
         configMap:
           name: {{ $fullName }}-rules
-      imagePullSecrets:
-        - name: {{ $config.config.imagePullSecretName }}
     {{- with $config.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -369,6 +373,10 @@ spec:
       - name: thirdpartysdk
         image: "{{ $config.config.thirdpartysdk.image.repository }}:{{ $config.config.thirdpartysdk.image.tag }}"
         imagePullPolicy: {{ $config.config.thirdpartysdk.image.pullPolicy }}
+        {{- if .config.config.imagePullSecrets }}
+        imagePullSecrets:
+        {{ toYaml .config.config.imagePullSecrets | indent 8 }}
+        {{- end }}
         # TODO: make configurable
         command: {{ $config.config.thirdpartysdk.image.command }}
         ports:
@@ -409,9 +417,6 @@ spec:
         {{- end }}
         resources:
 {{ toYaml $config.config.thirdpartysdk.resources | indent 10 }}
-
-      imagePullSecrets:
-        - name: {{ $config.config.imagePullSecretName }}
     {{- with $config.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/mojaloop-simulator/values.yaml
+++ b/mojaloop-simulator/values.yaml
@@ -44,7 +44,6 @@ simulators: {}
 # * support arbitrary init containers + config (that might just be config that goes into defaults
 #   or something?). Supply all config and volumes to the init containers.
 # * create some test containers
-# * parametrise imagePullSecretName (global? like https://github.com/bitnami/charts/tree/master/bitnami/redis#parameters)
 # * generate JWS private/public keys, so the user does not need to supply keys at all.
 # * generate public key from private, so the user only needs to supply private keys for each sim?
 #   (_might_ be possible with a job or init container or similar).
@@ -194,7 +193,14 @@ defaults:
     ##
     podAnnotations: {}
 
-    imagePullSecretName: dock-casa-secret
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g:
+    ## imagePullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    imagePullSecrets: []
 
     cache:
 

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
-version: 16.0.1
+version: 16.0.2
 appVersion: "ml-api-adapter: v14.0.5; central-ledger: v17.6.1; account-lookup-service: v15.2.3; quoting-service: v15.7.0; central-settlement: v16.0.0; bulk-api-adapter: v17.0.0; transaction-requests-service: v14.1.2; simulator: v12.1.0; mojaloop-simulator: v15.0.0; sdk-scheme-adapter: v23.4.0; auth-service: v15.0.0; als-consent-oracle: v0.2.2; thirdparty-sdk: v15.1.1; ml-testing-toolkit: v17.0.0; ml-testing-toolkit-ui: v15.4.2;"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
@@ -39,7 +39,7 @@ dependencies:
     repository: "file://../simulator"
     condition: simulator.enabled
   - name: mojaloop-simulator
-    version: ">= 15.2.0"
+    version: ">= 15.2.1"
     repository: "file://../mojaloop-simulator"
     condition: mojaloop-simulator.enabled
   - name: mojaloop-bulk
@@ -51,7 +51,7 @@ dependencies:
     repository: "file://../transaction-requests-service"
     condition: transaction-requests-service.enabled
   - name: thirdparty
-    version: ">= 3.6.0"
+    version: ">= 3.6.1"
     repository: "file://../thirdparty"
     condition: thirdparty.enabled
   - name: mojaloop-ttk-simulators

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -7890,7 +7890,6 @@ thirdparty:
     # * support arbitrary init containers + config (that might just be config that goes into defaults
     #   or something?). Supply all config and volumes to the init containers.
     # * create some test containers
-    # * parametrise imagePullSecretName (global? like https://github.com/bitnami/charts/tree/master/bitnami/redis#parameters)
     # * generate JWS private/public keys, so the user does not need to supply keys at all.
     # * generate public key from private, so the user only needs to supply private keys for each sim?
     #   (_might_ be possible with a job or init container or similar).
@@ -8697,7 +8696,14 @@ thirdparty:
         initContainers:
           waitForCache:
             enabled: true
-        imagePullSecretName: dock-casa-secret
+        ## Optionally specify an array of imagePullSecrets.
+        ## Secrets must be manually created in the namespace.
+        ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+        ## e.g:
+        ## imagePullSecrets:
+        ##   - myRegistryKeySecretName
+        ##
+        imagePullSecrets: []
         cache:
           # These will be supplied directly to the init containers array in the deployment for the
           # scheme adapter. They should look exactly as you'd declare them inside the deployment.
@@ -9363,7 +9369,6 @@ mojaloop-simulator:
   # * support arbitrary init containers + config (that might just be config that goes into defaults
   #   or something?). Supply all config and volumes to the init containers.
   # * create some test containers
-  # * parametrise imagePullSecretName (global? like https://github.com/bitnami/charts/tree/master/bitnami/redis#parameters)
   # * generate JWS private/public keys, so the user does not need to supply keys at all.
   # * generate public key from private, so the user only needs to supply private keys for each sim?
   #   (_might_ be possible with a job or init container or similar).
@@ -9814,7 +9819,14 @@ mojaloop-simulator:
       initContainers:
         waitForCache:
           enabled: true
-      imagePullSecretName: dock-casa-secret
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ## e.g:
+      ## imagePullSecrets:
+      ##   - myRegistryKeySecretName
+      ##
+      imagePullSecrets: []
       cache:
         # These will be supplied directly to the init containers array in the deployment for the
         # scheme adapter. They should look exactly as you'd declare them inside the deployment.

--- a/thirdparty/Chart.yaml
+++ b/thirdparty/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: thirdparty
-version: 3.6.0
+version: 3.6.1
 description: Third Party API Support for Mojaloop
 appVersion: "auth-service: v15.0.0; als-consent-oracle: v0.2.2; thirdparty-sdk: v15.1.1"
 home: http://mojaloop.io
@@ -29,7 +29,7 @@ dependencies:
     condition: tp-api-svc.enabled
   - name: mojaloop-simulator
     alias: thirdparty-simulator
-    version: ">= 15.2.0"
+    version: ">= 15.2.1"
     repository: "file://../mojaloop-simulator"
     condition: mojaloop-simulator.enabled
   - name: common

--- a/thirdparty/values.yaml
+++ b/thirdparty/values.yaml
@@ -1081,7 +1081,6 @@ thirdparty-simulator:
   # * support arbitrary init containers + config (that might just be config that goes into defaults
   #   or something?). Supply all config and volumes to the init containers.
   # * create some test containers
-  # * parametrise imagePullSecretName (global? like https://github.com/bitnami/charts/tree/master/bitnami/redis#parameters)
   # * generate JWS private/public keys, so the user does not need to supply keys at all.
   # * generate public key from private, so the user only needs to supply private keys for each sim?
   #   (_might_ be possible with a job or init container or similar).
@@ -2002,8 +2001,14 @@ thirdparty-simulator:
       initContainers:
         waitForCache:
           enabled: true
-
-      imagePullSecretName: dock-casa-secret
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ## e.g:
+      ## imagePullSecrets:
+      ##   - myRegistryKeySecretName
+      ##
+      imagePullSecrets: []
 
       cache:
 


### PR DESCRIPTION
Kubernetes deployment gives warnings for pull secret "dock-casa-secret" because there is hard coded reference in mojaloop simulator chart.