### PR TITLE
feat(#3994): update performance dashboard

### DIFF
--- a/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json
+++ b/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json
@@ -948,7 +948,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(node_disk_read_bytes_total{cluster=\"$cluster\"}[5m])) by (instance,nodename,device) > 1024 * 1024",
+          "expr": "sum(rate(node_disk_read_bytes_total{cluster=\"$cluster\"}[1m])) by (instance,nodename,device) > 1024 * 1024",
           "instant": false,
           "legendFormat": "{{nodename}}/{{device}}",
           "range": true,
@@ -1048,7 +1048,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(node_disk_written_bytes_total{cluster=\"$cluster\"}[5m])) by (instance,nodename,device) > 1024 * 1024",
+          "expr": "sum(rate(node_disk_written_bytes_total{cluster=\"$cluster\"}[1m])) by (instance,nodename,device) > 1024 * 1024",
           "instant": false,
           "legendFormat": "{{nodename}}/{{device}}",
           "range": true,

--- a/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json
+++ b/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json
@@ -824,7 +824,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -945,7 +946,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1039,7 +1041,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1133,7 +1136,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1228,7 +1232,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1324,7 +1329,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1419,7 +1425,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1516,7 +1523,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1610,7 +1618,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1707,7 +1716,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1755,125 +1765,17 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
+      "collapsed": false,
       "gridPos": {
-        "h": 4,
+        "h": 1,
         "w": 24,
         "x": 0,
         "y": 42
       },
-      "id": 8,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum by (pod)(max_over_time(mysql_global_status_threads_connected{namespace=\"mojaloop-db\", cluster=\"$cluster\"}[5m]))",
-          "hide": true,
-          "instant": false,
-          "legendFormat": "Connections {{pod}} last 5m",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum by (pod)(mysql_global_status_max_used_connections{namespace=\"mojaloop-db\", cluster=\"$cluster\"})",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Max Use Connections {{pod}}",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum by (pod)(mysql_global_variables_max_connections{namespace=\"mojaloop-db\", cluster=\"$cluster\"})",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Max Connections {{pod}}",
-          "range": true,
-          "refId": "C"
-        }
-      ],
-      "title": "MySQL Connections",
-      "type": "timeseries"
+      "id": 25,
+      "panels": [],
+      "title": "Mojaloop",
+      "type": "row"
     },
     {
       "datasource": {
@@ -1897,7 +1799,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1912,7 +1815,7 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 46
+        "y": 43
       },
       "id": 17,
       "options": {
@@ -1982,7 +1885,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1997,7 +1901,7 @@
         "h": 6,
         "w": 6,
         "x": 6,
-        "y": 46
+        "y": 43
       },
       "id": 18,
       "options": {
@@ -2067,7 +1971,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2082,7 +1987,7 @@
         "h": 6,
         "w": 6,
         "x": 12,
-        "y": 46
+        "y": 43
       },
       "id": 19,
       "options": {
@@ -2129,6 +2034,154 @@
         }
       ],
       "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 49
+      },
+      "id": 24,
+      "panels": [],
+      "title": "My SQL",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 50
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod)(max_over_time(mysql_global_status_threads_connected{namespace=\"mojaloop-db\", cluster=\"$cluster\"}[5m]))",
+          "hide": true,
+          "instant": false,
+          "legendFormat": "Connections {{pod}} last 5m",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod)(mysql_global_status_max_used_connections{namespace=\"mojaloop-db\", cluster=\"$cluster\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Max Use Connections {{pod}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod)(mysql_global_variables_max_connections{namespace=\"mojaloop-db\", cluster=\"$cluster\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Max Connections {{pod}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "MySQL Connections",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 54
+      },
+      "id": 26,
+      "panels": [],
+      "title": "Kafka",
+      "type": "row"
     }
   ],
   "refresh": "",
@@ -2149,6 +2202,10 @@
       },
       {
         "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
         "definition": "label_values(node_uname_info,cluster)",
         "hide": 0,
         "includeAll": false,
@@ -2175,7 +2232,7 @@
   "timepicker": {},
   "timezone": "",
   "title": "Performance Troubleshooting",
-  "uid": "f1068daf-16a2-4e52-9a57-1a662092584-v002",
+  "uid": "f1068daf-16a2-4e52-9a57-1a662092584-v003",
   "version": 1,
   "weekStart": ""
 }

--- a/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json
+++ b/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json
@@ -663,6 +663,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Shows network interfaces on each node which are consuming more than 1 MiB/s bandwidth (download).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -763,6 +764,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Shows network interfaces on each node which are consuming more than 1 MiB/s bandwidth (upload)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -863,6 +865,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Shows disks  on each node which are consuming more than 1 MiB/s disk read bandwidth ",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -963,6 +966,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Shows disks  on each node which are consuming more than 1 MiB/s disk write bandwidth ",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1789,6 +1793,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Shows mojaloop pods which are consuming more than 1 MiB/s network download bandwidth ",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1888,6 +1893,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Shows mojaloop pods which are consuming more than 1 MiB/s network upload bandwidth ",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json
+++ b/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json
@@ -1840,7 +1840,7 @@
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "binBps"
         },
         "overrides": []
       },
@@ -1849,6 +1849,204 @@
         "w": 12,
         "x": 0,
         "y": 38
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "rate(container_network_receive_bytes_total{namespace=~\"mojaloop\", pod=~\".*(account-lookup-service|account-lookup-service-admin|centralledger-handler-admin-transfer|centralledger-handler-timeout|centralledger-handler-transfer-fulfil|centralledger-handler-transfer-get|centralledger-handler-transfer-position|centralledger-service|handler-pos-batch|kafka).*\", cluster=\"$cluster\"}[5m]) > 1024 * 1024",
+          "instant": false,
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Mojaloop pods Network I/O - Download",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 38
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "rate(container_network_transmit_bytes_total{namespace=~\"mojaloop\", pod=~\".*(account-lookup-service|account-lookup-service-admin|centralledger-handler-admin-transfer|centralledger-handler-timeout|centralledger-handler-transfer-fulfil|centralledger-handler-transfer-get|centralledger-handler-transfer-position|centralledger-service|handler-pos-batch|kafka).*\", cluster=\"$cluster\"}[5m]) > 1024 * 1024 ",
+          "instant": false,
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Mojaloop pods Network I/O - Upload",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 45
       },
       "id": 6,
       "options": {
@@ -1945,7 +2143,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 38
+        "y": 45
       },
       "id": 7,
       "options": {
@@ -2041,7 +2239,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 45
+        "y": 52
       },
       "id": 20,
       "options": {
@@ -2138,7 +2336,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 45
+        "y": 52
       },
       "id": 21,
       "options": {
@@ -2176,7 +2374,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 59
       },
       "id": 25,
       "panels": [],
@@ -2221,7 +2419,7 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 53
+        "y": 60
       },
       "id": 17,
       "options": {
@@ -2307,7 +2505,7 @@
         "h": 6,
         "w": 6,
         "x": 6,
-        "y": 53
+        "y": 60
       },
       "id": 18,
       "options": {
@@ -2393,7 +2591,7 @@
         "h": 6,
         "w": 6,
         "x": 12,
-        "y": 53
+        "y": 60
       },
       "id": 19,
       "options": {
@@ -2447,7 +2645,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 66
       },
       "id": 24,
       "panels": [],
@@ -2501,8 +2699,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2517,7 +2714,7 @@
         "h": 4,
         "w": 24,
         "x": 0,
-        "y": 60
+        "y": 67
       },
       "id": 8,
       "options": {
@@ -2582,7 +2779,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 64
+        "y": 71
       },
       "id": 26,
       "panels": [],
@@ -2626,8 +2823,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2642,7 +2838,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 65
+        "y": 72
       },
       "id": 27,
       "options": {
@@ -2723,8 +2919,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2739,7 +2934,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 65
+        "y": 72
       },
       "id": 29,
       "options": {
@@ -2820,8 +3015,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2836,7 +3030,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 65
+        "y": 72
       },
       "id": 28,
       "options": {

--- a/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json
+++ b/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json
@@ -755,7 +755,7 @@
           "refId": "A"
         }
       ],
-      "title": "Network util - Downloading",
+      "title": "Network util - Download",
       "type": "timeseries"
     },
     {
@@ -855,7 +855,207 @@
           "refId": "A"
         }
       ],
-      "title": "Network util - Uploading",
+      "title": "Network util - Upload",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(node_disk_read_bytes_total{cluster=\"$cluster\"}[5m])) by (instance,nodename,device) > 1024 * 1024",
+          "instant": false,
+          "legendFormat": "{{nodename}}/{{device}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Disk I/O - Read",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(node_disk_written_bytes_total{cluster=\"$cluster\"}[5m])) by (instance,nodename,device) > 1024 * 1024",
+          "instant": false,
+          "legendFormat": "{{nodename}}/{{device}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Disk I/O - Write",
       "type": "timeseries"
     },
     {
@@ -864,7 +1064,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 21
       },
       "id": 11,
       "panels": [],
@@ -938,7 +1138,7 @@
         "h": 4,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 22
       },
       "id": 9,
       "options": {
@@ -1046,7 +1246,7 @@
         "h": 5,
         "w": 6,
         "x": 0,
-        "y": 21
+        "y": 26
       },
       "id": 1,
       "options": {
@@ -1168,7 +1368,7 @@
         "h": 5,
         "w": 6,
         "x": 6,
-        "y": 21
+        "y": 26
       },
       "id": 2,
       "options": {
@@ -1263,7 +1463,7 @@
         "h": 5,
         "w": 6,
         "x": 12,
-        "y": 21
+        "y": 26
       },
       "id": 3,
       "options": {
@@ -1358,7 +1558,7 @@
         "h": 5,
         "w": 6,
         "x": 18,
-        "y": 21
+        "y": 26
       },
       "id": 10,
       "options": {
@@ -1455,7 +1655,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 26
+        "y": 31
       },
       "id": 4,
       "options": {
@@ -1551,7 +1751,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 26
+        "y": 31
       },
       "id": 5,
       "options": {
@@ -1648,7 +1848,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 33
+        "y": 38
       },
       "id": 6,
       "options": {
@@ -1745,7 +1945,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 33
+        "y": 38
       },
       "id": 7,
       "options": {
@@ -1841,7 +2041,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 40
+        "y": 45
       },
       "id": 20,
       "options": {
@@ -1938,7 +2138,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 40
+        "y": 45
       },
       "id": 21,
       "options": {
@@ -1976,7 +2176,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 47
+        "y": 52
       },
       "id": 25,
       "panels": [],
@@ -2021,7 +2221,7 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 48
+        "y": 53
       },
       "id": 17,
       "options": {
@@ -2107,7 +2307,7 @@
         "h": 6,
         "w": 6,
         "x": 6,
-        "y": 48
+        "y": 53
       },
       "id": 18,
       "options": {
@@ -2193,7 +2393,7 @@
         "h": 6,
         "w": 6,
         "x": 12,
-        "y": 48
+        "y": 53
       },
       "id": 19,
       "options": {
@@ -2247,7 +2447,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 54
+        "y": 59
       },
       "id": 24,
       "panels": [],
@@ -2317,7 +2517,7 @@
         "h": 4,
         "w": 24,
         "x": 0,
-        "y": 55
+        "y": 60
       },
       "id": 8,
       "options": {
@@ -2382,7 +2582,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 64
       },
       "id": 26,
       "panels": [],
@@ -2442,7 +2642,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 60
+        "y": 65
       },
       "id": 27,
       "options": {
@@ -2539,7 +2739,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 60
+        "y": 65
       },
       "id": 29,
       "options": {
@@ -2636,7 +2836,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 60
+        "y": 65
       },
       "id": 28,
       "options": {
@@ -2729,7 +2929,7 @@
   "timepicker": {},
   "timezone": "",
   "title": "Performance Troubleshooting",
-  "uid": "f1068daf-16a2-4e52-9a57-1a662092584-v004",
-  "version": 2,
+  "uid": "f1068daf-16a2-4e52-9a57-1a662092584-v005",
+  "version": 1,
   "weekStart": ""
 }

--- a/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json
+++ b/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json
@@ -2240,7 +2240,7 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 55
       },
@@ -2283,7 +2283,104 @@
           "refId": "A"
         }
       ],
-      "title": "Partition count ",
+      "title": "Partition count w-r-t topic",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Shows the no. of consumers in each consumer group",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 55
+      },
+      "id": 29,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(kafka_consumergroup_members{cluster=\"$cluster\"}) by (consumergroup)",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Consumers count  w-r-t consumer group",
       "type": "barchart"
     },
     {
@@ -2337,8 +2434,8 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 16,
         "y": 55
       },
       "id": 28,

--- a/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json
+++ b/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json
@@ -2992,7 +2992,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Shows the consumer group lag averaged across different partitions",
+      "description": "Shows the maximum lag (in message count) faced by a consumer in given (consumergroup,topic). ",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3074,14 +3074,14 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "avg(kafka_consumergroup_lag{cluster=\"$cluster\"}) by (consumergroup,topic)",
+          "expr": "max(clamp_min(kafka_consumergroup_lag{cluster=\"$cluster\"},0)) by (consumergroup,topic)",
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
           "refId": "A"
         }
       ],
-      "title": "Consumer group lag",
+      "title": "Max consumer group lag",
       "type": "barchart"
     }
   ],

--- a/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json
+++ b/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json
@@ -659,12 +659,212 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(node_network_receive_bytes_total{device!~\"cali.*|lo\",cluster=\"$cluster\"}[1m])) by (nodename,instance,device) > 1024 * 1024",
+          "instant": false,
+          "legendFormat": "{{nodename}}/{{device}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Network util - Downloading",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(node_network_transmit_bytes_total{device!~\"cali.*|lo\",cluster=\"$cluster\"}[1m])) by (nodename,instance,device) > 1024 * 1024",
+          "instant": false,
+          "legendFormat": "{{nodename}}/{{device}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Network util - Uploading",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 11
+        "y": 16
       },
       "id": 11,
       "panels": [],
@@ -738,7 +938,7 @@
         "h": 4,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 17
       },
       "id": 9,
       "options": {
@@ -846,7 +1046,7 @@
         "h": 5,
         "w": 6,
         "x": 0,
-        "y": 16
+        "y": 21
       },
       "id": 1,
       "options": {
@@ -968,7 +1168,7 @@
         "h": 5,
         "w": 6,
         "x": 6,
-        "y": 16
+        "y": 21
       },
       "id": 2,
       "options": {
@@ -1063,7 +1263,7 @@
         "h": 5,
         "w": 6,
         "x": 12,
-        "y": 16
+        "y": 21
       },
       "id": 3,
       "options": {
@@ -1158,7 +1358,7 @@
         "h": 5,
         "w": 6,
         "x": 18,
-        "y": 16
+        "y": 21
       },
       "id": 10,
       "options": {
@@ -1255,7 +1455,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 21
+        "y": 26
       },
       "id": 4,
       "options": {
@@ -1351,7 +1551,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 21
+        "y": 26
       },
       "id": 5,
       "options": {
@@ -1448,7 +1648,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 28
+        "y": 33
       },
       "id": 6,
       "options": {
@@ -1545,7 +1745,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 28
+        "y": 33
       },
       "id": 7,
       "options": {
@@ -1641,7 +1841,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 35
+        "y": 40
       },
       "id": 20,
       "options": {
@@ -1738,7 +1938,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 35
+        "y": 40
       },
       "id": 21,
       "options": {
@@ -1776,7 +1976,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 47
       },
       "id": 25,
       "panels": [],
@@ -1821,7 +2021,7 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 43
+        "y": 48
       },
       "id": 17,
       "options": {
@@ -1907,7 +2107,7 @@
         "h": 6,
         "w": 6,
         "x": 6,
-        "y": 43
+        "y": 48
       },
       "id": 18,
       "options": {
@@ -1993,7 +2193,7 @@
         "h": 6,
         "w": 6,
         "x": 12,
-        "y": 43
+        "y": 48
       },
       "id": 19,
       "options": {
@@ -2047,7 +2247,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 49
+        "y": 54
       },
       "id": 24,
       "panels": [],
@@ -2117,7 +2317,7 @@
         "h": 4,
         "w": 24,
         "x": 0,
-        "y": 50
+        "y": 55
       },
       "id": 8,
       "options": {
@@ -2182,7 +2382,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 54
+        "y": 59
       },
       "id": 26,
       "panels": [],
@@ -2242,7 +2442,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 55
+        "y": 60
       },
       "id": 27,
       "options": {
@@ -2339,7 +2539,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 55
+        "y": 60
       },
       "id": 29,
       "options": {
@@ -2436,7 +2636,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 55
+        "y": 60
       },
       "id": 28,
       "options": {
@@ -2529,7 +2729,7 @@
   "timepicker": {},
   "timezone": "",
   "title": "Performance Troubleshooting",
-  "uid": "f1068daf-16a2-4e52-9a57-1a662092584-v003",
-  "version": 1,
+  "uid": "f1068daf-16a2-4e52-9a57-1a662092584-v004",
+  "version": 2,
   "weekStart": ""
 }

--- a/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json
+++ b/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json
@@ -755,7 +755,7 @@
           "refId": "A"
         }
       ],
-      "title": "Network util - Download",
+      "title": "Network I/O - Download",
       "type": "timeseries"
     },
     {
@@ -855,7 +855,7 @@
           "refId": "A"
         }
       ],
-      "title": "Network util - Upload",
+      "title": "Network I/O - Upload",
       "type": "timeseries"
     },
     {
@@ -2699,7 +2699,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2823,7 +2824,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2919,7 +2921,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3015,7 +3018,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",

--- a/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json
+++ b/monitoring/dashboards/mojaloop/dashboard-performance-troubleshooting.json
@@ -12,6 +12,12 @@
   "__elements": {},
   "__requires": [
     {
+      "type": "panel",
+      "id": "barchart",
+      "name": "Bar chart",
+      "version": ""
+    },
+    {
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
@@ -2182,6 +2188,200 @@
       "panels": [],
       "title": "Kafka",
       "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Shows the no. of partitions for each topic",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 55
+      },
+      "id": 27,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(kafka_topic_partitions{cluster=\"$cluster\"}) by (topic)",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Partition count ",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Shows the consumer group lag averaged across different partitions",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 55
+      },
+      "id": 28,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg(kafka_consumergroup_lag{cluster=\"$cluster\"}) by (consumergroup,topic)",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Consumer group lag",
+      "type": "barchart"
     }
   ],
   "refresh": "",


### PR DESCRIPTION
# Description
## New charts 
Following charts have been added to the dashboard
- Kafka: partitions by topic
- Kafka: consumers by consumer group
- Kafka: Lag by topic
- network util by node
- disk I/O rate by node
- network util by container 