### PR TITLE
feat(auto): release candidate for Zambezi v16.1.0

### DIFF
--- a/.changelog/release-v16.1.0.md
+++ b/.changelog/release-v16.1.0.md
@@ -1,0 +1,138 @@
+# Helm Release Notes
+
+Date | Revision | Description
+---------|----------|---------
+2024-07-09 | 0 | Initial draft
+
+## 0. Summary
+
+Enhancements and breaking changes to the [v16.0.0 Release](https://github.com/mojaloop/helm/blob/main/.changelog/release-v16.0.0.md), which includes:
+
+_Release summary points go here..._
+
+## 1. New Features
+* **mojaloop/#3984** update ci, deps and audit ([mojaloop/#135](https://github.com/mojaloop/auth-service/pull/135)), closes [mojaloop/#3984](https://github.com/mojaloop/project/issues/3984)
+* **mojaloop/#109** parameterize switch id ([mojaloop/#109](https://github.com/mojaloop/bulk-api-adapter/pull/109)), closes [mojaloop/#109](https://github.com/mojaloop/project/issues/109)
+* **mojaloop/#: used https.Agent for WSO2 requests in api-svc (** used https.Agent for WSO2 requests in api-svc ([mojaloop/#457](https://github.com/mojaloop/sdk-scheme-adapter/pull/457)), closes [mojaloop/#: used https.Agent for WSO2 requests in api-svc (](https://github.com/mojaloop/project/issues/: used https.Agent for WSO2 requests in api-svc ()
+* **mojaloop/#260** parameterize switch id ([mojaloop/#260](https://github.com/mojaloop/simulator/pull/260)), closes [mojaloop/#260](https://github.com/mojaloop/project/issues/260)
+* **mojaloop/#3984** parameterize switch id ([mojaloop/#94](https://github.com/mojaloop/thirdparty-api-svc/pull/94)), closes [mojaloop/#3984](https://github.com/mojaloop/project/issues/3984)
+* **mojaloop/#103** parameterize switch id ([mojaloop/#103](https://github.com/mojaloop/transaction-requests-service/pull/103)), closes [mojaloop/#103](https://github.com/mojaloop/project/issues/103)
+
+## 2. Bug Fixes
+* **mojaloop/#3829** added jwsSigner defining to PUT /participants callback ([mojaloop/#472](https://github.com/mojaloop/account-lookup-service/pull/472)), closes [mojaloop/#3829](https://github.com/mojaloop/project/issues/3829)
+* **mojaloop/#3750** add timer for party lookup in cache ([mojaloop/#471](https://github.com/mojaloop/sdk-scheme-adapter/pull/471)), closes [mojaloop/#3750](https://github.com/mojaloop/project/issues/3750)
+
+## 3. Application Versions
+
+1. bulk-api-adapter: v17.0.0 ->                     [v17.1.0](https://github.com/mojaloop/bulk-api-adapter/releases/v17.1.0)                     ([Compare](https://github.com/mojaloop/bulk-api-adapter/compare/v17.0.0...v17.1.0))
+2. event-sidecar: v14.0.0 ->                     [v14.0.1](https://github.com/mojaloop/event-sidecar/releases/v14.0.1)                     ([Compare](https://github.com/mojaloop/event-sidecar/compare/v14.0.0...v14.0.1))
+3. ml-testing-toolkit-ui: v15.4.2 ->                     [v15.5.0](https://github.com/mojaloop/ml-testing-toolkit-ui/releases/v15.5.0)                     ([Compare](https://github.com/mojaloop/ml-testing-toolkit-ui/compare/v15.4.2...v15.5.0))
+4. auth-service: v15.0.0 ->                     [v15.1.0](https://github.com/mojaloop/auth-service/releases/v15.1.0)                     ([Compare](https://github.com/mojaloop/auth-service/compare/v15.0.0...v15.1.0))
+5. ml-testing-toolkit: v17.1.1 ->                     [v17.2.3](https://github.com/mojaloop/ml-testing-toolkit/releases/v17.2.3)                     ([Compare](https://github.com/mojaloop/ml-testing-toolkit/compare/v17.1.1...v17.2.3))
+6. transaction-requests-service: v14.1.2 ->                     [v14.2.0](https://github.com/mojaloop/transaction-requests-service/releases/v14.2.0)                     ([Compare](https://github.com/mojaloop/transaction-requests-service/compare/v14.1.2...v14.2.0))
+7. ml-api-adapter: v14.0.5 ->                     [v14.0.7](https://github.com/mojaloop/ml-api-adapter/releases/v14.0.7)                     ([Compare](https://github.com/mojaloop/ml-api-adapter/compare/v14.0.5...v14.0.7))
+8. sdk-scheme-adapter: v23.4.0 ->                     [v23.5.1](https://github.com/mojaloop/sdk-scheme-adapter/releases/v23.5.1)                     ([Compare](https://github.com/mojaloop/sdk-scheme-adapter/compare/v23.4.0...v23.5.1))
+9. thirdparty-api-svc: v14.0.0 ->                     [v15.0.0](https://github.com/mojaloop/thirdparty-api-svc/releases/v15.0.0)                     ([Compare](https://github.com/mojaloop/thirdparty-api-svc/compare/v14.0.0...v15.0.0))
+10. account-lookup-service: v15.2.3 ->                     [v15.3.4](https://github.com/mojaloop/account-lookup-service/releases/v15.3.4)                     ([Compare](https://github.com/mojaloop/account-lookup-service/compare/v15.2.3...v15.3.4))
+11. simulator: v12.1.0 ->                     [v12.2.0](https://github.com/mojaloop/simulator/releases/v12.2.0)                     ([Compare](https://github.com/mojaloop/simulator/compare/v12.1.0...v12.2.0))
+12. central-ledger: v17.6.0 ->                     [v17.6.1](https://github.com/mojaloop/central-ledger/releases/v17.6.1)                     ([Compare](https://github.com/mojaloop/central-ledger/compare/v17.6.0...v17.6.1))
+13. central-event-processor: [v12.1.0](https://github.com/mojaloop/central-event-processor/releases/v12.1.0)
+14. als-oracle-pathfinder: [v12.1.0](https://github.com/mojaloop/als-oracle-pathfinder/releases/v12.1.0)
+15. ml-testing-toolkit-client-lib: [v1.2.2](https://github.com/mojaloop/ml-testing-toolkit-client-lib/releases/v1.2.2)
+16. mojaloop-simulator: [v15.0.0](https://github.com/mojaloop/mojaloop-simulator/releases/v15.0.0)
+17. als-consent-oracle: [v0.2.2](https://github.com/mojaloop/als-consent-oracle/releases/v0.2.2)
+18. quoting-service: [v15.7.0](https://github.com/mojaloop/quoting-service/releases/v15.7.0)
+19. thirdparty-sdk: [v15.1.1](https://github.com/mojaloop/thirdparty-sdk/releases/v15.1.1)
+20. event-stream-processor: [v12.0.0-snapshot.9](https://github.com/mojaloop/event-stream-processor/releases/v12.0.0-snapshot.9)
+21. central-settlement: [v16.0.0](https://github.com/mojaloop/central-settlement/releases/v16.0.0)
+22. email-notifier: [v14.0.0](https://github.com/mojaloop/email-notifier/releases/v14.0.0)
+
+## 4. API Versions
+
+This release supports the following versions of the [Mojaloop family of APIs](https://docs.mojaloop.io/api):
+
+| API         | Supported Versions                                                                                                                                    | Notes |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
+| FSPIOP      | [v1.1](https://docs.mojaloop.io/api/fspiop/v1.1/api-definition.html), [v1.0](https://docs.mojaloop.io/api/fspiop/v1.0/api-definition.html) |       |
+| Settlements | [v2.0](https://docs.mojaloop.io/api/settlement)                                                                                            |       |
+| Admin       | [v1.0](https://docs.mojaloop.io/api/administration/central-ledger-api.html)                                                                |       |
+| Oracle      | [v1.0](https://docs.mojaloop.io/legacy/api/als-oracle-api-specification.html)                                                              |       |
+| Thirdparty  | [v1.0](https://docs.mojaloop.io/api/thirdparty)                                                                                            |       |
+
+## 5. Testing notes
+
+1. This release has been validated against the following Dependency Test Matrix:
+
+    | Dependency | Version |  Notes   |
+    | ---------- | ------- | --- |
+    | Kubernetes | v1.29 | [AWS EKS](https://aws.amazon.com/eks/), [AWS EKS Supported Version Notes](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)  |
+    | containerd  |  v1.6.19  |  |
+    | Nginx Ingress Controller | [helm-ingress-nginx-4.7.0](https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.7.0) / [ingress-controller-v1.8.0](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.8.0) |     |
+    |  Amazon Linux   |  v2   |     |
+    |  MySQL   |  bitnami/mysql:8.0.32-debian-11-r0   |     |
+    |  Kafka   |  bitnami/kafka:3.3.1-debian-11-r1   |     |
+    |  Redis   |  bitnami/redis:7.0.5-debian-11-r7   |     |
+    |  MongoDB   |  bitnami/mongodb:6.0.2-debian-11-r11   |     |
+    |  Testing Toolkit Test Cases   |  [v16.1.0](https://github.com/mojaloop/testing-toolkit-test-cases/releases/tag/v16.1.0)   |     |
+    |  example-mojaloop-backend   |  v15.0.0   |  [README](https://github.com/mojaloop/helm/blob/main/example-mojaloop-backend/README.md)   |
+
+2. It is recommended that all Mojaloop deployments are verified using the [Mojaloop Testing Toolkit](https://docs.mojaloop.io/documentation/mojaloop-technical-overview/ml-testing-toolkit/). More information can be found in the [Mojaloop Deployment Guide](https://docs.mojaloop.io/documentation/deployment-guide).
+
+3. The [testing-toolkit-test-cases](https://github.com/mojaloop/testing-toolkit-test-cases/releases) (See above Dependency Test Matrix for exact version required for this release) Golden Path collections expects:
+    - the Quoting service operating mode to be set quoting-service.config.simple_routing_mode_enabled=true (in helm mojaloop/values.yaml under quoting-service config). If this is incorrectly configured, it will result in several failures in the quoting-service tests (7 expected failures). If this is disabled, ensure that you update the corresponding test-case environment variable parameter **SIMPLE_ROUTING_MODE_ENABLED** ( in helm mojaloop/values.yaml ml-testing-toolkit -> extraEnvironments.hub-k8s-default-environment.json.inputValues) to match.
+    - the **on-us transfers** (in mojaloop/values.yaml "enable_on_us_transfers: false" under centralledger-handler-transfer-prepare -> config and  cl-handler-bulk-transfer-prepare -> config) configuration to be disabled. The test-case environment variable parameter (**ON_US_TRANSFERS_ENABLED** (in helm mojaloop/values.yaml ml-testing-toolkit -> extraEnvironments.hub-k8s-default-environment.json.inputValues), the same name used on postman collections) must similarly match this value.
+
+4. Simulators
+    - We recommend using Testing Toolkit instead of Postman which is better suited for the async nature of the Mojaloop API specification (see above)
+    - [Mojaloop-Simulator](https://github.com/mojaloop/mojaloop-simulator) is enabled by default (six instances used for single transfers usually and three more specific to bulk).
+    - Ensure that correct Postman Scripts are used if you wish to test against the Mojaloop-Simulators:
+        - Setup Mojaloop Hub: [MojaloopHub_Setup](https://github.com/mojaloop/postman/blob/v12.0.0/MojaloopHub_Setup.postman_collection.json)
+        - Setup Mojaloop Simulators for testing : [MojaloopSims_Onboarding](https://github.com/mojaloop/postman/blob/v12.0.0/MojaloopSims_Onboarding.postman_collection.json)
+        - Golden path tests: [Golden_Path_Mojaloop](https://github.com/mojaloop/postman/blob/v12.0.0/Golden_Path_Mojaloop.postman_collection.json)
+    - Legacy Simulators are still required and deployed by default; disabling this will cause issues since there is Account Lookup directory mocking functionality in this service.
+
+5. Thirdparty Testing Toolkit Test Collections are not repeatable. Please refer to the following issue for more information [#2717 - Thirdparty TTK Test-Collection is not repeatable](https://github.com/mojaloop/project/issues/2717). It is possible to manually cleanup persistent data to re-run the test if required.
+
+6. Bulk API Helm Tests
+
+    Refer to the [Testing Deployments](https://github.com/mojaloop/helm/blob/main/README.md#testing-deployments) section in the main README for detailed information on how to enable bulk-api-adapter tests.
+
+7. Thirdparty API Helm Tests
+
+    Refer to [thirdparty/README.md#validating-and-testing-the-3p-api](https://github.com/mojaloop/helm/blob/main/thirdparty/README.md#validating-and-testing-the-3p-api) on how to enabled and execute Thirdparty verification tests.
+
+8. Testing the Bulk functionality including "sdk-scheme-adapter"
+
+    For details regarding deployment and validation of simulators needed for bulk (for adoption provided in sdk-scheme-adapter) refer to [deploying Mojaloop TTK simulators](https://github.com/mojaloop/helm/blob/main/mojaloop-ttk-simulators/README.md).
+
+## 6. Breaking Changes
+
+
+### central-ledger
+  * config/default.json: (https://github.com/mojaloop/central-ledger/blob/4165045e2c8d0cfb15730bd9090eeca6e6bba606/config%2Fdefault.json)
+### bulk-api-adapter
+  * config/default.json: (https://github.com/mojaloop/bulk-api-adapter/blob/6ce22e8fb8d5d9bc1e0d9f7501f04f0abef7bf99/config%2Fdefault.json)
+  * docker/bulk-api-adapter/default.json: (https://github.com/mojaloop/bulk-api-adapter/blob/6ce22e8fb8d5d9bc1e0d9f7501f04f0abef7bf99/docker%2Fbulk-api-adapter%2Fdefault.json)
+### transaction-requests-service
+  * config/default.json: (https://github.com/mojaloop/transaction-requests-service/blob/e8d0289ed82977d4c2ae5ef43933ff3356189f39/config%2Fdefault.json)
+### thirdparty-api-svc
+  * config/default.json: (https://github.com/mojaloop/thirdparty-api-svc/blob/288270cc576ca957f000d519858f7638e7945ffa/config%2Fdefault.json)
+
+## 7. Known Issues
+
+1. [#2119 - Idempotency for duplicate quote request](https://github.com/mojaloop/project/issues/2119)
+2. [#2322 - Helm install failing with with "medium to large" release names](https://github.com/mojaloop/project/issues/2322)
+3. [#2317 - Mojaloop Helm deployments are not compatible when deployed to ARM-arch based hosts](https://github.com/mojaloop/project/issues/2317)
+4. [#2435 - Quoting-Service is incorrectly handling failed responses to FSPs when forwarding requests](https://github.com/mojaloop/project/issues/2435)
+5. Test issues causing instability/intermitant failures on Test Case Results
+    1. [#2717 - Thirdparty TTK Test-Collection is not repeatable](https://github.com/mojaloop/project/issues/2717)
+    2. [#2925 - Helm Test Intermittent failure with 'Generic ID not found](https://github.com/mojaloop/project/issues/2925)
+
+## 8. Contributors
+
+- Organizations: BMGF, InFiTX, MLF
+- Individuals: @TWith2Sugars, @dependabot[bot], @devarsh10, @elnyry-sam-k, @geka-evk, @kalinkrustev, @kleyow, @oderayi, @vijayg10
+
+*Note: companies are in alphabetical order, individuals are in no particular order.*
+
+**Full Changelog**: https://github.com/mojaloop/helm/compare/v16.0.0...v16.1.0

--- a/account-lookup-service/Chart.yaml
+++ b/account-lookup-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 14.11.0
-appVersion: "account-lookup-service: v15.2.3; als-oracle-pathfinder: v12.1.0"
+version: 14.15.0
+appVersion: "account-lookup-service: v15.3.4; als-oracle-pathfinder: v12.1.0"
 description: Account Lookup Service Helm Chart for Mojaloop
 name: account-lookup-service
 maintainers:
@@ -10,11 +10,11 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: account-lookup-service
-    version: ">= 14.6.0"
+    version: ">= 14.8.0"
     repository: "file://./chart-service"
     condition: account-lookup-service.enabled
   - name: account-lookup-service-admin
-    version: ">= 14.6.0"
+    version: ">= 14.8.0"
     repository: "file://./chart-admin"
     condition: account-lookup-service-admin.enabled
   - name: als-oracle-pathfinder

--- a/account-lookup-service/chart-admin/Chart.yaml
+++ b/account-lookup-service/chart-admin/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 14.6.0
-appVersion: v15.2.1
+version: 14.8.0
+appVersion: v15.3.4
 description: A Helm chart for Kubernetes
 name: account-lookup-service-admin
 maintainers:

--- a/account-lookup-service/chart-admin/values.yaml
+++ b/account-lookup-service/chart-admin/values.yaml
@@ -5,7 +5,7 @@
 image:
   registry: docker.io
   repository: mojaloop/account-lookup-service
-  tag: v15.2.3
+  tag: v15.3.4
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -86,7 +86,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.0
+    tag: v14.0.1
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:
@@ -212,19 +212,19 @@ config:
     # Expected properties of `jwsSigningKeySecret` are `name` and `key`.
     jwsSigningKeySecret: null
     jwsSigningKey: null
-# To generate this key:
-# Private:
-# ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key
-# Public:
-# openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub
-# Should look like:
-# -----BEGIN RSA PRIVATE KEY-----
-# MIIJKQIBAAKCAgEAxfqaZivMPd4MpdBHu0jVMf3MSuSdkSMHn+sNJdDQfl+x4R5R
-# ..
-# ..
-# mBynFpdjO0D3PnLKjnBDn1vFAfANOwVpGXCw5mn+484A/SIXYebWruFd03g4
-# -----END RSA PRIVATE KEY-----
-## Tracing Configuration
+  # To generate this key:
+  # Private:
+  # ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key
+  # Public:
+  # openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub
+  # Should look like:
+  # -----BEGIN RSA PRIVATE KEY-----
+  # MIIJKQIBAAKCAgEAxfqaZivMPd4MpdBHu0jVMf3MSuSdkSMHn+sNJdDQfl+x4R5R
+  # ..
+  # ..
+  # mBynFpdjO0D3PnLKjnBDn1vFAfANOwVpGXCw5mn+484A/SIXYebWruFd03g4
+  # -----END RSA PRIVATE KEY-----
+  ## Tracing Configuration
   event_trace_vendor: mojaloop
   event_log_filter: 'audit:*, log:warn, log:error'
   # If set to true, only the metadata object from the event will be printed.
@@ -328,14 +328,14 @@ service:
   ## clusterIP: None
   ##
   clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
-## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
-##
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+  ##
   loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
-## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-## e.g:
-## loadBalancerSourceRanges:
-##   - 10.10.10.0/24
-##
+  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ## e.g:
+  ## loadBalancerSourceRanges:
+  ##   - 10.10.10.0/24
+  ##
   loadBalancerSourceRanges: []
   ## @param service.externalTrafficPolicy %%MAIN_CONTAINER_NAME%% service external traffic policy
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
@@ -363,7 +363,7 @@ ingress:
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
   apiVersion: null ## @param ingress.hostname Default host for the ingress record
-##
+  ##
   hostname: account-lookup-service-admin.local
   ## @param servicePort : port for the service
   ##
@@ -375,12 +375,12 @@ ingress:
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
   annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
-## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
-## You can:
-##   - Use the `ingress.secrets` parameter to create this TLS secret
-##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
-##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
-##
+  ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+  ## You can:
+  ##   - Use the `ingress.secrets` parameter to create this TLS secret
+  ##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
+  ##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
+  ##
   tls: false
   ## @param ingress.certManager Add the corresponding annotations for cert-manager integration
   ##

--- a/account-lookup-service/chart-service/Chart.yaml
+++ b/account-lookup-service/chart-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 14.6.0
-appVersion: v15.2.1
+version: 14.8.0
+appVersion: v15.3.4
 description: A Helm chart for Kubernetes
 name: account-lookup-service
 maintainers:

--- a/account-lookup-service/chart-service/values.yaml
+++ b/account-lookup-service/chart-service/values.yaml
@@ -5,7 +5,7 @@
 image:
   registry: docker.io
   repository: mojaloop/account-lookup-service
-  tag: v15.2.3
+  tag: v15.3.4
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -88,7 +88,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.0
+    tag: v14.0.1
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:
@@ -214,19 +214,19 @@ config:
     # Expected properties of `jwsSigningKeySecret` are `name` and `key`.
     jwsSigningKeySecret: null
     jwsSigningKey: null
-# To generate this key:
-# Private:
-# ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key
-# Public:
-# openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub
-# Should look like:
-# -----BEGIN RSA PRIVATE KEY-----
-# MIIJKQIBAAKCAgEAxfqaZivMPd4MpdBHu0jVMf3MSuSdkSMHn+sNJdDQfl+x4R5R
-# ..
-# ..
-# mBynFpdjO0D3PnLKjnBDn1vFAfANOwVpGXCw5mn+484A/SIXYebWruFd03g4
-# -----END RSA PRIVATE KEY-----
-# Thirdparty API Config
+  # To generate this key:
+  # Private:
+  # ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key
+  # Public:
+  # openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub
+  # Should look like:
+  # -----BEGIN RSA PRIVATE KEY-----
+  # MIIJKQIBAAKCAgEAxfqaZivMPd4MpdBHu0jVMf3MSuSdkSMHn+sNJdDQfl+x4R5R
+  # ..
+  # ..
+  # mBynFpdjO0D3PnLKjnBDn1vFAfANOwVpGXCw5mn+484A/SIXYebWruFd03g4
+  # -----END RSA PRIVATE KEY-----
+  # Thirdparty API Config
   featureEnableExtendedPartyIdType: false
   ## Tracing Configuration
   event_trace_vendor: mojaloop
@@ -307,14 +307,14 @@ service:
   ## clusterIP: None
   ##
   clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
-## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
-##
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+  ##
   loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
-## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-## e.g:
-## loadBalancerSourceRanges:
-##   - 10.10.10.0/24
-##
+  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ## e.g:
+  ## loadBalancerSourceRanges:
+  ##   - 10.10.10.0/24
+  ##
   loadBalancerSourceRanges: []
   ## @param service.externalTrafficPolicy %%MAIN_CONTAINER_NAME%% service external traffic policy
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
@@ -342,7 +342,7 @@ ingress:
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
   apiVersion: null ## @param ingress.hostname Default host for the ingress record
-##
+  ##
   hostname: account-lookup-service.local
   ## @param servicePort : port for the service
   ##
@@ -354,12 +354,12 @@ ingress:
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
   annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
-## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
-## You can:
-##   - Use the `ingress.secrets` parameter to create this TLS secret
-##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
-##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
-##
+  ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+  ## You can:
+  ##   - Use the `ingress.secrets` parameter to create this TLS secret
+  ##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
+  ##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
+  ##
   tls: false
   ## @param ingress.certManager Add the corresponding annotations for cert-manager integration
   ##

--- a/account-lookup-service/values.yaml
+++ b/account-lookup-service/values.yaml
@@ -7,7 +7,7 @@ account-lookup-service:
   image:
     registry: docker.io
     repository: mojaloop/account-lookup-service
-    tag: v15.2.3
+    tag: v15.3.4
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -328,7 +328,7 @@ account-lookup-service-admin:
   image:
     registry: docker.io
     repository: mojaloop/account-lookup-service
-    tag: v15.2.3
+    tag: v15.3.4
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bulk-api-adapter/Chart.yaml
+++ b/bulk-api-adapter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: bulk-api-adapter Helm chart for Kubernetes
 name: bulk-api-adapter
-version: 14.6.0
-appVersion: v17.0.0
+version: 14.9.0
+appVersion: v17.1.0
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -16,11 +16,11 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: bulk-api-adapter-service
-    version: ">= 14.4.0"
+    version: ">= 14.5.0"
     repository: "file://./chart-service"
     condition: bulk-api-adapter-service.enabled
   - name: bulk-api-adapter-handler-notification
-    version: ">= 14.4.0"
+    version: ">= 14.5.0"
     repository: "file://./chart-handler-notification"
     condition: bulk-api-adapter-handler-notification.enabled
   - name: common

--- a/bulk-api-adapter/chart-handler-notification/Chart.yaml
+++ b/bulk-api-adapter/chart-handler-notification/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: bulk-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: bulk-api-adapter-handler-notification
-version: 14.4.0
-appVersion: v17.0.0
+version: 14.5.0
+appVersion: v17.1.0
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/chart-handler-notification/values.yaml
+++ b/bulk-api-adapter/chart-handler-notification/values.yaml
@@ -5,7 +5,7 @@
 image:
   registry: docker.io
   repository: mojaloop/bulk-api-adapter
-  tag: v17.0.0
+  tag: v17.1.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -31,7 +31,7 @@ diagnosticMode:
   enabled: false
   ## @param diagnosticMode.command Command to override all containers in the deployment
   ##
-  command: 
+  command:
     - node
     - src/handlers/index.js
     - handler
@@ -40,7 +40,6 @@ diagnosticMode:
   ##
   args:
     - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-  
   ## @param diagnosticMode.debug config to override all debug information
   ##
   debug:
@@ -151,19 +150,18 @@ config:
     # Expected properties of `jwsSigningKeySecret` are `name` and `key`.
     jwsSigningKeySecret: null
     jwsSigningKey: null
-      # To generate this key:
-      # Private:
-      # ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key
-      # Public:
-      # openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub
-      # Should look like:
-      # -----BEGIN RSA PRIVATE KEY-----
-      # MIIJKQIBAAKCAgEAxfqaZivMPd4MpdBHu0jVMf3MSuSdkSMHn+sNJdDQfl+x4R5R
-      # ..
-      # ..
-      # mBynFpdjO0D3PnLKjnBDn1vFAfANOwVpGXCw5mn+484A/SIXYebWruFd03g4
-      # -----END RSA PRIVATE KEY-----
-
+    # To generate this key:
+    # Private:
+    # ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key
+    # Public:
+    # openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub
+    # Should look like:
+    # -----BEGIN RSA PRIVATE KEY-----
+    # MIIJKQIBAAKCAgEAxfqaZivMPd4MpdBHu0jVMf3MSuSdkSMHn+sNJdDQfl+x4R5R
+    # ..
+    # ..
+    # mBynFpdjO0D3PnLKjnBDn1vFAfANOwVpGXCw5mn+484A/SIXYebWruFd03g4
+    # -----END RSA PRIVATE KEY-----
 ## @param initContainers Add additional init containers to the %%MAIN_CONTAINER_NAME%% pod(s)
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 ## e.g:
@@ -250,17 +248,15 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP:
-  ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
-  ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
-  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-  ## e.g:
-  ## loadBalancerSourceRanges:
-  ##   - 10.10.10.0/24
-  ##
+  clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+##
+  loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+## e.g:
+## loadBalancerSourceRanges:
+##   - 10.10.10.0/24
+##
   loadBalancerSourceRanges: []
   ## @param service.externalTrafficPolicy %%MAIN_CONTAINER_NAME%% service external traffic policy
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
@@ -288,9 +284,8 @@ ingress:
   pathType: ImplementationSpecific
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
-  apiVersion:
-  ## @param ingress.hostname Default host for the ingress record
-  ##
+  apiVersion: null ## @param ingress.hostname Default host for the ingress record
+##
   hostname: bulk-api-adapter-notification.local
   ## @param servicePort : port for the service
   ##
@@ -301,14 +296,13 @@ ingress:
   ## @param ingress.annotations Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
-  annotations:
-  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
-  ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
-  ## You can:
-  ##   - Use the `ingress.secrets` parameter to create this TLS secret
-  ##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
-  ##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
-  ##
+  annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+## You can:
+##   - Use the `ingress.secrets` parameter to create this TLS secret
+##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
+##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
+##
   tls: false
   ## @param ingress.certManager Add the corresponding annotations for cert-manager integration
   ##
@@ -322,12 +316,11 @@ ingress:
   ##   - name: transfer-api-svc.local
   ##     path: /
   ##
-  extraHosts:
-  extraPaths:
-  extraTls:
-  secrets:
+  extraHosts: null
+  extraPaths: null
+  extraTls: null
+  secrets: null
   className: "nginx"
-
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/bulk-api-adapter/chart-service/Chart.yaml
+++ b/bulk-api-adapter/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: bulk-api-adapter API component Helm chart for Kubernetes
 name: bulk-api-adapter-service
-version: 14.4.0
-appVersion: v17.0.0
+version: 14.5.0
+appVersion: v17.1.0
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-api-adapter/chart-service/values.yaml
+++ b/bulk-api-adapter/chart-service/values.yaml
@@ -5,7 +5,7 @@
 image:
   registry: docker.io
   repository: mojaloop/bulk-api-adapter
-  tag: v17.0.0
+  tag: v17.1.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -31,14 +31,13 @@ diagnosticMode:
   enabled: false
   ## @param diagnosticMode.command Command to override all containers in the deployment
   ##
-  command: 
+  command:
     - node
     - src/api/index.js
   ## @param diagnosticMode.args Args to override all containers in the deployment
   ##
   args:
     - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-  
   ## @param diagnosticMode.debug config to override all debug information
   ##
   debug:
@@ -227,17 +226,15 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP:
-  ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
-  ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
-  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-  ## e.g:
-  ## loadBalancerSourceRanges:
-  ##   - 10.10.10.0/24
-  ##
+  clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+##
+  loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+## e.g:
+## loadBalancerSourceRanges:
+##   - 10.10.10.0/24
+##
   loadBalancerSourceRanges: []
   ## @param service.externalTrafficPolicy %%MAIN_CONTAINER_NAME%% service external traffic policy
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
@@ -265,9 +262,8 @@ ingress:
   pathType: ImplementationSpecific
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
-  apiVersion:
-  ## @param ingress.hostname Default host for the ingress record
-  ##
+  apiVersion: null ## @param ingress.hostname Default host for the ingress record
+##
   hostname: bulk-api-adapter.local
   ## @param servicePort : port for the service
   ##
@@ -278,14 +274,13 @@ ingress:
   ## @param ingress.annotations Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
-  annotations:
-  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
-  ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
-  ## You can:
-  ##   - Use the `ingress.secrets` parameter to create this TLS secret
-  ##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
-  ##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
-  ##
+  annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+## You can:
+##   - Use the `ingress.secrets` parameter to create this TLS secret
+##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
+##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
+##
   tls: false
   ## @param ingress.certManager Add the corresponding annotations for cert-manager integration
   ##
@@ -299,12 +294,11 @@ ingress:
   ##   - name: transfer-api-svc.local
   ##     path: /
   ##
-  extraHosts:
-  extraPaths:
-  extraTls:
-  secrets:
+  extraHosts: null
+  extraPaths: null
+  extraTls: null
+  secrets: null
   className: "nginx"
-
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/bulk-api-adapter/values.yaml
+++ b/bulk-api-adapter/values.yaml
@@ -13,7 +13,7 @@ bulk-api-adapter-service:
   image:
     registry: docker.io
     repository: mojaloop/bulk-api-adapter
-    tag: v17.0.0
+    tag: v17.1.0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -39,14 +39,13 @@ bulk-api-adapter-service:
     enabled: false
     ## @param diagnosticMode.command Command to override all containers in the deployment
     ##
-    command: 
+    command:
       - node
       - src/api/index.js
     ## @param diagnosticMode.args Args to override all containers in the deployment
     ##
     args:
       - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-    
     ## @param diagnosticMode.debug config to override all debug information
     ##
     debug:
@@ -230,18 +229,15 @@ bulk-api-adapter-service:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -274,8 +270,7 @@ bulk-api-adapter-service:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: bulk-api-adapter.local
     ## @param servicePort : port for the service
@@ -287,8 +282,7 @@ bulk-api-adapter-service:
     ## @param ingress.annotations Additional custom annotations for the ingress record
     ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
     ##
-    annotations:
-    ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
     ## You can:
     ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -308,12 +302,11 @@ bulk-api-adapter-service:
     ##   - name: transfer-api-svc.local
     ##     path: /
     ##
-    extraHosts:
-    extraPaths:
-    extraTls:
-    secrets:
+    extraHosts: null
+    extraPaths: null
+    extraTls: null
+    secrets: null
     className: "nginx"
-
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -335,7 +328,7 @@ bulk-api-adapter-handler-notification:
   image:
     registry: docker.io
     repository: mojaloop/bulk-api-adapter
-    tag: v17.0.0
+    tag: v17.1.0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -361,7 +354,7 @@ bulk-api-adapter-handler-notification:
     enabled: false
     ## @param diagnosticMode.command Command to override all containers in the deployment
     ##
-    command: 
+    command:
       - node
       - src/handlers/index.js
       - handler
@@ -370,7 +363,6 @@ bulk-api-adapter-handler-notification:
     ##
     args:
       - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-    
     ## @param diagnosticMode.debug config to override all debug information
     ##
     debug:
@@ -481,19 +473,18 @@ bulk-api-adapter-handler-notification:
       # Expected properties of `jwsSigningKeySecret` are `name` and `key`.
       jwsSigningKeySecret: null
       jwsSigningKey: null
-        # To generate this key:
-        # Private:
-        # ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key
-        # Public:
-        # openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub
-        # Should look like:
-        # -----BEGIN RSA PRIVATE KEY-----
-        # MIIJKQIBAAKCAgEAxfqaZivMPd4MpdBHu0jVMf3MSuSdkSMHn+sNJdDQfl+x4R5R
-        # ..
-        # ..
-        # mBynFpdjO0D3PnLKjnBDn1vFAfANOwVpGXCw5mn+484A/SIXYebWruFd03g4
-        # -----END RSA PRIVATE KEY-----
-
+      # To generate this key:
+      # Private:
+      # ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key
+      # Public:
+      # openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub
+      # Should look like:
+      # -----BEGIN RSA PRIVATE KEY-----
+      # MIIJKQIBAAKCAgEAxfqaZivMPd4MpdBHu0jVMf3MSuSdkSMHn+sNJdDQfl+x4R5R
+      # ..
+      # ..
+      # mBynFpdjO0D3PnLKjnBDn1vFAfANOwVpGXCw5mn+484A/SIXYebWruFd03g4
+      # -----END RSA PRIVATE KEY-----
   ## @param initContainers Add additional init containers to the %%MAIN_CONTAINER_NAME%% pod(s)
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
   ## e.g:
@@ -575,18 +566,15 @@ bulk-api-adapter-handler-notification:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -619,8 +607,7 @@ bulk-api-adapter-handler-notification:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: bulk-api-adapter-notification.local
     ## @param servicePort : port for the service
@@ -632,8 +619,7 @@ bulk-api-adapter-handler-notification:
     ## @param ingress.annotations Additional custom annotations for the ingress record
     ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
     ##
-    annotations:
-    ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
     ## You can:
     ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -653,12 +639,11 @@ bulk-api-adapter-handler-notification:
     ##   - name: transfer-api-svc.local
     ##     path: /
     ##
-    extraHosts:
-    extraPaths:
-    extraTls:
-    secrets:
+    extraHosts: null
+    extraPaths: null
+    extraTls: null
+    secrets: null
     className: "nginx"
-
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/bulk-centralledger/Chart.yaml
+++ b/bulk-centralledger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Bulk Services Helm chart for Kubernetes
 name: bulk-centralledger
-version: 14.8.0
-appVersion: v17.6.1
+version: 14.15.0
+appVersion: v17.7.8
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -16,15 +16,15 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: cl-handler-bulk-transfer-prepare
-    version: ">= 14.5.0"
+    version: ">= 14.6.0"
     repository: "file://./chart-handler-bulk-transfer-prepare"
     condition: cl-handler-bulk-transfer-prepare.enabled
   - name: cl-handler-bulk-transfer-fulfil
-    version: ">= 14.5.0"
+    version: ">= 14.6.0"
     repository: "file://./chart-handler-bulk-transfer-fulfil"
     condition: cl-handler-bulk-transfer-fulfil.enabled
   - name: cl-handler-bulk-transfer-processing
-    version: ">= 14.5.0"
+    version: ">= 14.6.0"
     repository: "file://./chart-handler-bulk-transfer-processing"
     condition: cl-handler-bulk-transfer-processing.enabled
   - name: cl-handler-bulk-transfer-get

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Bulk Transfer Fulfil Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-fulfil
-version: 14.5.0
-appVersion: v17.6.1
+version: 14.6.0
+appVersion: v17.7.8
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v17.6.1
+  tag: v17.7.8
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -289,17 +289,15 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP:
-  ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
-  ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
-  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-  ## e.g:
-  ## loadBalancerSourceRanges:
-  ##   - 10.10.10.0/24
-  ##
+  clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+##
+  loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+## e.g:
+## loadBalancerSourceRanges:
+##   - 10.10.10.0/24
+##
   loadBalancerSourceRanges: []
   ## @param service.externalTrafficPolicy %%MAIN_CONTAINER_NAME%% service external traffic policy
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
@@ -327,9 +325,8 @@ ingress:
   pathType: ImplementationSpecific
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
-  apiVersion:
-  ## @param ingress.hostname Default host for the ingress record
-  ##
+  apiVersion: null ## @param ingress.hostname Default host for the ingress record
+##
   hostname: central-ledger-transfer-bulkfulfil.local
   ## @param servicePort : port for the service
   ##
@@ -340,14 +337,13 @@ ingress:
   ## @param ingress.annotations Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
-  annotations:
-  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
-  ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
-  ## You can:
-  ##   - Use the `ingress.secrets` parameter to create this TLS secret
-  ##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
-  ##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
-  ##
+  annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+## You can:
+##   - Use the `ingress.secrets` parameter to create this TLS secret
+##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
+##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
+##
   tls: false
   ## @param ingress.certManager Add the corresponding annotations for cert-manager integration
   ##
@@ -361,12 +357,11 @@ ingress:
   ##   - name: transfer-api-svc.local
   ##     path: /
   ##
-  extraHosts:
-  extraPaths:
-  extraTls:
-  secrets:
+  extraHosts: null
+  extraPaths: null
+  extraTls: null
+  secrets: null
   className: "nginx"
-
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/bulk-centralledger/chart-handler-bulk-transfer-get/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-get/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Bulk Transfer Get Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-get
-version: 14.5.0
-appVersion: v17.6.1
+version: 14.6.0
+appVersion: v17.7.8
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-get/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-get/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v17.6.1
+  tag: v17.7.8
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -289,17 +289,15 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP:
-  ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
-  ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
-  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-  ## e.g:
-  ## loadBalancerSourceRanges:
-  ##   - 10.10.10.0/24
-  ##
+  clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+##
+  loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+## e.g:
+## loadBalancerSourceRanges:
+##   - 10.10.10.0/24
+##
   loadBalancerSourceRanges: []
   ## @param service.externalTrafficPolicy %%MAIN_CONTAINER_NAME%% service external traffic policy
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
@@ -327,9 +325,8 @@ ingress:
   pathType: ImplementationSpecific
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
-  apiVersion:
-  ## @param ingress.hostname Default host for the ingress record
-  ##
+  apiVersion: null ## @param ingress.hostname Default host for the ingress record
+##
   hostname: central-ledger-transfer-bulkget.local
   ## @param servicePort : port for the service
   ##
@@ -340,14 +337,13 @@ ingress:
   ## @param ingress.annotations Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
-  annotations:
-  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
-  ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
-  ## You can:
-  ##   - Use the `ingress.secrets` parameter to create this TLS secret
-  ##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
-  ##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
-  ##
+  annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+## You can:
+##   - Use the `ingress.secrets` parameter to create this TLS secret
+##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
+##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
+##
   tls: false
   ## @param ingress.certManager Add the corresponding annotations for cert-manager integration
   ##
@@ -361,12 +357,11 @@ ingress:
   ##   - name: transfer-api-svc.local
   ##     path: /
   ##
-  extraHosts:
-  extraPaths:
-  extraTls:
-  secrets:
+  extraHosts: null
+  extraPaths: null
+  extraTls: null
+  secrets: null
   className: "nginx"
-
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Bulk Transfer Prepare Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-prepare
-version: 14.5.0
-appVersion: v17.6.1
+version: 14.6.0
+appVersion: v17.7.8
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v17.6.1
+  tag: v17.7.8
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -292,17 +292,15 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP:
-  ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
-  ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
-  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-  ## e.g:
-  ## loadBalancerSourceRanges:
-  ##   - 10.10.10.0/24
-  ##
+  clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+##
+  loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+## e.g:
+## loadBalancerSourceRanges:
+##   - 10.10.10.0/24
+##
   loadBalancerSourceRanges: []
   ## @param service.externalTrafficPolicy %%MAIN_CONTAINER_NAME%% service external traffic policy
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
@@ -330,9 +328,8 @@ ingress:
   pathType: ImplementationSpecific
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
-  apiVersion:
-  ## @param ingress.hostname Default host for the ingress record
-  ##
+  apiVersion: null ## @param ingress.hostname Default host for the ingress record
+##
   hostname: central-ledger-transfer-bulkprepare.local
   ## @param servicePort : port for the service
   ##
@@ -343,14 +340,13 @@ ingress:
   ## @param ingress.annotations Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
-  annotations:
-  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
-  ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
-  ## You can:
-  ##   - Use the `ingress.secrets` parameter to create this TLS secret
-  ##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
-  ##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
-  ##
+  annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+## You can:
+##   - Use the `ingress.secrets` parameter to create this TLS secret
+##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
+##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
+##
   tls: false
   ## @param ingress.certManager Add the corresponding annotations for cert-manager integration
   ##
@@ -364,12 +360,11 @@ ingress:
   ##   - name: transfer-api-svc.local
   ##     path: /
   ##
-  extraHosts:
-  extraPaths:
-  extraTls:
-  secrets:
+  extraHosts: null
+  extraPaths: null
+  extraTls: null
+  secrets: null
   className: "nginx"
-
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Bulk Transfer Processing Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-processing
-version: 14.5.0
-appVersion: v17.6.1
+version: 14.6.0
+appVersion: v17.7.8
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v17.6.1
+  tag: v17.7.8
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -289,17 +289,15 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP:
-  ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
-  ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
-  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-  ## e.g:
-  ## loadBalancerSourceRanges:
-  ##   - 10.10.10.0/24
-  ##
+  clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+##
+  loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+## e.g:
+## loadBalancerSourceRanges:
+##   - 10.10.10.0/24
+##
   loadBalancerSourceRanges: []
   ## @param service.externalTrafficPolicy %%MAIN_CONTAINER_NAME%% service external traffic policy
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
@@ -327,9 +325,8 @@ ingress:
   pathType: ImplementationSpecific
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
-  apiVersion:
-  ## @param ingress.hostname Default host for the ingress record
-  ##
+  apiVersion: null ## @param ingress.hostname Default host for the ingress record
+##
   hostname: central-ledger-transfer-bulkprocessing.local
   ## @param servicePort : port for the service
   ##
@@ -340,14 +337,13 @@ ingress:
   ## @param ingress.annotations Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
-  annotations:
-  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
-  ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
-  ## You can:
-  ##   - Use the `ingress.secrets` parameter to create this TLS secret
-  ##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
-  ##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
-  ##
+  annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+## You can:
+##   - Use the `ingress.secrets` parameter to create this TLS secret
+##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
+##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
+##
   tls: false
   ## @param ingress.certManager Add the corresponding annotations for cert-manager integration
   ##
@@ -361,12 +357,11 @@ ingress:
   ##   - name: transfer-api-svc.local
   ##     path: /
   ##
-  extraHosts:
-  extraPaths:
-  extraTls:
-  secrets:
+  extraHosts: null
+  extraPaths: null
+  extraTls: null
+  secrets: null
   className: "nginx"
-
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/bulk-centralledger/values.yaml
+++ b/bulk-centralledger/values.yaml
@@ -13,7 +13,7 @@ cl-handler-bulk-transfer-prepare:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v17.6.1
+    tag: v17.7.8
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -291,18 +291,15 @@ cl-handler-bulk-transfer-prepare:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -335,8 +332,7 @@ cl-handler-bulk-transfer-prepare:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: central-ledger-transfer-bulkprepare.local
     ## @param servicePort : port for the service
@@ -348,8 +344,7 @@ cl-handler-bulk-transfer-prepare:
     ## @param ingress.annotations Additional custom annotations for the ingress record
     ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
     ##
-    annotations:
-    ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
     ## You can:
     ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -369,12 +364,11 @@ cl-handler-bulk-transfer-prepare:
     ##   - name: transfer-api-svc.local
     ##     path: /
     ##
-    extraHosts:
-    extraPaths:
-    extraTls:
-    secrets:
+    extraHosts: null
+    extraPaths: null
+    extraTls: null
+    secrets: null
     className: "nginx"
-
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -396,7 +390,7 @@ cl-handler-bulk-transfer-fulfil:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v17.6.1
+    tag: v17.7.8
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -662,18 +656,15 @@ cl-handler-bulk-transfer-fulfil:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -706,8 +697,7 @@ cl-handler-bulk-transfer-fulfil:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: central-ledger-transfer-bulkfulfil.local
     ## @param servicePort : port for the service
@@ -719,8 +709,7 @@ cl-handler-bulk-transfer-fulfil:
     ## @param ingress.annotations Additional custom annotations for the ingress record
     ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
     ##
-    annotations:
-    ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
     ## You can:
     ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -740,12 +729,11 @@ cl-handler-bulk-transfer-fulfil:
     ##   - name: transfer-api-svc.local
     ##     path: /
     ##
-    extraHosts:
-    extraPaths:
-    extraTls:
-    secrets:
+    extraHosts: null
+    extraPaths: null
+    extraTls: null
+    secrets: null
     className: "nginx"
-
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -767,7 +755,7 @@ cl-handler-bulk-transfer-processing:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v17.6.1
+    tag: v17.7.8
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1042,18 +1030,15 @@ cl-handler-bulk-transfer-processing:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -1086,8 +1071,7 @@ cl-handler-bulk-transfer-processing:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: central-ledger-transfer-bulkprocessing.local
     ## @param servicePort : port for the service
@@ -1099,8 +1083,7 @@ cl-handler-bulk-transfer-processing:
     ## @param ingress.annotations Additional custom annotations for the ingress record
     ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
     ##
-    annotations:
-    ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
     ## You can:
     ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -1120,12 +1103,11 @@ cl-handler-bulk-transfer-processing:
     ##   - name: transfer-api-svc.local
     ##     path: /
     ##
-    extraHosts:
-    extraPaths:
-    extraTls:
-    secrets:
+    extraHosts: null
+    extraPaths: null
+    extraTls: null
+    secrets: null
     className: "nginx"
-
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -1147,7 +1129,7 @@ cl-handler-bulk-transfer-get:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v17.6.1
+    tag: v17.7.8
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1422,18 +1404,15 @@ cl-handler-bulk-transfer-get:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -1466,8 +1445,7 @@ cl-handler-bulk-transfer-get:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: central-ledger-transfer-bulkget.local
     ## @param servicePort : port for the service
@@ -1479,8 +1457,7 @@ cl-handler-bulk-transfer-get:
     ## @param ingress.annotations Additional custom annotations for the ingress record
     ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
     ##
-    annotations:
-    ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
     ## You can:
     ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -1500,12 +1477,11 @@ cl-handler-bulk-transfer-get:
     ##   - name: transfer-api-svc.local
     ##     path: /
     ##
-    extraHosts:
-    extraPaths:
-    extraTls:
-    secrets:
+    extraHosts: null
+    extraPaths: null
+    extraTls: null
+    secrets: null
     className: "nginx"
-
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/centralledger/Chart.yaml
+++ b/centralledger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Helm chart for Kubernetes
 name: centralledger
-version: 14.16.0
-appVersion: v17.6.1
+version: 14.37.0
+appVersion: v17.7.8
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -16,31 +16,31 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: centralledger-service
-    version: ">= 14.5.0"
+    version: ">= 14.7.0"
     repository: "file://./chart-service"
     condition: centralledger-service.enabled
   - name: centralledger-handler-transfer-prepare
-    version: ">= 14.5.0"
+    version: ">= 14.7.0"
     repository: "file://./chart-handler-transfer-prepare"
     condition: centralledger-handler-transfer-prepare.enabled
   - name: centralledger-handler-transfer-position
-    version: ">= 14.5.0"
+    version: ">= 14.7.0"
     repository: "file://./chart-handler-transfer-position"
     condition: centralledger-handler-transfer-position.enabled
   - name: centralledger-handler-transfer-position-batch
-    version: ">= 15.5.0"
+    version: ">= 14.7.0"
     repository: "file://./chart-handler-transfer-position-batch"
     condition: centralledger-handler-transfer-position-batch.enabled
   - name: centralledger-handler-transfer-get
-    version: ">= 14.5.0"
+    version: ">= 14.7.0"
     repository: "file://./chart-handler-transfer-get"
     condition: centralledger-handler-transfer-get.enabled
   - name: centralledger-handler-transfer-fulfil
-    version: ">= 14.5.0"
+    version: ">= 14.7.0"
     repository: "file://./chart-handler-transfer-fulfil"
     condition: centralledger-handler-transfer-fulfil.enabled
   - name: centralledger-handler-timeout
-    version: ">= 14.5.0"
+    version: ">= 14.7.0"
     repository: "file://./chart-handler-timeout"
     condition: centralledger-handler-timeout.enabled
   - name: centralledger-handler-admin-transfer

--- a/centralledger/chart-handler-admin-transfer/Chart.yaml
+++ b/centralledger/chart-handler-admin-transfer/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-admin-transfer
-version: 14.5.0
-appVersion: v17.6.1
+version: 14.7.0
+appVersion: v17.7.8
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-admin-transfer/values.yaml
+++ b/centralledger/chart-handler-admin-transfer/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v17.6.1
+  tag: v17.7.8
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -90,7 +90,7 @@ sidecar:
   enabled: false
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.0
+    tag: v14.0.1
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:
@@ -301,12 +301,10 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP:
-  ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+  clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
   ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+  loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
   ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
   ## e.g:
   ## loadBalancerSourceRanges:
@@ -339,8 +337,7 @@ ingress:
   pathType: ImplementationSpecific
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
-  apiVersion:
-  ## @param ingress.hostname Default host for the ingress record
+  apiVersion: null ## @param ingress.hostname Default host for the ingress record
   ##
   hostname: central-ledger-transfer-prepare.local
   ## @param servicePort : port for the service
@@ -352,8 +349,7 @@ ingress:
   ## @param ingress.annotations Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
-  annotations:
-  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+  annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
   ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
   ## You can:
   ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -373,12 +369,11 @@ ingress:
   ##   - name: transfer-api-svc.local
   ##     path: /
   ##
-  extraHosts:
-  extraPaths:
-  extraTls:
-  secrets:
+  extraHosts: null
+  extraPaths: null
+  extraTls: null
+  secrets: null
   className: "nginx"
-
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/centralledger/chart-handler-timeout/Chart.yaml
+++ b/centralledger/chart-handler-timeout/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Timeout Handler Helm chart for Kubernetes
 name: centralledger-handler-timeout
-version: 14.5.0
-appVersion: v17.6.1
+version: 14.7.0
+appVersion: v17.7.8
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-timeout/values.yaml
+++ b/centralledger/chart-handler-timeout/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v17.6.1
+  tag: v17.7.8
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -90,7 +90,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.0
+    tag: v14.0.1
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:
@@ -114,30 +114,24 @@ sidecar:
     event_log_metadata_only: true
     log_level: info
     log_filter: 'error, warn, info'
-
-       ## metric configuration for prometheus instrumentation
-metrics:
-       ## flag to enable/disable the metrics end-points
+    ## metric configuration for prometheus instrumentation
+metrics: ## flag to enable/disable the metrics end-points
   enabled: false
   config:
     timeout: 5000
     prefix: moja_
     defaultLabels:
       serviceName: central-handler-timeout
-
-config:
-       ## Forensic Logging sidecar
+config: ## Forensic Logging sidecar
   # this is for Forensic Logging Sidecar
   forensicloggingsidecar_disabled: true
   forensicloggingsidecar_host: forensicloggingsidecar-ledger
   forensicloggingsidecar_port: 5678
-
-       ## Error handling Configuration
+  ## Error handling Configuration
   error_handling:
     include_cause_extension: false
     truncate_extensions: true
-
-       ## DB Configuration
+    ## DB Configuration
   # db_type can either be 'postgres' or 'mysql'. Ensure the correct DB is enabled and configured below: postgresql.enabled or mysql.enabled
   db_type: 'mysql'
   # db_driver can either be 'pg' or 'mysql'. Ensure the correct corresponding db_type above has been set.
@@ -165,18 +159,15 @@ config:
   db_reap_interval_millis: 1000
   db_create_retry_interval_millis: 200
   db_debug: false
-
-       ## Hub Configuration
+  ## Hub Configuration
   hub_participant:
     id: 1
     name: Hub
-
-       ## Timeout Configuration
+    ## Timeout Configuration
   timeout:
     expiration: '*/15 * * * * *'
     timezone: UTC
-
-       ## MongoDB Configuration for Object Store
+    ## MongoDB Configuration for Object Store
   objstore_disabled: true
   mongo_host: 'cep-mongodb'
   mongo_port: 27017
@@ -192,19 +183,16 @@ config:
   #   name: cep-mongodb
   #   key: mongodb-passwords
   mongo_database: mlos
-
-       ## Kafka Configuration
+  ## Kafka Configuration
   # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
   kafka_host: kafka
   kafka_port: 9092
   kafka_partitioner: 'murmur2_random'
-
-       ## Log Configuration
+  ## Log Configuration
   log_level: info
   log_filter: 'error, warn, info'
   log_transport: file
-
-       ## Tracing Configuration
+  ## Tracing Configuration
   event_trace_vendor: mojaloop
   event_log_filter: 'audit:*, log:warn, log:error'
   # If set to true, only the metadata object from the event will be printed.
@@ -214,8 +202,7 @@ config:
   event_async_override: 'log,trace'
   event_trace_state_enabled: true
   event_traceid_per_vendor: false
-
-       ## Cache configuration
+  ## Cache configuration
   cache_enabled: false
   cache_max_byte_size: 10000000
   cache_expires_in_ms: 1000
@@ -306,12 +293,10 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP:
-  ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+  clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
   ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+  loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
   ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
   ## e.g:
   ## loadBalancerSourceRanges:
@@ -344,8 +329,7 @@ ingress:
   pathType: ImplementationSpecific
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
-  apiVersion:
-  ## @param ingress.hostname Default host for the ingress record
+  apiVersion: null ## @param ingress.hostname Default host for the ingress record
   ##
   hostname: central-ledger-timeout.local
   ## @param servicePort : port for the service
@@ -357,8 +341,7 @@ ingress:
   ## @param ingress.annotations Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
-  annotations:
-  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+  annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
   ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
   ## You can:
   ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -378,12 +361,11 @@ ingress:
   ##   - name: transfer-api-svc.local
   ##     path: /
   ##
-  extraHosts:
-  extraPaths:
-  extraTls:
-  secrets:
+  extraHosts: null
+  extraPaths: null
+  extraTls: null
+  secrets: null
   className: "nginx"
-
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/centralledger/chart-handler-transfer-fulfil/Chart.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Transfer Fulfil Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-fulfil
-version: 14.5.0
-appVersion: v17.6.1
+version: 14.7.0
+appVersion: v17.7.8
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-fulfil/values.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v17.6.1
+  tag: v17.7.8
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -90,7 +90,7 @@ sidecar:
   enabled: false
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.0
+    tag: v14.0.1
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:
@@ -301,12 +301,10 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP:
-  ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+  clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
   ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+  loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
   ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
   ## e.g:
   ## loadBalancerSourceRanges:
@@ -339,8 +337,7 @@ ingress:
   pathType: ImplementationSpecific
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
-  apiVersion:
-  ## @param ingress.hostname Default host for the ingress record
+  apiVersion: null ## @param ingress.hostname Default host for the ingress record
   ##
   hostname: central-ledger-transfer-fulfil.local
   ## @param servicePort : port for the service
@@ -352,8 +349,7 @@ ingress:
   ## @param ingress.annotations Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
-  annotations:
-  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+  annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
   ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
   ## You can:
   ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -373,12 +369,11 @@ ingress:
   ##   - name: transfer-api-svc.local
   ##     path: /
   ##
-  extraHosts:
-  extraPaths:
-  extraTls:
-  secrets:
+  extraHosts: null
+  extraPaths: null
+  extraTls: null
+  secrets: null
   className: "nginx"
-
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/centralledger/chart-handler-transfer-get/Chart.yaml
+++ b/centralledger/chart-handler-transfer-get/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Get Transfer Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-get
-version: 14.5.0
-appVersion: v17.6.1
+version: 14.7.0
+appVersion: v17.7.8
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-get/values.yaml
+++ b/centralledger/chart-handler-transfer-get/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v17.6.1
+  tag: v17.7.8
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -90,7 +90,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.0
+    tag: v14.0.1
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:
@@ -301,12 +301,10 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP:
-  ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+  clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
   ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+  loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
   ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
   ## e.g:
   ## loadBalancerSourceRanges:
@@ -339,8 +337,7 @@ ingress:
   pathType: ImplementationSpecific
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
-  apiVersion:
-  ## @param ingress.hostname Default host for the ingress record
+  apiVersion: null ## @param ingress.hostname Default host for the ingress record
   ##
   hostname: central-ledger-transfer-get.local
   ## @param servicePort : port for the service
@@ -352,8 +349,7 @@ ingress:
   ## @param ingress.annotations Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
-  annotations:
-  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+  annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
   ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
   ## You can:
   ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -373,12 +369,11 @@ ingress:
   ##   - name: transfer-api-svc.local
   ##     path: /
   ##
-  extraHosts:
-  extraPaths:
-  extraTls:
-  secrets:
+  extraHosts: null
+  extraPaths: null
+  extraTls: null
+  secrets: null
   className: "nginx"
-
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/centralledger/chart-handler-transfer-position/Chart.yaml
+++ b/centralledger/chart-handler-transfer-position/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Transfer Position Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-position
-version: 14.5.0
-appVersion: v17.6.1
+version: 14.7.0
+appVersion: v17.7.8
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-position/values.yaml
+++ b/centralledger/chart-handler-transfer-position/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v17.6.1
+  tag: v17.7.8
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -90,7 +90,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.0
+    tag: v14.0.1
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:
@@ -301,12 +301,10 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP:
-  ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+  clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
   ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+  loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
   ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
   ## e.g:
   ## loadBalancerSourceRanges:
@@ -339,8 +337,7 @@ ingress:
   pathType: ImplementationSpecific
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
-  apiVersion:
-  ## @param ingress.hostname Default host for the ingress record
+  apiVersion: null ## @param ingress.hostname Default host for the ingress record
   ##
   hostname: central-ledger-transfer-position.local
   ## @param servicePort : port for the service
@@ -352,8 +349,7 @@ ingress:
   ## @param ingress.annotations Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
-  annotations:
-  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+  annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
   ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
   ## You can:
   ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -373,12 +369,11 @@ ingress:
   ##   - name: transfer-api-svc.local
   ##     path: /
   ##
-  extraHosts:
-  extraPaths:
-  extraTls:
-  secrets:
+  extraHosts: null
+  extraPaths: null
+  extraTls: null
+  secrets: null
   className: "nginx"
-
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/centralledger/chart-handler-transfer-prepare/Chart.yaml
+++ b/centralledger/chart-handler-transfer-prepare/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-prepare
-version: 14.5.0
-appVersion: v17.6.1
+version: 14.7.0
+appVersion: v17.7.8
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-prepare/values.yaml
+++ b/centralledger/chart-handler-transfer-prepare/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v17.6.1
+  tag: v17.7.8
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -90,7 +90,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.0
+    tag: v14.0.1
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:
@@ -307,12 +307,10 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP:
-  ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+  clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
   ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+  loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
   ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
   ## e.g:
   ## loadBalancerSourceRanges:
@@ -345,8 +343,7 @@ ingress:
   pathType: ImplementationSpecific
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
-  apiVersion:
-  ## @param ingress.hostname Default host for the ingress record
+  apiVersion: null ## @param ingress.hostname Default host for the ingress record
   ##
   hostname: central-ledger-transfer-prepare.local
   ## @param servicePort : port for the service
@@ -358,8 +355,7 @@ ingress:
   ## @param ingress.annotations Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
-  annotations:
-  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+  annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
   ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
   ## You can:
   ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -379,12 +375,11 @@ ingress:
   ##   - name: transfer-api-svc.local
   ##     path: /
   ##
-  extraHosts:
-  extraPaths:
-  extraTls:
-  secrets:
+  extraHosts: null
+  extraPaths: null
+  extraTls: null
+  secrets: null
   className: "nginx"
-
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/centralledger/chart-service/Chart.yaml
+++ b/centralledger/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Service Helm chart for Kubernetes
 name: centralledger-service
-version: 14.5.0
-appVersion: v17.6.1
+version: 14.7.0
+appVersion: v17.7.8
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v17.6.1
+  tag: v17.7.8
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -88,7 +88,7 @@ sidecar:
   enabled: false
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.0
+    tag: v14.0.1
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:
@@ -304,12 +304,10 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP:
-  ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+  clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
   ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+  loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
   ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
   ## e.g:
   ## loadBalancerSourceRanges:
@@ -342,8 +340,7 @@ ingress:
   pathType: ImplementationSpecific
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
-  apiVersion:
-  ## @param ingress.hostname Default host for the ingress record
+  apiVersion: null ## @param ingress.hostname Default host for the ingress record
   ##
   hostname: central-ledger.local
   ## @param servicePort : port for the service
@@ -355,8 +352,7 @@ ingress:
   ## @param ingress.annotations Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
-  annotations:
-  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+  annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
   ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
   ## You can:
   ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -376,12 +372,11 @@ ingress:
   ##   - name: transfer-api-svc.local
   ##     path: /
   ##
-  extraHosts:
-  extraPaths:
-  extraTls:
-  secrets:
+  extraHosts: null
+  extraPaths: null
+  extraTls: null
+  secrets: null
   className: "nginx"
-
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -16,7 +16,7 @@ centralledger-service:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v17.6.1
+    tag: v17.7.8
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -105,7 +105,7 @@ centralledger-service:
     enabled: false
     image:
       repository: mojaloop/event-sidecar
-      tag: v14.0.0
+      tag: v14.0.1
       pullPolicy: IfNotPresent
       command: '["npm", "run", "start"]'
     service:
@@ -316,18 +316,15 @@ centralledger-service:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -360,8 +357,7 @@ centralledger-service:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: central-ledger.local
     ## @param servicePort : port for the service
@@ -373,8 +369,7 @@ centralledger-service:
     ## @param ingress.annotations Additional custom annotations for the ingress record
     ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
     ##
-    annotations:
-    ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
     ## You can:
     ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -394,12 +389,11 @@ centralledger-service:
     ##   - name: transfer-api-svc.local
     ##     path: /
     ##
-    extraHosts:
-    extraPaths:
-    extraTls:
-    secrets:
+    extraHosts: null
+    extraPaths: null
+    extraTls: null
+    secrets: null
     className: "nginx"
-
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -422,7 +416,7 @@ centralledger-handler-transfer-prepare:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v17.6.1
+    tag: v17.7.8
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -513,7 +507,7 @@ centralledger-handler-transfer-prepare:
     enabled: true
     image:
       repository: mojaloop/event-sidecar
-      tag: v14.0.0
+      tag: v14.0.1
       pullPolicy: IfNotPresent
       command: '["npm", "run", "start"]'
     service:
@@ -725,18 +719,15 @@ centralledger-handler-transfer-prepare:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -769,8 +760,7 @@ centralledger-handler-transfer-prepare:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: central-ledger-transfer-prepare.local
     ## @param servicePort : port for the service
@@ -782,8 +772,7 @@ centralledger-handler-transfer-prepare:
     ## @param ingress.annotations Additional custom annotations for the ingress record
     ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
     ##
-    annotations:
-    ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
     ## You can:
     ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -803,12 +792,11 @@ centralledger-handler-transfer-prepare:
     ##   - name: transfer-api-svc.local
     ##     path: /
     ##
-    extraHosts:
-    extraPaths:
-    extraTls:
-    secrets:
+    extraHosts: null
+    extraPaths: null
+    extraTls: null
+    secrets: null
     className: "nginx"
-
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -831,7 +819,7 @@ centralledger-handler-transfer-position:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v17.6.1
+    tag: v17.7.8
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -922,7 +910,7 @@ centralledger-handler-transfer-position:
     enabled: true
     image:
       repository: mojaloop/event-sidecar
-      tag: v14.0.0
+      tag: v14.0.1
       pullPolicy: IfNotPresent
       command: '["npm", "run", "start"]'
     service:
@@ -1128,18 +1116,15 @@ centralledger-handler-transfer-position:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -1172,8 +1157,7 @@ centralledger-handler-transfer-position:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: central-ledger-transfer-position.local
     ## @param servicePort : port for the service
@@ -1185,8 +1169,7 @@ centralledger-handler-transfer-position:
     ## @param ingress.annotations Additional custom annotations for the ingress record
     ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
     ##
-    annotations:
-    ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
     ## You can:
     ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -1206,12 +1189,11 @@ centralledger-handler-transfer-position:
     ##   - name: transfer-api-svc.local
     ##     path: /
     ##
-    extraHosts:
-    extraPaths:
-    extraTls:
-    secrets:
+    extraHosts: null
+    extraPaths: null
+    extraTls: null
+    secrets: null
     className: "nginx"
-
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -1537,18 +1519,15 @@ centralledger-handler-transfer-position-batch:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -1581,8 +1560,7 @@ centralledger-handler-transfer-position-batch:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: central-ledger-transfer-position.local
     ## @param servicePort : port for the service
@@ -1594,8 +1572,7 @@ centralledger-handler-transfer-position-batch:
     ## @param ingress.annotations Additional custom annotations for the ingress record
     ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
     ##
-    annotations:
-    ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
     ## You can:
     ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -1615,12 +1592,11 @@ centralledger-handler-transfer-position-batch:
     ##   - name: transfer-api-svc.local
     ##     path: /
     ##
-    extraHosts:
-    extraPaths:
-    extraTls:
-    secrets:
+    extraHosts: null
+    extraPaths: null
+    extraTls: null
+    secrets: null
     className: "nginx"
-
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -1643,7 +1619,7 @@ centralledger-handler-transfer-get:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v17.6.1
+    tag: v17.7.8
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1734,7 +1710,7 @@ centralledger-handler-transfer-get:
     enabled: true
     image:
       repository: mojaloop/event-sidecar
-      tag: v14.0.0
+      tag: v14.0.1
       pullPolicy: IfNotPresent
       command: '["npm", "run", "start"]'
     service:
@@ -1940,18 +1916,15 @@ centralledger-handler-transfer-get:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -1984,8 +1957,7 @@ centralledger-handler-transfer-get:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: central-ledger-transfer-get.local
     ## @param servicePort : port for the service
@@ -1997,8 +1969,7 @@ centralledger-handler-transfer-get:
     ## @param ingress.annotations Additional custom annotations for the ingress record
     ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
     ##
-    annotations:
-    ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
     ## You can:
     ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -2018,12 +1989,11 @@ centralledger-handler-transfer-get:
     ##   - name: transfer-api-svc.local
     ##     path: /
     ##
-    extraHosts:
-    extraPaths:
-    extraTls:
-    secrets:
+    extraHosts: null
+    extraPaths: null
+    extraTls: null
+    secrets: null
     className: "nginx"
-
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -2046,7 +2016,7 @@ centralledger-handler-transfer-fulfil:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v17.6.1
+    tag: v17.7.8
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2137,7 +2107,7 @@ centralledger-handler-transfer-fulfil:
     enabled: false
     image:
       repository: mojaloop/event-sidecar
-      tag: v14.0.0
+      tag: v14.0.1
       pullPolicy: IfNotPresent
       command: '["npm", "run", "start"]'
     service:
@@ -2343,18 +2313,15 @@ centralledger-handler-transfer-fulfil:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -2387,8 +2354,7 @@ centralledger-handler-transfer-fulfil:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: central-ledger-transfer-fulfil.local
     ## @param servicePort : port for the service
@@ -2400,8 +2366,7 @@ centralledger-handler-transfer-fulfil:
     ## @param ingress.annotations Additional custom annotations for the ingress record
     ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
     ##
-    annotations:
-    ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
     ## You can:
     ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -2421,12 +2386,11 @@ centralledger-handler-transfer-fulfil:
     ##   - name: transfer-api-svc.local
     ##     path: /
     ##
-    extraHosts:
-    extraPaths:
-    extraTls:
-    secrets:
+    extraHosts: null
+    extraPaths: null
+    extraTls: null
+    secrets: null
     className: "nginx"
-
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -2449,7 +2413,7 @@ centralledger-handler-timeout:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v17.6.1
+    tag: v17.7.8
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2540,7 +2504,7 @@ centralledger-handler-timeout:
     enabled: true
     image:
       repository: mojaloop/event-sidecar
-      tag: v14.0.0
+      tag: v14.0.1
       pullPolicy: IfNotPresent
       command: '["npm", "run", "start"]'
     service:
@@ -2586,8 +2550,7 @@ centralledger-handler-timeout:
     error_handling:
       include_cause_extension: false
       truncate_extensions: true
-
-        ## DB Configuration
+      ## DB Configuration
     # db_type can either be 'postgres' or 'mysql'. Ensure the correct DB is enabled and configured below: postgresql.enabled or mysql.enabled
     db_type: 'mysql'
     # db_driver can either be 'pg' or 'mysql'. Ensure the correct corresponding db_type above has been set.
@@ -2751,18 +2714,15 @@ centralledger-handler-timeout:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -2795,8 +2755,7 @@ centralledger-handler-timeout:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: central-ledger-timeout.local
     ## @param servicePort : port for the service
@@ -2808,8 +2767,7 @@ centralledger-handler-timeout:
     ## @param ingress.annotations Additional custom annotations for the ingress record
     ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
     ##
-    annotations:
-    ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
     ## You can:
     ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -2829,12 +2787,11 @@ centralledger-handler-timeout:
     ##   - name: transfer-api-svc.local
     ##     path: /
     ##
-    extraHosts:
-    extraPaths:
-    extraTls:
-    secrets:
+    extraHosts: null
+    extraPaths: null
+    extraTls: null
+    secrets: null
     className: "nginx"
-
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -2857,7 +2814,7 @@ centralledger-handler-admin-transfer:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v17.6.1
+    tag: v17.7.8
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2948,7 +2905,7 @@ centralledger-handler-admin-transfer:
     enabled: false
     image:
       repository: mojaloop/event-sidecar
-      tag: v14.0.0
+      tag: v14.0.1
       pullPolicy: IfNotPresent
       command: '["npm", "run", "start"]'
     service:
@@ -3154,18 +3111,15 @@ centralledger-handler-admin-transfer:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -3198,8 +3152,7 @@ centralledger-handler-admin-transfer:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: central-ledger-transfer-prepare.local
     ## @param servicePort : port for the service
@@ -3211,8 +3164,7 @@ centralledger-handler-admin-transfer:
     ## @param ingress.annotations Additional custom annotations for the ingress record
     ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
     ##
-    annotations:
-    ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
     ## You can:
     ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -3232,12 +3184,11 @@ centralledger-handler-admin-transfer:
     ##   - name: transfer-api-svc.local
     ##     path: /
     ##
-    extraHosts:
-    extraPaths:
-    extraTls:
-    secrets:
+    extraHosts: null
+    extraPaths: null
+    extraTls: null
+    secrets: null
     className: "nginx"
-
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/centralsettlement/Chart.yaml
+++ b/centralsettlement/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Central-Settlement Helm chart for Kubernetes
 name: centralsettlement
-version: 14.7.0
+version: 14.15.0
 appVersion: v16.0.0
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
@@ -16,22 +16,22 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: centralsettlement-service
-    version: ">= 15.2.0"
+    version: ">= 15.3.0"
     repository: "file://./chart-service"
     alias: centralsettlement-service
     condition: centralsettlement-service.enabled
   - name: centralsettlement-service
-    version: ">= 15.2.0"
+    version: ">= 15.3.0"
     repository: "file://./chart-service"
     alias: centralsettlement-handler-deferredsettlement
     condition: centralsettlement-handler-deferredsettlement.enabled
   - name: centralsettlement-service
-    version: ">= 15.2.0"
+    version: ">= 15.3.0"
     repository: "file://./chart-service"
     alias: centralsettlement-handler-grosssettlement
     condition: centralsettlement-handler-grosssettlement.enabled
   - name: centralsettlement-service
-    version: ">= 15.2.0"
+    version: ">= 15.3.0"
     repository: "file://./chart-service"
     alias: centralsettlement-handler-rules
     condition: centralsettlement-handler-rules.enabled

--- a/centralsettlement/chart-service/Chart.yaml
+++ b/centralsettlement/chart-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Central-Settlement helm chart for API services and handlers
 name: centralsettlement-service
-version: 15.2.0
+version: 15.3.0
 appVersion: v16.0.0
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png

--- a/centralsettlement/chart-service/values.yaml
+++ b/centralsettlement/chart-service/values.yaml
@@ -34,7 +34,7 @@ diagnosticMode:
   enabled: false
   ## @param diagnosticMode.command Command to override all containers in the deployment
   ##
-  command: 
+  command:
     - node
     - src/handlers/index.js
     - h
@@ -43,7 +43,6 @@ diagnosticMode:
   ##
   args:
     - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-  
   ## @param diagnosticMode.debug config to override all debug information
   ##
   debug:
@@ -89,7 +88,7 @@ sidecar:
   enabled: false
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.0
+    tag: v14.0.1
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:
@@ -270,62 +269,52 @@ config:
   error_handling:
     include_cause_extension: false
     truncate_extensions: true
-
   rules: {}
-    ## The rules object defines rules files represented as key-value pairs. These rules will be executed per commited transfer.
-    ## Expected key-value format for the rules object:
-    ##  nameOfFile.js: fileContents
-    ## See below example of interchange fee rule.
-
-    # interchangeFeeCalculation.js: |
-    #   /* eslint-disable no-undef */
-    #   // ********************************************************
-    #   // Name: Interchange fee calculation
-    #   // Type: notification
-    #   // Action: commit
-    #   // Status: success
-    #   // Start: 2020-06-01T00:00:00.000Z
-    #   // End: 2100-12-31T23:59:59.999Z
-    #   // Description: This script calculates the interchange fees between DFSPs where the account type is "Wallet"
-    #   // ********************************************************
-
-           ## Globals:
-    #   // payload: The contents of the message from the Kafka topic.
-    #   // transfer: The transfer object.
-
-    #   // # Functions:
-           ## Data retrieval functions:
-    #   // getTransfer(transferId): Retrieves a mojaloop transfer from the central-ledger API.
-
-           ## Helper functions:
-    #   // getExtensionValue(list, key): Gets a value from an extension list
-    #   // log(message): allows the script to log to standard out for debugging purposes
-
-    #   // Math functions:
-    #   // multiply(number1, number2, decimalPlaces): Uses ml-number to handle multiplication of money values
-
-    #   // Ledger functions:
-    #   // addLedgerEntry: Adds a debit and credit ledger entry to the specified account to the specified DFSPs
-
-    #   log(JSON.stringify(transfer))
-    #   const payerFspId = transfer.payer.partyIdInfo.fspId
-    #   const payeeFspId = transfer.payee.partyIdInfo.fspId
-
-    #   if ((payeeFspId !== payerFspId) &&
-    #     (getExtensionValue(transfer.payee.partyIdInfo.extensionList.extension, 'accountType') === 'Wallet' &&
-    #       getExtensionValue(transfer.payer.partyIdInfo.extensionList.extension, 'accountType') === 'Wallet') &&
-    #     (transfer.transactionType.scenario === 'TRANSFER' &&
-    #       transfer.transactionType.initiator === 'PAYER' &&
-    #       transfer.transactionType.initiatorType === 'CONSUMER')) {
-    #     log(`Adding an interchange fee for Wallet to Wallet from ${payerFspId} to ${payeeFspId}`)
-    #     addLedgerEntry(payload.id, 'INTERCHANGE_FEE', // Ledger account type Id
-    #       'INTERCHANGE_FEE', // Ledger entry type Id
-    #       multiply(transfer.amount.amount, 0.006, 2),
-    #       transfer.amount.currency,
-    #       payerFspId,
-    #       payeeFspId)
-    #   }
-
+  ## The rules object defines rules files represented as key-value pairs. These rules will be executed per commited transfer.
+  ## Expected key-value format for the rules object:
+  ##  nameOfFile.js: fileContents
+  ## See below example of interchange fee rule.
+  # interchangeFeeCalculation.js: |
+  #   /* eslint-disable no-undef */
+  #   // ********************************************************
+  #   // Name: Interchange fee calculation
+  #   // Type: notification
+  #   // Action: commit
+  #   // Status: success
+  #   // Start: 2020-06-01T00:00:00.000Z
+  #   // End: 2100-12-31T23:59:59.999Z
+  #   // Description: This script calculates the interchange fees between DFSPs where the account type is "Wallet"
+  #   // ********************************************************
+  ## Globals:
+  #   // payload: The contents of the message from the Kafka topic.
+  #   // transfer: The transfer object.
+  #   // # Functions:
+  ## Data retrieval functions:
+  #   // getTransfer(transferId): Retrieves a mojaloop transfer from the central-ledger API.
+  ## Helper functions:
+  #   // getExtensionValue(list, key): Gets a value from an extension list
+  #   // log(message): allows the script to log to standard out for debugging purposes
+  #   // Math functions:
+  #   // multiply(number1, number2, decimalPlaces): Uses ml-number to handle multiplication of money values
+  #   // Ledger functions:
+  #   // addLedgerEntry: Adds a debit and credit ledger entry to the specified account to the specified DFSPs
+  #   log(JSON.stringify(transfer))
+  #   const payerFspId = transfer.payer.partyIdInfo.fspId
+  #   const payeeFspId = transfer.payee.partyIdInfo.fspId
+  #   if ((payeeFspId !== payerFspId) &&
+  #     (getExtensionValue(transfer.payee.partyIdInfo.extensionList.extension, 'accountType') === 'Wallet' &&
+  #       getExtensionValue(transfer.payer.partyIdInfo.extensionList.extension, 'accountType') === 'Wallet') &&
+  #     (transfer.transactionType.scenario === 'TRANSFER' &&
+  #       transfer.transactionType.initiator === 'PAYER' &&
+  #       transfer.transactionType.initiatorType === 'CONSUMER')) {
+  #     log(`Adding an interchange fee for Wallet to Wallet from ${payerFspId} to ${payeeFspId}`)
+  #     addLedgerEntry(payload.id, 'INTERCHANGE_FEE', // Ledger account type Id
+  #       'INTERCHANGE_FEE', // Ledger entry type Id
+  #       multiply(transfer.amount.amount, 0.006, 2),
+  #       transfer.amount.currency,
+  #       payerFspId,
+  #       payeeFspId)
+  #   }
 ## @param initContainers Add additional init containers to the %%MAIN_CONTAINER_NAME%% pod(s)
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 ## e.g:
@@ -412,17 +401,15 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP:
-  ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
-  ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
-  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-  ## e.g:
-  ## loadBalancerSourceRanges:
-  ##   - 10.10.10.0/24
-  ##
+  clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+##
+  loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+## e.g:
+## loadBalancerSourceRanges:
+##   - 10.10.10.0/24
+##
   loadBalancerSourceRanges: []
   ## @param service.externalTrafficPolicy %%MAIN_CONTAINER_NAME%% service external traffic policy
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
@@ -450,9 +437,8 @@ ingress:
   pathType: ImplementationSpecific
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
-  apiVersion:
-  ## @param ingress.hostname Default host for the ingress record
-  ##
+  apiVersion: null ## @param ingress.hostname Default host for the ingress record
+##
   hostname: central-settlement-grosssettlement.local
   ## @param servicePort : port for the service
   ##
@@ -463,14 +449,13 @@ ingress:
   ## @param ingress.annotations Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
-  annotations:
-  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
-  ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
-  ## You can:
-  ##   - Use the `ingress.secrets` parameter to create this TLS secret
-  ##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
-  ##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
-  ##
+  annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+## You can:
+##   - Use the `ingress.secrets` parameter to create this TLS secret
+##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
+##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
+##
   tls: false
   ## @param ingress.certManager Add the corresponding annotations for cert-manager integration
   ##
@@ -484,12 +469,11 @@ ingress:
   ##   - name: transfer-api-svc.local
   ##     path: /
   ##
-  extraHosts:
-  extraPaths:
-  extraTls:
-  secrets:
+  extraHosts: null
+  extraPaths: null
+  extraTls: null
+  secrets: null
   className: "nginx"
-
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/centralsettlement/values.yaml
+++ b/centralsettlement/values.yaml
@@ -90,7 +90,7 @@ centralsettlement-service:
     enabled: false
     image:
       repository: mojaloop/event-sidecar
-      tag: v14.0.0
+      tag: v14.0.1
       pullPolicy: IfNotPresent
       command: '["npm", "run", "start"]'
     service:
@@ -348,18 +348,15 @@ centralsettlement-service:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -392,8 +389,7 @@ centralsettlement-service:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: central-settlement-service.local
     ## @param servicePort : port for the service
@@ -405,8 +401,7 @@ centralsettlement-service:
     ## @param ingress.annotations Additional custom annotations for the ingress record
     ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
     ##
-    annotations:
-    ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
     ## You can:
     ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -426,12 +421,11 @@ centralsettlement-service:
     ##   - name: transfer-api-svc.local
     ##     path: /
     ##
-    extraHosts:
-    extraPaths:
-    extraTls:
-    secrets:
+    extraHosts: null
+    extraPaths: null
+    extraTls: null
+    secrets: null
     className: "nginx"
-
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -532,7 +526,7 @@ centralsettlement-handler-deferredsettlement:
     enabled: false
     image:
       repository: mojaloop/event-sidecar
-      tag: v14.0.0
+      tag: v14.0.1
       pullPolicy: IfNotPresent
       command: '["npm", "run", "start"]'
     service:
@@ -790,18 +784,15 @@ centralsettlement-handler-deferredsettlement:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -834,8 +825,7 @@ centralsettlement-handler-deferredsettlement:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: central-settlement-deferredsettlement.local
     ## @param servicePort : port for the service
@@ -847,8 +837,7 @@ centralsettlement-handler-deferredsettlement:
     ## @param ingress.annotations Additional custom annotations for the ingress record
     ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
     ##
-    annotations:
-    ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
     ## You can:
     ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -868,12 +857,11 @@ centralsettlement-handler-deferredsettlement:
     ##   - name: transfer-api-svc.local
     ##     path: /
     ##
-    extraHosts:
-    extraPaths:
-    extraTls:
-    secrets:
+    extraHosts: null
+    extraPaths: null
+    extraTls: null
+    secrets: null
     className: "nginx"
-
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -976,7 +964,7 @@ centralsettlement-handler-grosssettlement:
     enabled: false
     image:
       repository: mojaloop/event-sidecar
-      tag: v14.0.0
+      tag: v14.0.1
       pullPolicy: IfNotPresent
       command: '["npm", "run", "start"]'
     service:
@@ -1233,18 +1221,15 @@ centralsettlement-handler-grosssettlement:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -1277,8 +1262,7 @@ centralsettlement-handler-grosssettlement:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: central-settlement-grosssettlement.local
     ## @param servicePort : port for the service
@@ -1290,8 +1274,7 @@ centralsettlement-handler-grosssettlement:
     ## @param ingress.annotations Additional custom annotations for the ingress record
     ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
     ##
-    annotations:
-    ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
     ## You can:
     ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -1311,12 +1294,11 @@ centralsettlement-handler-grosssettlement:
     ##   - name: transfer-api-svc.local
     ##     path: /
     ##
-    extraHosts:
-    extraPaths:
-    extraTls:
-    secrets:
+    extraHosts: null
+    extraPaths: null
+    extraTls: null
+    secrets: null
     className: "nginx"
-
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -1419,7 +1401,7 @@ centralsettlement-handler-rules:
     enabled: false
     image:
       repository: mojaloop/event-sidecar
-      tag: v14.0.0
+      tag: v14.0.1
       pullPolicy: IfNotPresent
       command: '["npm", "run", "start"]'
     service:
@@ -1614,13 +1596,13 @@ centralsettlement-handler-rules:
       #   // End: 2100-12-31T23:59:59.999Z
       #   // Description: This is empty rules script
       #   // ********************************************************
-             ## Globals:
+      ## Globals:
       #   // payload: The contents of the message from the Kafka topic.
       #   // transfer: The transfer object.
       #   // # Functions:
-             ## Data retrieval functions:
+      ## Data retrieval functions:
       #   // getTransfer(transferId): Retrieves a mojaloop transfer from the central-ledger API.
-             ## Helper functions:
+      ## Helper functions:
       #   // getExtensionValue(list, key): Gets a value from an extension list
       #   // log(message): allows the script to log to standard out for debugging purposes
       #   // Math functions:
@@ -1766,18 +1748,15 @@ centralsettlement-handler-rules:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -1810,8 +1789,7 @@ centralsettlement-handler-rules:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: central-settlement-rules.local
     ## @param servicePort : port for the service
@@ -1823,8 +1801,7 @@ centralsettlement-handler-rules:
     ## @param ingress.annotations Additional custom annotations for the ingress record
     ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
     ##
-    annotations:
-    ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
     ## You can:
     ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -1844,12 +1821,11 @@ centralsettlement-handler-rules:
     ##   - name: transfer-api-svc.local
     ##     path: /
     ##
-    extraHosts:
-    extraPaths:
-    extraTls:
-    secrets:
+    extraHosts: null
+    extraPaths: null
+    extraTls: null
+    secrets: null
     className: "nginx"
-
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/example-mojaloop-backend/Chart.yaml
+++ b/example-mojaloop-backend/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Example Helm chart for mojaloop backend dependencies
 name: example-mojaloop-backend
-version: 15.7.0
-appVersion: "nginx: 4.4.2; mysql: 9.19.1; kafka: 26.8.5; mongodb: 14.8.3; redis: 18.12.1"
+version: 15.14.0
+appVersion: "nginx: 4.4.2; mysql: 11.1.9; kafka: 29.3.7; mongodb: 15.6.12; redis: 19.6.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -23,7 +23,7 @@ dependencies:
       - dependency
       - backend
       - kafka
-    version: 26.8.5
+    version: 29.3.7
   ## mysql database
   - name: mysql
     alias: mysql
@@ -36,7 +36,7 @@ dependencies:
       - mysql
       - centralledger
       - account-lookup
-    version: 9.19.1
+    version: 11.1.9
   ## Bulk backend
   - name: mongodb
     alias: cl-mongodb
@@ -48,7 +48,7 @@ dependencies:
       - backend
       - mongodb
       - centralledger
-    version: 14.8.3
+    version: 15.6.12
   ## Central-event-processor backend
   - name: mongodb
     alias: cep-mongodb
@@ -60,7 +60,7 @@ dependencies:
       - backend
       - mongodb
       - centralledger
-    version: 14.8.3
+    version: 15.6.12
   - name: mongodb
     alias: ttk-mongodb
     condition: ttk-mongodb.enabled
@@ -71,7 +71,7 @@ dependencies:
       - backend
       - mongodb
       - centralledger
-    version: 14.8.3
+    version: 15.6.12
   ## Redis for SDK-Scheme-Adapter that are part of the TTKSims
   - name: redis
     alias: ttksims-redis
@@ -85,7 +85,7 @@ dependencies:
       - sdk
       - bulk
       - ttksims
-    version: 18.12.1
+    version: 19.6.1
   ## Redis for Thirdparty Auth-Service
   - name: redis
     alias: auth-svc-redis
@@ -97,4 +97,4 @@ dependencies:
       - backend
       - redis
       - thirdparty
-    version: 18.12.1
+    version: 19.6.1

--- a/ml-api-adapter/Chart.yaml
+++ b/ml-api-adapter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: ml-api-adapter Helm chart for Kubernetes
 name: ml-api-adapter
-version: 13.6.0
-appVersion: v14.0.5
+version: 13.12.0
+appVersion: v14.0.7
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -16,11 +16,11 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: ml-api-adapter-service
-    version: ">= 13.4.0"
+    version: ">= 13.6.0"
     repository: "file://./chart-service"
     condition: ml-api-adapter-service.enabled
   - name: ml-api-adapter-handler-notification
-    version: ">= 13.4.0"
+    version: ">= 13.6.0"
     repository: "file://./chart-handler-notification"
     condition: ml-api-adapter-handler-notification.enabled
   - name: common

--- a/ml-api-adapter/chart-handler-notification/Chart.yaml
+++ b/ml-api-adapter/chart-handler-notification/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: ml-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: ml-api-adapter-handler-notification
-version: 13.4.0
-appVersion: v14.0.5
+version: 13.6.0
+appVersion: v14.0.7
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -5,7 +5,7 @@
 image:
   registry: docker.io
   repository: mojaloop/ml-api-adapter
-  tag: v14.0.5
+  tag: v14.0.7
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -71,7 +71,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.5
+    tag: v14.0.7
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:
@@ -212,20 +212,20 @@ config:
     # If `jwsSigningKeySecret` is not null, then the `jwsSigningKey` value will be ignored.
     # Expected properties of `jwsSigningKeySecret` are `name` and `key`.
     jwsSigningKeySecret: null
-    jwsSigningKey: null 
-# To generate this key:
-# Private:
-# ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key
-# Public:
-# openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub
-# Should look like:
-# -----BEGIN RSA PRIVATE KEY-----
-# MIIJKQIBAAKCAgEAxfqaZivMPd4MpdBHu0jVMf3MSuSdkSMHn+sNJdDQfl+x4R5R
-# ..
-# ..
-# mBynFpdjO0D3PnLKjnBDn1vFAfANOwVpGXCw5mn+484A/SIXYebWruFd03g4
-# -----END RSA PRIVATE KEY-----
-## Error handling Configuration
+    jwsSigningKey: null
+  # To generate this key:
+  # Private:
+  # ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key
+  # Public:
+  # openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub
+  # Should look like:
+  # -----BEGIN RSA PRIVATE KEY-----
+  # MIIJKQIBAAKCAgEAxfqaZivMPd4MpdBHu0jVMf3MSuSdkSMHn+sNJdDQfl+x4R5R
+  # ..
+  # ..
+  # mBynFpdjO0D3PnLKjnBDn1vFAfANOwVpGXCw5mn+484A/SIXYebWruFd03g4
+  # -----END RSA PRIVATE KEY-----
+  ## Error handling Configuration
   error_handling:
     include_cause_extension: false
     truncate_extensions: true
@@ -253,14 +253,14 @@ service:
   ## clusterIP: None
   ##
   clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
-## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
-##
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+  ##
   loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
-## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-## e.g:
-## loadBalancerSourceRanges:
-##   - 10.10.10.0/24
-##
+  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ## e.g:
+  ## loadBalancerSourceRanges:
+  ##   - 10.10.10.0/24
+  ##
   loadBalancerSourceRanges: []
   ## @param service.externalTrafficPolicy %%MAIN_CONTAINER_NAME%% service external traffic policy
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
@@ -289,7 +289,7 @@ ingress:
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
   apiVersion: null ## @param ingress.hostname Default host for the ingress record
-##
+  ##
   hostname: ml-api-adapter-notification.local
   ## @param servicePort : port for the service
   ##
@@ -301,12 +301,12 @@ ingress:
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
   annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
-## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
-## You can:
-##   - Use the `ingress.secrets` parameter to create this TLS secret
-##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
-##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
-##
+  ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+  ## You can:
+  ##   - Use the `ingress.secrets` parameter to create this TLS secret
+  ##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
+  ##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
+  ##
   tls: false
   ## @param ingress.certManager Add the corresponding annotations for cert-manager integration
   ##

--- a/ml-api-adapter/chart-service/Chart.yaml
+++ b/ml-api-adapter/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: ml-api-adapter API component Helm chart for Kubernetes
 name: ml-api-adapter-service
-version: 13.4.0
-appVersion: v14.0.5
+version: 13.6.0
+appVersion: v14.0.7
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-api-adapter/chart-service/values.yaml
+++ b/ml-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 image:
   registry: docker.io
   repository: mojaloop/ml-api-adapter
-  tag: v14.0.5
+  tag: v14.0.7
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -18,10 +18,8 @@ image:
   ##   - myRegistryKeySecretName
   ##
   pullSecrets: []
-
 replicaCount: 1
-command: '["node", "src/api/index.js"]' 
-
+command: '["node", "src/api/index.js"]'
 ## Enable diagnostic mode in the deployment
 ##
 diagnosticMode:
@@ -30,14 +28,13 @@ diagnosticMode:
   enabled: false
   ## @param diagnosticMode.command Command to override all containers in the deployment
   ##
-  command: 
+  command:
     - node
     - src/api/index.js
   ## @param diagnosticMode.args Args to override all containers in the deployment
   ##
   args:
     - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-  
   ## @param diagnosticMode.debug config to override all debug information
   ##
   debug:
@@ -69,7 +66,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.0
+    tag: v14.0.1
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:
@@ -111,14 +108,7 @@ initContainers:
     command:
       - sh
       - -c
-      - until ./bin/kafka-broker-api-versions.sh --bootstrap-server ${KAFKA_HOST}:${KAFKA_PORT}; 
-        do
-          echo --------------------;
-          echo Waiting for Kafka...;
-          sleep 2; 
-        done;
-        echo ====================; 
-        echo Kafka ok!;
+      - until ./bin/kafka-broker-api-versions.sh --bootstrap-server ${KAFKA_HOST}:${KAFKA_PORT}; do echo --------------------; echo Waiting for Kafka...; sleep 2; done; echo ====================; echo Kafka ok!;
     env:
       - name: KAFKA_HOST
         value: '{{ .Values.config.kafka_host }}'
@@ -138,9 +128,7 @@ livenessProbe:
     path: /health
   initialDelaySeconds: 90
   periodSeconds: 15
-
-    ## metric configuration for prometheus instrumentation
-
+  ## metric configuration for prometheus instrumentation
 metrics:
   ## flag to enable/disable the metrics end-points
   enabled: true
@@ -231,12 +219,10 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP:
-  ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+  clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
   ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+  loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
   ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
   ## e.g:
   ## loadBalancerSourceRanges:
@@ -269,8 +255,7 @@ ingress:
   pathType: ImplementationSpecific
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
-  apiVersion:
-  ## @param ingress.hostname Default host for the ingress record
+  apiVersion: null ## @param ingress.hostname Default host for the ingress record
   ##
   hostname: ml-api-adapter.local
   ## @param servicePort : port for the service
@@ -282,8 +267,7 @@ ingress:
   ## @param ingress.annotations Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
-  annotations:
-  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+  annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
   ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
   ## You can:
   ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -303,12 +287,11 @@ ingress:
   ##   - name: transfer-api-svc.local
   ##     path: /
   ##
-  extraHosts:
-  extraPaths:
-  extraTls:
-  secrets:
+  extraHosts: null
+  extraPaths: null
+  extraTls: null
+  secrets: null
   className: "nginx"
-
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -14,7 +14,7 @@ ml-api-adapter-service:
   image:
     registry: docker.io
     repository: mojaloop/ml-api-adapter
-    tag: v14.0.5
+    tag: v14.0.7
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -80,7 +80,7 @@ ml-api-adapter-service:
     enabled: true
     image:
       repository: mojaloop/event-sidecar
-      tag: v14.0.0
+      tag: v14.0.1
       pullPolicy: IfNotPresent
     readinessProbe:
       enabled: true
@@ -112,14 +112,7 @@ ml-api-adapter-service:
       command:
         - sh
         - -c
-        - until ./bin/kafka-broker-api-versions.sh --bootstrap-server ${KAFKA_HOST}:${KAFKA_PORT};
-          do
-            echo --------------------;
-            echo Waiting for Kafka...;
-            sleep 2;
-          done;
-          echo ====================;
-          echo Kafka ok!;
+        - until ./bin/kafka-broker-api-versions.sh --bootstrap-server ${KAFKA_HOST}:${KAFKA_PORT}; do echo --------------------; echo Waiting for Kafka...; sleep 2; done; echo ====================; echo Kafka ok!;
       env:
         - name: KAFKA_HOST
           value: '{{ .Values.config.kafka_host }}'
@@ -219,18 +212,15 @@ ml-api-adapter-service:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -263,8 +253,7 @@ ml-api-adapter-service:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: ml-api-adapter.local
     ## @param servicePort : port for the service
@@ -276,8 +265,7 @@ ml-api-adapter-service:
     ## @param ingress.annotations Additional custom annotations for the ingress record
     ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
     ##
-    annotations:
-    ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
     ## You can:
     ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -297,24 +285,23 @@ ml-api-adapter-service:
     ##   - name: transfer-api-svc.local
     ##     path: /
     ##
-    extraHosts:
-    extraPaths:
-    extraTls:
-    secrets:
+    extraHosts: null
+    extraPaths: null
+    extraTls: null
+    secrets: null
     className: "nginx"
   ##
   resources: {}
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #  cpu: 100m
-    #  memory: 128Mi
-    # requests:
-    #  cpu: 100m
-    #  memory: 128Mi
-
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
 ml-api-adapter-handler-notification:
   enabled: true
   # Default values for ml-api-adapter.
@@ -324,7 +311,7 @@ ml-api-adapter-handler-notification:
   image:
     registry: docker.io
     repository: mojaloop/ml-api-adapter
-    tag: v14.0.5
+    tag: v14.0.7
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -392,7 +379,7 @@ ml-api-adapter-handler-notification:
     enabled: true
     image:
       repository: mojaloop/event-sidecar
-      tag: v14.0.0
+      tag: v14.0.1
       pullPolicy: IfNotPresent
     readinessProbe:
       enabled: true
@@ -426,14 +413,7 @@ ml-api-adapter-handler-notification:
         command:
           - sh
           - -c
-          - until ./bin/kafka-broker-api-versions.sh --bootstrap-server ${KAFKA_HOST}:${KAFKA_PORT};
-            do
-              echo --------------------;
-              echo Waiting for Kafka...;
-              sleep 2;
-            done;
-            echo ====================;
-            echo Kafka ok!;
+          - until ./bin/kafka-broker-api-versions.sh --bootstrap-server ${KAFKA_HOST}:${KAFKA_PORT}; do echo --------------------; echo Waiting for Kafka...; sleep 2; done; echo ====================; echo Kafka ok!;
         env:
           - name: KAFKA_HOST
             value: '{{ .Values.config.kafka_host }}'
@@ -526,19 +506,18 @@ ml-api-adapter-handler-notification:
       # Expected properties of `jwsSigningKeySecret` are `name` and `key`.
       jwsSigningKeySecret: null
       jwsSigningKey: null
-        # To generate this key:
-        # Private:
-        # ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key
-        # Public:
-        # openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub
-        # Should look like:
-        # -----BEGIN RSA PRIVATE KEY-----
-        # MIIJKQIBAAKCAgEAxfqaZivMPd4MpdBHu0jVMf3MSuSdkSMHn+sNJdDQfl+x4R5R
-        # ..
-        # ..
-        # mBynFpdjO0D3PnLKjnBDn1vFAfANOwVpGXCw5mn+484A/SIXYebWruFd03g4
-        # -----END RSA PRIVATE KEY-----
-
+      # To generate this key:
+      # Private:
+      # ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key
+      # Public:
+      # openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub
+      # Should look like:
+      # -----BEGIN RSA PRIVATE KEY-----
+      # MIIJKQIBAAKCAgEAxfqaZivMPd4MpdBHu0jVMf3MSuSdkSMHn+sNJdDQfl+x4R5R
+      # ..
+      # ..
+      # mBynFpdjO0D3PnLKjnBDn1vFAfANOwVpGXCw5mn+484A/SIXYebWruFd03g4
+      # -----END RSA PRIVATE KEY-----
     ## Error handling Configuration
     error_handling:
       include_cause_extension: false
@@ -556,8 +535,7 @@ ml-api-adapter-handler-notification:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: ml-api-adapter-notification.local
     ## @param servicePort : port for the service
@@ -569,8 +547,7 @@ ml-api-adapter-handler-notification:
     ## @param ingress.annotations Additional custom annotations for the ingress record
     ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
     ##
-    annotations:
-    ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
     ## You can:
     ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -590,20 +567,20 @@ ml-api-adapter-handler-notification:
     ##   - name: transfer-api-svc.local
     ##     path: /
     ##
-    extraHosts:
-    extraPaths:
-    extraTls:
-    secrets:
+    extraHosts: null
+    extraPaths: null
+    extraTls: null
+    secrets: null
     className: "nginx"
   ##
   resources: {}
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #  cpu: 100m
-    #  memory: 128Mi
-    # requests:
-    #  cpu: 100m
-    #  memory: 128Mi
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi

--- a/ml-testing-toolkit-cli/Chart.yaml
+++ b/ml-testing-toolkit-cli/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: ml-testing-toolkit-cli Helm chart for Kubernetes
 name: ml-testing-toolkit-cli
-version: 15.6.0
-appVersion: v1.2.1
+version: 15.7.0
+appVersion: v1.2.2
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-testing-toolkit/Chart.yaml
+++ b/ml-testing-toolkit/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: ml-testing-toolkit Helm chart for Kubernetes
 name: ml-testing-toolkit
-version: 17.4.0
-appVersion: "ml-testing-toolkit: v17.0.0; ml-testing-toolkit-ui: v15.4.2"
+version: 17.6.0
+appVersion: "ml-testing-toolkit: v17.2.3; ml-testing-toolkit-ui: v17.2.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -21,11 +21,11 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: ml-testing-toolkit-frontend
-    version: ">= 15.7.0"
+    version: ">= 15.8.0"
     repository: "file://./chart-frontend"
     condition: ml-testing-toolkit-frontend.enabled
   - name: ml-testing-toolkit-backend
-    version: ">= 16.3.0"
+    version: ">= 16.4.0"
     repository: "file://./chart-backend"
     condition: ml-testing-toolkit-backend.enabled
   - name: common

--- a/ml-testing-toolkit/chart-backend/Chart.yaml
+++ b/ml-testing-toolkit/chart-backend/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: ml-testing-toolkit-backend Helm chart for Kubernetes
 name: ml-testing-toolkit-backend
-version: 16.3.0
-appVersion: v17.0.0
+version: 16.4.0
+appVersion: v17.2.3
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-testing-toolkit/chart-backend/values.yaml
+++ b/ml-testing-toolkit/chart-backend/values.yaml
@@ -6,10 +6,9 @@ enabled: true
 # Default values
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-
 image:
   repository: mojaloop/ml-testing-toolkit
-  tag: v17.1.1
+  tag: v17.2.3
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -110,7 +109,8 @@ parameters: {}
 ##    imagePullPolicy: Always
 ##    command: ['sh', '-c', 'echo "hello world"']
 ##
-initContainers: [] # We want to disable init-containers as there is no need
+initContainers: []
+# We want to disable init-containers as there is no need
 ## Use the following initContainers if you are using a MongoDB as a dependency
 # initContainers: |
 #   - name: wait-for-mongodb
@@ -175,13 +175,12 @@ service:
   ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
   ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
-  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-  ## e.g:
-  ## loadBalancerSourceRanges:
-  ##   - 10.10.10.0/24
-  ##
+  loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+## e.g:
+## loadBalancerSourceRanges:
+##   - 10.10.10.0/24
+##
   loadBalancerSourceRanges: []
   ## @param service.externalTrafficPolicy %%MAIN_CONTAINER_NAME%% service external traffic policy
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip

--- a/ml-testing-toolkit/chart-frontend/Chart.yaml
+++ b/ml-testing-toolkit/chart-frontend/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: ml-testing-toolkit-frontend Helm chart for Kubernetes
 name: ml-testing-toolkit-frontend
-version: 15.7.0
-appVersion: v15.4.2
+version: 15.8.0
+appVersion: v15.5.0
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/ml-testing-toolkit/chart-frontend/values.yaml
+++ b/ml-testing-toolkit/chart-frontend/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: mojaloop/ml-testing-toolkit-ui
-  tag: v15.4.2
+  tag: v15.5.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -92,17 +92,17 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP: null 
-## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
-## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
-##
-  loadBalancerIP: null 
-## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
-## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-## e.g:
-## loadBalancerSourceRanges:
-##   - 10.10.10.0/24
-##
+  clusterIP: null
+  ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+  ##
+  loadBalancerIP: null
+  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ## e.g:
+  ## loadBalancerSourceRanges:
+  ##   - 10.10.10.0/24
+  ##
   loadBalancerSourceRanges: []
   ## @param service.externalTrafficPolicy %%MAIN_CONTAINER_NAME%% service external traffic policy
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip

--- a/mojaloop-bulk/Chart.yaml
+++ b/mojaloop-bulk/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Mojaloop Bulk Helm chart for Kubernetes
 name: mojaloop-bulk
-version: 16.7.0
-appVersion: "bulk-api-adapter: v17.0.0; central-ledger: v17.6.1"
+version: 16.17.0
+appVersion: "bulk-api-adapter: v17.1.0; central-ledger: v17.7.8"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -15,11 +15,11 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: bulk-api-adapter
-    version: ">= 14.6.0"
+    version: ">= 14.9.0"
     repository: "file://../bulk-api-adapter"
     condition: bulk-api-adapter.enabled
   - name: bulk-centralledger
-    version: ">= 14.8.0"
+    version: ">= 14.15.0"
     repository: "file://../bulk-centralledger"
     condition: bulk-centralledger.enabled
   - name: common

--- a/mojaloop-bulk/values.yaml
+++ b/mojaloop-bulk/values.yaml
@@ -15,7 +15,7 @@ bulk-api-adapter:
     image:
       registry: docker.io
       repository: mojaloop/bulk-api-adapter
-      tag: v17.0.0
+      tag: v17.1.0
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -242,18 +242,15 @@ bulk-api-adapter:
       ## NOTE: choose port between <30000-32767>
       ##
       nodePorts:
-        http:
-        https:
-      ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+        http: null
+        https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
       ## e.g.:
       ## clusterIP: None
       ##
-      clusterIP:
-      ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+      clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
       ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
       ##
-      loadBalancerIP:
-      ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+      loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
       ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
       ## e.g:
       ## loadBalancerSourceRanges:
@@ -286,8 +283,7 @@ bulk-api-adapter:
       pathType: ImplementationSpecific
       ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
       ##
-      apiVersion:
-      ## @param ingress.hostname Default host for the ingress record
+      apiVersion: null ## @param ingress.hostname Default host for the ingress record
       ##
       hostname: bulk-api-adapter.local
       ## @param servicePort : port for the service
@@ -299,8 +295,7 @@ bulk-api-adapter:
       ## @param ingress.annotations Additional custom annotations for the ingress record
       ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
       ##
-      annotations:
-      ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+      annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
       ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
       ## You can:
       ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -320,12 +315,11 @@ bulk-api-adapter:
       ##   - name: transfer-api-svc.local
       ##     path: /
       ##
-      extraHosts:
-      extraPaths:
-      extraTls:
-      secrets:
+      extraHosts: null
+      extraPaths: null
+      extraTls: null
+      secrets: null
       className: "nginx"
-
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -347,7 +341,7 @@ bulk-api-adapter:
     image:
       registry: docker.io
       repository: mojaloop/bulk-api-adapter
-      tag: v17.0.0
+      tag: v17.1.0
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -503,19 +497,18 @@ bulk-api-adapter:
         # Expected properties of `jwsSigningKeySecret` are `name` and `key`.
         jwsSigningKeySecret: null
         jwsSigningKey: null
-          # To generate this key:
-          # Private:
-          # ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key
-          # Public:
-          # openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub
-          # Should look like:
-          # -----BEGIN RSA PRIVATE KEY-----
-          # MIIJKQIBAAKCAgEAxfqaZivMPd4MpdBHu0jVMf3MSuSdkSMHn+sNJdDQfl+x4R5R
-          # ..
-          # ..
-          # mBynFpdjO0D3PnLKjnBDn1vFAfANOwVpGXCw5mn+484A/SIXYebWruFd03g4
-          # -----END RSA PRIVATE KEY-----
-
+        # To generate this key:
+        # Private:
+        # ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key
+        # Public:
+        # openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub
+        # Should look like:
+        # -----BEGIN RSA PRIVATE KEY-----
+        # MIIJKQIBAAKCAgEAxfqaZivMPd4MpdBHu0jVMf3MSuSdkSMHn+sNJdDQfl+x4R5R
+        # ..
+        # ..
+        # mBynFpdjO0D3PnLKjnBDn1vFAfANOwVpGXCw5mn+484A/SIXYebWruFd03g4
+        # -----END RSA PRIVATE KEY-----
     ## @param initContainers Add additional init containers to the %%MAIN_CONTAINER_NAME%% pod(s)
     ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
     ## e.g:
@@ -597,18 +590,15 @@ bulk-api-adapter:
       ## NOTE: choose port between <30000-32767>
       ##
       nodePorts:
-        http:
-        https:
-      ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+        http: null
+        https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
       ## e.g.:
       ## clusterIP: None
       ##
-      clusterIP:
-      ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+      clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
       ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
       ##
-      loadBalancerIP:
-      ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+      loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
       ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
       ## e.g:
       ## loadBalancerSourceRanges:
@@ -641,8 +631,7 @@ bulk-api-adapter:
       pathType: ImplementationSpecific
       ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
       ##
-      apiVersion:
-      ## @param ingress.hostname Default host for the ingress record
+      apiVersion: null ## @param ingress.hostname Default host for the ingress record
       ##
       hostname: bulk-api-adapter-notification.local
       ## @param servicePort : port for the service
@@ -654,8 +643,7 @@ bulk-api-adapter:
       ## @param ingress.annotations Additional custom annotations for the ingress record
       ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
       ##
-      annotations:
-      ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+      annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
       ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
       ## You can:
       ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -675,12 +663,11 @@ bulk-api-adapter:
       ##   - name: transfer-api-svc.local
       ##     path: /
       ##
-      extraHosts:
-      extraPaths:
-      extraTls:
-      secrets:
+      extraHosts: null
+      extraPaths: null
+      extraTls: null
+      secrets: null
       className: "nginx"
-
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -705,7 +692,7 @@ bulk-centralledger:
     image:
       registry: docker.io
       repository: mojaloop/central-ledger
-      tag: v17.6.1
+      tag: v17.7.8
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -993,18 +980,15 @@ bulk-centralledger:
       ## NOTE: choose port between <30000-32767>
       ##
       nodePorts:
-        http:
-        https:
-      ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+        http: null
+        https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
       ## e.g.:
       ## clusterIP: None
       ##
-      clusterIP:
-      ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+      clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
       ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
       ##
-      loadBalancerIP:
-      ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+      loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
       ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
       ## e.g:
       ## loadBalancerSourceRanges:
@@ -1037,8 +1021,7 @@ bulk-centralledger:
       pathType: ImplementationSpecific
       ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
       ##
-      apiVersion:
-      ## @param ingress.hostname Default host for the ingress record
+      apiVersion: null ## @param ingress.hostname Default host for the ingress record
       ##
       hostname: central-ledger-transfer-bulkprepare.local
       ## @param servicePort : port for the service
@@ -1050,8 +1033,7 @@ bulk-centralledger:
       ## @param ingress.annotations Additional custom annotations for the ingress record
       ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
       ##
-      annotations:
-      ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+      annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
       ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
       ## You can:
       ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -1071,12 +1053,11 @@ bulk-centralledger:
       ##   - name: transfer-api-svc.local
       ##     path: /
       ##
-      extraHosts:
-      extraPaths:
-      extraTls:
-      secrets:
+      extraHosts: null
+      extraPaths: null
+      extraTls: null
+      secrets: null
       className: "nginx"
-
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -1098,7 +1079,7 @@ bulk-centralledger:
     image:
       registry: docker.io
       repository: mojaloop/central-ledger
-      tag: v17.6.1
+      tag: v17.7.8
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1374,18 +1355,15 @@ bulk-centralledger:
       ## NOTE: choose port between <30000-32767>
       ##
       nodePorts:
-        http:
-        https:
-      ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+        http: null
+        https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
       ## e.g.:
       ## clusterIP: None
       ##
-      clusterIP:
-      ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+      clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
       ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
       ##
-      loadBalancerIP:
-      ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+      loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
       ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
       ## e.g:
       ## loadBalancerSourceRanges:
@@ -1418,8 +1396,7 @@ bulk-centralledger:
       pathType: ImplementationSpecific
       ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
       ##
-      apiVersion:
-      ## @param ingress.hostname Default host for the ingress record
+      apiVersion: null ## @param ingress.hostname Default host for the ingress record
       ##
       hostname: central-ledger-transfer-bulkfulfil.local
       ## @param servicePort : port for the service
@@ -1431,8 +1408,7 @@ bulk-centralledger:
       ## @param ingress.annotations Additional custom annotations for the ingress record
       ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
       ##
-      annotations:
-      ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+      annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
       ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
       ## You can:
       ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -1452,12 +1428,11 @@ bulk-centralledger:
       ##   - name: transfer-api-svc.local
       ##     path: /
       ##
-      extraHosts:
-      extraPaths:
-      extraTls:
-      secrets:
+      extraHosts: null
+      extraPaths: null
+      extraTls: null
+      secrets: null
       className: "nginx"
-
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -1479,7 +1454,7 @@ bulk-centralledger:
     image:
       registry: docker.io
       repository: mojaloop/central-ledger
-      tag: v17.6.1
+      tag: v17.7.8
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1764,18 +1739,15 @@ bulk-centralledger:
       ## NOTE: choose port between <30000-32767>
       ##
       nodePorts:
-        http:
-        https:
-      ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+        http: null
+        https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
       ## e.g.:
       ## clusterIP: None
       ##
-      clusterIP:
-      ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+      clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
       ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
       ##
-      loadBalancerIP:
-      ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+      loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
       ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
       ## e.g:
       ## loadBalancerSourceRanges:
@@ -1808,8 +1780,7 @@ bulk-centralledger:
       pathType: ImplementationSpecific
       ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
       ##
-      apiVersion:
-      ## @param ingress.hostname Default host for the ingress record
+      apiVersion: null ## @param ingress.hostname Default host for the ingress record
       ##
       hostname: central-ledger-transfer-bulkprocessing.local
       ## @param servicePort : port for the service
@@ -1821,8 +1792,7 @@ bulk-centralledger:
       ## @param ingress.annotations Additional custom annotations for the ingress record
       ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
       ##
-      annotations:
-      ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+      annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
       ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
       ## You can:
       ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -1842,12 +1812,11 @@ bulk-centralledger:
       ##   - name: transfer-api-svc.local
       ##     path: /
       ##
-      extraHosts:
-      extraPaths:
-      extraTls:
-      secrets:
+      extraHosts: null
+      extraPaths: null
+      extraTls: null
+      secrets: null
       className: "nginx"
-
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -1869,7 +1838,7 @@ bulk-centralledger:
     image:
       registry: docker.io
       repository: mojaloop/central-ledger
-      tag: v17.6.1
+      tag: v17.7.8
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2154,18 +2123,15 @@ bulk-centralledger:
       ## NOTE: choose port between <30000-32767>
       ##
       nodePorts:
-        http:
-        https:
-      ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+        http: null
+        https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
       ## e.g.:
       ## clusterIP: None
       ##
-      clusterIP:
-      ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+      clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
       ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
       ##
-      loadBalancerIP:
-      ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+      loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
       ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
       ## e.g:
       ## loadBalancerSourceRanges:
@@ -2198,8 +2164,7 @@ bulk-centralledger:
       pathType: ImplementationSpecific
       ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
       ##
-      apiVersion:
-      ## @param ingress.hostname Default host for the ingress record
+      apiVersion: null ## @param ingress.hostname Default host for the ingress record
       ##
       hostname: central-ledger-transfer-bulkget.local
       ## @param servicePort : port for the service
@@ -2211,8 +2176,7 @@ bulk-centralledger:
       ## @param ingress.annotations Additional custom annotations for the ingress record
       ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
       ##
-      annotations:
-      ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+      annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
       ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
       ## You can:
       ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -2232,12 +2196,11 @@ bulk-centralledger:
       ##   - name: transfer-api-svc.local
       ##     path: /
       ##
-      extraHosts:
-      extraPaths:
-      extraTls:
-      secrets:
+      extraHosts: null
+      extraPaths: null
+      extraTls: null
+      secrets: null
       className: "nginx"
-
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/mojaloop-simulator/Chart.yaml
+++ b/mojaloop-simulator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: "Helm Chart for the Mojaloop (SDK-based) Simulator"
 name: mojaloop-simulator
-version: 15.2.1
-appVersion: "sdk-scheme-adapter: v23.4.0; mojaloop-simulator: v15.0.0; thirdparty-sdk: v15.1.1"
+version: 15.3.0
+appVersion: "sdk-scheme-adapter: v23.5.1; mojaloop-simulator: v15.0.0; thirdparty-sdk: v15.1.1"
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"

--- a/mojaloop-simulator/values.yaml
+++ b/mojaloop-simulator/values.yaml
@@ -105,13 +105,10 @@ simulators: {}
 #   to port-forward with a named port instead of a numbered port?)
 # * It is likely possible to have the user supply a CA cert + key and use those to generate and
 #   sign automatically generated per-simulator keys.
-
-
-  # Every key added to this `simulators` object will be a simulator that takes on the default
-  # config below. The default is deliberately left empty so nothing is deployed by default.
-  # payerfsp: {}
-  # payeefsp: {}
-
+# Every key added to this `simulators` object will be a simulator that takes on the default
+# config below. The default is deliberately left empty so nothing is deployed by default.
+# payerfsp: {}
+# payeefsp: {}
 defaultProbes: &defaultProbes
   livenessProbe:
     enabled: true
@@ -165,12 +162,10 @@ ingress:
 # your switch is using `FSPIOP-Source: peter` you will need a property `peter` in the following
 # object. Do not add the public keys of your simulators to this object. Instead, put them in
 # `mojaloop-simulator.simulators.$yourSimName.config.schemeAdapter.secrets.jws.publicKey`.
-sharedJWSPubKeys:
-  # switch: |-
-  #   -----BEGIN PUBLIC KEY-----
-  #   blah blah blah
-  #   -----END PUBLIC KEY-----
-
+sharedJWSPubKeys: null # switch: |-
+#   -----BEGIN PUBLIC KEY-----
+#   blah blah blah
+#   -----END PUBLIC KEY-----
 defaults:
   # Changes to this object in the parent chart, for example 'mojaloop-simulator.defaults' will be
   # applied to all simulators deployed by this child chart.
@@ -201,10 +196,7 @@ defaults:
     ##   - myRegistryKeySecretName
     ##
     imagePullSecrets: []
-
-    cache:
-
-      # These will be supplied directly to the init containers array in the deployment for the
+    cache: # These will be supplied directly to the init containers array in the deployment for the
       # scheme adapter. They should look exactly as you'd declare them inside the deployment.
       # Example: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#init-containers-in-use
       # This init container will have the same environment variables as the main backend container,
@@ -292,7 +284,7 @@ defaults:
           publicKey: ''
       image:
         repository: mojaloop/sdk-scheme-adapter
-        tag: v23.4.0
+        tag: v23.5.1
         pullPolicy: IfNotPresent
         command: '[ "yarn", "start:api-svc" ]'
       <<: *defaultProbes
@@ -642,22 +634,20 @@ defaults:
         NODE_ENV: production
         INBOUND_LISTEN_PORT: 4005
         OUTBOUND_LISTEN_PORT: 4006
-         # Path to JWS signing key (private key of THIS DFSP)
+        # Path to JWS signing key (private key of THIS DFSP)
         JWS_SIGNING_KEY_PATH: "/jwsSigningKey/private.key" # do not change this unless you know what you are doing - this will break the chart
         JWS_VERIFICATION_KEYS_DIRECTORY: "/jwsVerificationKeys"
-
     resources: {}
-      # We usually recommend not to specify default resources and to leave this as a conscious
-      # choice for the user. This also increases chances charts run on environments with little
-      # resources, such as Minikube. If you do want to specify resources, uncomment the following
-      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-      # limits:
-      #  cpu: 100m
-      #  memory: 128Mi
-      # requests:
-      #  cpu: 100m
-      #  memory: 128Mi
-
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
     ## Pod scheduling preferences.
     ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
     affinity: {}

--- a/mojaloop-ttk-simulators/Chart.yaml
+++ b/mojaloop-ttk-simulators/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: mojaloop-ttk-simulator Helm chart for Kubernetes
 name: mojaloop-ttk-simulators
 version: 2.3.0
-appVersion: "ml-testing-toolkit: v17.0.0; ml-testing-toolkit-ui: v15.4.2; sdk-scheme-adapter: v23.4.0"
+appVersion: "ml-testing-toolkit: v17.2.3; ml-testing-toolkit-ui: v15.5.0; sdk-scheme-adapter: v23.5.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop-ttk-simulators/chart-sim1/Chart.yaml
+++ b/mojaloop-ttk-simulators/chart-sim1/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mojaloop-ttk-sim1-svc
 version: 2.2.0
 description: A Helm chart for Kubernetes
-appVersion: "ml-testing-toolkit: v17.0.0; ml-testing-toolkit-ui: v15.4.2; sdk-scheme-adapter: v23.4.0"
+appVersion: "ml-testing-toolkit: v17.2.3; ml-testing-toolkit-ui: v15.5.0; sdk-scheme-adapter: v23.5.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop-ttk-simulators/chart-sim1/values.yaml
+++ b/mojaloop-ttk-simulators/chart-sim1/values.yaml
@@ -211,11 +211,11 @@ ml-testing-toolkit:
           }
         ]
       }
-      rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.4.0/test/func/config/ttk-ttksim1/spec_files/rules_response/default.json'
-      api_definitions__mojaloop_simulator_sim_1.4__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.4.0/test/func/config/ttk-ttksim1/spec_files/api_definitions/mojaloop_simulator_sim_1.4/api_spec.yaml'
-      api_definitions__mojaloop_simulator_sim_1.4__response_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.4.0/test/func/config/ttk-ttksim1/spec_files/api_definitions/mojaloop_simulator_sim_1.4/response_map.json'
-      api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.4.0/test/func/config/ttk-ttksim1/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/api_spec.yaml'
-      api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.4.0/test/func/config/ttk-ttksim1/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/callback_map.json'
+      rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.5.1/test/func/config/ttk-ttksim1/spec_files/rules_response/default.json'
+      api_definitions__mojaloop_simulator_sim_1.4__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.5.1/test/func/config/ttk-ttksim1/spec_files/api_definitions/mojaloop_simulator_sim_1.4/api_spec.yaml'
+      api_definitions__mojaloop_simulator_sim_1.4__response_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.5.1/test/func/config/ttk-ttksim1/spec_files/api_definitions/mojaloop_simulator_sim_1.4/response_map.json'
+      api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.5.1/test/func/config/ttk-ttksim1/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/api_spec.yaml'
+      api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.5.1/test/func/config/ttk-ttksim1/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/callback_map.json'
 
 
     ## @param initContainers Add additional init containers to the %%MAIN_CONTAINER_NAME%% pod(s)

--- a/mojaloop-ttk-simulators/chart-sim2/Chart.yaml
+++ b/mojaloop-ttk-simulators/chart-sim2/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mojaloop-ttk-sim2-svc
 version: 2.2.0
 description: A Helm chart for Kubernetes
-appVersion: "ml-testing-toolkit: v17.0.0; ml-testing-toolkit-ui: v15.4.2; sdk-scheme-adapter: v23.4.0"
+appVersion: "ml-testing-toolkit: v17.2.3; ml-testing-toolkit-ui: v15.5.0; sdk-scheme-adapter: v23.5.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop-ttk-simulators/chart-sim2/values.yaml
+++ b/mojaloop-ttk-simulators/chart-sim2/values.yaml
@@ -206,11 +206,11 @@ ml-testing-toolkit:
           }
         ]
       }
-      rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.4.0/test/func/config/ttk-ttksim2/spec_files/rules_response/default.json'
-      api_definitions__mojaloop_simulator_sim_1.4__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.4.0/test/func/config/ttk-ttksim2/spec_files/api_definitions/mojaloop_simulator_sim_1.4/api_spec.yaml'
-      api_definitions__mojaloop_simulator_sim_1.4__response_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.4.0/test/func/config/ttk-ttksim2/spec_files/api_definitions/mojaloop_simulator_sim_1.4/response_map.json'
-      api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.4.0/test/func/config/ttk-ttksim2/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/api_spec.yaml'
-      api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.4.0/test/func/config/ttk-ttksim2/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/callback_map.json'
+      rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.5.1/test/func/config/ttk-ttksim2/spec_files/rules_response/default.json'
+      api_definitions__mojaloop_simulator_sim_1.4__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.5.1/test/func/config/ttk-ttksim2/spec_files/api_definitions/mojaloop_simulator_sim_1.4/api_spec.yaml'
+      api_definitions__mojaloop_simulator_sim_1.4__response_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.5.1/test/func/config/ttk-ttksim2/spec_files/api_definitions/mojaloop_simulator_sim_1.4/response_map.json'
+      api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.5.1/test/func/config/ttk-ttksim2/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/api_spec.yaml'
+      api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.5.1/test/func/config/ttk-ttksim2/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/callback_map.json'
 
   ## @param initContainers Add additional init containers to the %%MAIN_CONTAINER_NAME%% pod(s)
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/

--- a/mojaloop-ttk-simulators/chart-sim3/Chart.yaml
+++ b/mojaloop-ttk-simulators/chart-sim3/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mojaloop-ttk-sim3-svc
 version: 2.2.0
 description: A Helm chart for Kubernetes
-appVersion: "ml-testing-toolkit: v17.0.0; ml-testing-toolkit-ui: v15.4.2; sdk-scheme-adapter: v23.4.0"
+appVersion: "ml-testing-toolkit: v17.2.3; ml-testing-toolkit-ui: v15.5.0; sdk-scheme-adapter: v23.5.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/mojaloop-ttk-simulators/chart-sim3/values.yaml
+++ b/mojaloop-ttk-simulators/chart-sim3/values.yaml
@@ -206,11 +206,11 @@ ml-testing-toolkit:
           }
         ]
       }
-      rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.4.0/test/func/config/ttk-ttksim3/spec_files/rules_response/default.json'
-      api_definitions__mojaloop_simulator_sim_1.4__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.4.0/test/func/config/ttk-ttksim3/spec_files/api_definitions/mojaloop_simulator_sim_1.4/api_spec.yaml'
-      api_definitions__mojaloop_simulator_sim_1.4__response_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.4.0/test/func/config/ttk-ttksim3/spec_files/api_definitions/mojaloop_simulator_sim_1.4/response_map.json'
-      api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.4.0/test/func/config/ttk-ttksim3/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/api_spec.yaml'
-      api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.4.0/test/func/config/ttk-ttksim3/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/callback_map.json'
+      rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.5.1/test/func/config/ttk-ttksim3/spec_files/rules_response/default.json'
+      api_definitions__mojaloop_simulator_sim_1.4__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.5.1/test/func/config/ttk-ttksim3/spec_files/api_definitions/mojaloop_simulator_sim_1.4/api_spec.yaml'
+      api_definitions__mojaloop_simulator_sim_1.4__response_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.5.1/test/func/config/ttk-ttksim3/spec_files/api_definitions/mojaloop_simulator_sim_1.4/response_map.json'
+      api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.5.1/test/func/config/ttk-ttksim3/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/api_spec.yaml'
+      api_definitions__mojaloop_sdk_outbound_scheme_adapter_1.0__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v23.5.1/test/func/config/ttk-ttksim3/spec_files/api_definitions/mojaloop_sdk_outbound_scheme_adapter_1.0/callback_map.json'
 
   ## @param initContainers Add additional init containers to the %%MAIN_CONTAINER_NAME%% pod(s)
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
-version: 16.0.3
+version: 16.1.0
 appVersion: "ml-api-adapter: v14.0.5; central-ledger: v17.6.1; account-lookup-service: v15.2.3; quoting-service: v15.7.0; central-settlement: v16.0.0; bulk-api-adapter: v17.0.0; transaction-requests-service: v14.1.2; simulator: v12.1.0; mojaloop-simulator: v15.0.0; sdk-scheme-adapter: v23.4.0; auth-service: v15.0.0; als-consent-oracle: v0.2.2; thirdparty-sdk: v15.1.1; ml-testing-toolkit: v17.0.0; ml-testing-toolkit-ui: v15.4.2;"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
@@ -15,7 +15,7 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: account-lookup-service
-    version: ">= 14.11.0"
+    version: ">= 14.15.0"
     repository: "file://../account-lookup-service"
     condition: account-lookup-service.enabled
   - name: quoting-service
@@ -23,35 +23,35 @@ dependencies:
     repository: "file://../quoting-service"
     condition: quoting-service.enabled
   - name: ml-api-adapter
-    version: ">= 13.6.0"
+    version: ">= 13.12.0"
     repository: "file://../ml-api-adapter"
     condition: ml-api-adapter.enabled
   - name: centralledger
-    version: ">= 14.16.0"
+    version: ">= 14.37.0"
     repository: "file://../centralledger"
     condition: centralledger.enabled
   - name: centralsettlement
-    version: ">= 14.7.0"
+    version: ">= 14.15.0"
     repository: "file://../centralsettlement"
     condition: centralsettlement.enabled
   - name: simulator
-    version: ">= 13.3.0"
+    version: ">= 13.4.0"
     repository: "file://../simulator"
     condition: simulator.enabled
   - name: mojaloop-simulator
-    version: ">= 15.2.1"
+    version: ">= 15.3.0"
     repository: "file://../mojaloop-simulator"
     condition: mojaloop-simulator.enabled
   - name: mojaloop-bulk
-    version: ">= 16.7.0"
+    version: ">= 16.17.0"
     repository: "file://../mojaloop-bulk"
     condition: mojaloop-bulk.enabled
   - name: transaction-requests-service
-    version: ">= 13.3.0"
+    version: ">= 13.5.0"
     repository: "file://../transaction-requests-service"
     condition: transaction-requests-service.enabled
   - name: thirdparty
-    version: ">= 3.6.1"
+    version: ">= 3.12.0"
     repository: "file://../thirdparty"
     condition: thirdparty.enabled
   - name: mojaloop-ttk-simulators
@@ -64,71 +64,71 @@ dependencies:
     tags:
       - moja-common
   - name: ml-testing-toolkit
-    version: ">= 17.4.0"
+    version: ">= 17.6.0"
     repository: "file://../ml-testing-toolkit"
     condition: ml-testing-toolkit.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-test-setup
-    version: ">= 15.6.0"
+    version: ">= 15.7.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-test-setup.tests.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-test-val-gp
-    version: ">= 15.6.0"
+    version: ">= 15.7.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-test-val-gp.tests.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-test-val-bulk
-    version: ">= 15.6.0"
+    version: ">= 15.7.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-test-val-bulk.tests.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-test-setup-tp
-    version: ">= 15.6.0"
+    version: ">= 15.7.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-test-setup-tp.tests.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-test-val-tp
-    version: ">= 15.6.0"
+    version: ">= 15.7.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-test-val-tp.tests.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-posthook-setup
-    version: ">= 15.6.0"
+    version: ">= 15.7.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-posthook-setup.postInstallHook.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-posthook-tests
-    version: ">= 15.6.0"
+    version: ">= 15.7.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-posthook-tests.postInstallHook.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-cronjob-tests
-    version: ">= 15.6.0"
+    version: ">= 15.7.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-cronjob-tests.scheduling.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-cronjob-cleanup
-    version: ">= 15.6.0"
+    version: ">= 15.7.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-cronjob-cleanup.scheduling.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-test-setup-sdk-bulk
-    version: ">= 15.6.0"
+    version: ">= 15.7.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-test-setup-sdk-bulk.tests.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-test-val-sdk-bulk
-    version: ">= 15.6.0"
+    version: ">= 15.7.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-test-val-sdk-bulk.tests.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-test-val-sdk-r2p
-    version: ">= 15.6.0"
+    version: ">= 15.7.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-test-val-sdk-r2p.tests.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-test-cleanup
-    version: ">= 15.6.0"
+    version: ">= 15.7.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-test-cleanup.tests.enabled

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -12984,9 +12984,9 @@ ml-testing-toolkit:
       ## We can pass the JSON content as the value for the parameters
       ## Or we can pass a http/https URL for the JSON file as the value for the parameters. Then the file will be downloaded and replaced in the corresponding location.
       ## Ex: rules_callback__default.json: "https://raw.githubusercontent.com/mojaloop/ml-testing-toolkit/master/spec_files/rules_callback/default.json"
-      rules_callback__default.json: "https://github.com/mojaloop/testing-toolkit-test-cases/raw/v16.0.0/rules/mojaloop/ml-testing-toolkit/spec_files/rules_callback/default.json"
-      rules_response__default.json: "https://github.com/mojaloop/testing-toolkit-test-cases/raw/v16.0.0/rules/mojaloop/ml-testing-toolkit/spec_files/rules_response/default.json"
-      rules_validation__default.json: "https://github.com/mojaloop/testing-toolkit-test-cases/raw/v16.0.0/rules/mojaloop/ml-testing-toolkit/spec_files/rules_validation/default.json"
+      rules_callback__default.json: "https://github.com/mojaloop/testing-toolkit-test-cases/raw/v16.1.0/rules/mojaloop/ml-testing-toolkit/spec_files/rules_callback/default.json"
+      rules_response__default.json: "https://github.com/mojaloop/testing-toolkit-test-cases/raw/v16.1.0/rules/mojaloop/ml-testing-toolkit/spec_files/rules_response/default.json"
+      rules_validation__default.json: "https://github.com/mojaloop/testing-toolkit-test-cases/raw/v16.1.0/rules/mojaloop/ml-testing-toolkit/spec_files/rules_validation/default.json"
     # We can change the names of the simulators to configure the environment files for the testing toolkit.
     # If you change these values, you need to change the simulator names in the mojaloop-simulats->simulators section
     parameters: &simNames
@@ -13017,8 +13017,8 @@ ml-ttk-posthook-setup:
     weight: -5
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
-    testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/v16.0.0.zip
-    testCasesPathInZip: &ttkGitPathSetup testing-toolkit-test-cases-16.0.0/collections/hub/provisioning
+    testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/v16.1.0.zip
+    testCasesPathInZip: &ttkGitPathSetup testing-toolkit-test-cases-16.1.0/collections/hub/provisioning
     ttkBackendURL: http://$release_name-ml-testing-toolkit-backend:5050
   parameters:
     <<: *simNames
@@ -13031,7 +13031,7 @@ ml-ttk-posthook-tests:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: &ttkGitPathGP testing-toolkit-test-cases-16.0.0/collections/hub/golden_path
+    testCasesPathInZip: &ttkGitPathGP testing-toolkit-test-cases-16.1.0/collections/hub/golden_path
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
     ttkBackendURL: http://$release_name-ml-testing-toolkit-backend:5050
@@ -13132,7 +13132,7 @@ ml-ttk-cronjob-cleanup:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: &ttkGitPathCleanup testing-toolkit-test-cases-16.0.0/collections/hub/cleanup
+    testCasesPathInZip: &ttkGitPathCleanup testing-toolkit-test-cases-16.1.0/collections/hub/cleanup
     # testCasesPathInZip: *ttkGitPathGP
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
@@ -13241,7 +13241,7 @@ ml-ttk-test-val-bulk:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: testing-toolkit-test-cases-16.0.0/collections/hub/other_tests/bulk_transfers
+    testCasesPathInZip: testing-toolkit-test-cases-16.1.0/collections/hub/other_tests/bulk_transfers
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
@@ -13286,7 +13286,7 @@ ml-ttk-test-setup-tp:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: testing-toolkit-test-cases-16.0.0/collections/hub/provisioning_thirdparty
+    testCasesPathInZip: testing-toolkit-test-cases-16.1.0/collections/hub/provisioning_thirdparty
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
@@ -13331,7 +13331,7 @@ ml-ttk-test-val-tp:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: testing-toolkit-test-cases-16.0.0/collections/hub/thirdparty
+    testCasesPathInZip: testing-toolkit-test-cases-16.1.0/collections/hub/thirdparty
     # awsS3FilePath: ttk-tests/reports
     testSuiteName: Thirdparty Tests
     environmentName: Development
@@ -13373,7 +13373,7 @@ ml-ttk-test-setup-sdk-bulk:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: testing-toolkit-test-cases-16.0.0/collections/hub/provisioning_sdkbulk
+    testCasesPathInZip: testing-toolkit-test-cases-16.1.0/collections/hub/provisioning_sdkbulk
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
@@ -13418,7 +13418,7 @@ ml-ttk-test-val-sdk-bulk:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: testing-toolkit-test-cases-16.0.0/collections/hub/sdk_scheme_adapter/bulk/basic
+    testCasesPathInZip: testing-toolkit-test-cases-16.1.0/collections/hub/sdk_scheme_adapter/bulk/basic
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
@@ -13463,7 +13463,7 @@ ml-ttk-test-val-sdk-r2p:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: testing-toolkit-test-cases-16.0.0/collections/hub/sdk_scheme_adapter/request-to-pay/basic
+    testCasesPathInZip: testing-toolkit-test-cases-16.1.0/collections/hub/sdk_scheme_adapter/request-to-pay/basic
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports

--- a/sdk-scheme-adapter/Chart.yaml
+++ b/sdk-scheme-adapter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: sdk-scheme-adapter Helm chart for Kubernetes
 name: sdk-scheme-adapter
-version: 1.8.0
-appVersion: v23.4.0
+version: 1.14.0
+appVersion: v23.5.1
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -20,21 +20,21 @@ dependencies:
     repository: "file://./chart-service"
     tags:
       - sdk-scheme-adapter
-    version: ">= 1.5.0"
+    version: ">= 1.6.0"
     condition: sdk-scheme-adapter-api-svc.enabled
   - name: sdk-scheme-adapter-svc
     alias: sdk-scheme-adapter-dom-evt-handler
     repository: "file://./chart-service"
     tags:
       - sdk-scheme-adapter
-    version: ">= 1.5.0"
+    version: ">= 1.6.0"
     condition: sdk-scheme-adapter-dom-evt-handler.enabled
   - name: sdk-scheme-adapter-svc
     alias: sdk-scheme-adapter-cmd-evt-handler
     repository: "file://./chart-service"
     tags:
       - sdk-scheme-adapter
-    version: ">= 1.5.0"
+    version: ">= 1.6.0"
     condition: sdk-scheme-adapter-cmd-evt-handler.enabled
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"

--- a/sdk-scheme-adapter/chart-service/Chart.yaml
+++ b/sdk-scheme-adapter/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: sdk-scheme-adapter-svc
-version: 1.5.0
+version: 1.6.0
 description: A Helm chart for Kubernetes
-appVersion: v23.4.0
+appVersion: v23.5.1
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/sdk-scheme-adapter/chart-service/values.yaml
+++ b/sdk-scheme-adapter/chart-service/values.yaml
@@ -173,14 +173,12 @@ env:
   OAUTH_TOKEN_ENDPOINT_CLIENT_KEY: test-client-key
   OAUTH_TOKEN_ENDPOINT_CLIENT_SECRET: test-client-secret
   OAUTH_TOKEN_ENDPOINT_LISTEN_PORT: 6000
-
   # WSO2 Bearer Token specific to golden-fsp instance and environment
   WSO2_BEARER_TOKEN: 7718fa9b-be13-3fe7-87f0-a12cf1628168
-
   # OAuth2 data used to obtain WSO2 bearer token
-  OAUTH_TOKEN_ENDPOINT:
-  OAUTH_CLIENT_KEY:
-  OAUTH_CLIENT_SECRET:
+  OAUTH_TOKEN_ENDPOINT: null
+  OAUTH_CLIENT_KEY: null
+  OAUTH_CLIENT_SECRET: null
   OAUTH_REFRESH_SECONDS: 3600
   # use these instead of OAUTH_CLIENT_SECRET when secret is stored as k8s secret
   # OAUTH_CLIENT_SECRET_KEY:
@@ -308,7 +306,7 @@ containerSecurityContext:
 image:
   registry: docker.io
   repository: mojaloop/sdk-scheme-adapter
-  tag: v23.4.0
+  tag: v23.5.1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -473,17 +471,15 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP:
-  ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
-  ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
-  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-  ## e.g:
-  ## loadBalancerSourceRanges:
-  ##   - 10.10.10.0/24
-  ##
+  clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+##
+  loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+## e.g:
+## loadBalancerSourceRanges:
+##   - 10.10.10.0/24
+##
   loadBalancerSourceRanges: []
   ## @param service.externalTrafficPolicy %%MAIN_CONTAINER_NAME%% service external traffic policy
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
@@ -513,9 +509,8 @@ ingress:
   pathType: ImplementationSpecific
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
-  apiVersion:
-  ## @param ingress.hostname Default host for the ingress record
-  ##
+  apiVersion: null ## @param ingress.hostname Default host for the ingress record
+##
   hostname: sdk-scheme-adapter.local
   ## @param ingress.path Default path for the ingress record
   ## NOTE: You may need to set this to '/*' in order to use this with ALB ingress controllers

--- a/sdk-scheme-adapter/values.yaml
+++ b/sdk-scheme-adapter/values.yaml
@@ -289,7 +289,7 @@ sdk-scheme-adapter-api-svc:
   image:
     registry: docker.io
     repository: mojaloop/sdk-scheme-adapter
-    tag: v23.4.0
+    tag: v23.5.1
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -442,18 +442,15 @@ sdk-scheme-adapter-api-svc:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -488,8 +485,7 @@ sdk-scheme-adapter-api-svc:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: sdk-scheme-adapter.local
     ## @param ingress.path Default path for the ingress record
@@ -709,7 +705,7 @@ sdk-scheme-adapter-dom-evt-handler:
   image:
     registry: docker.io
     repository: mojaloop/sdk-scheme-adapter
-    tag: v23.4.0
+    tag: v23.5.1
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -863,18 +859,15 @@ sdk-scheme-adapter-dom-evt-handler:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -909,8 +902,7 @@ sdk-scheme-adapter-dom-evt-handler:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: sdk-scheme-adapter.local
     ## @param ingress.path Default path for the ingress record
@@ -986,9 +978,9 @@ sdk-scheme-adapter-dom-evt-handler:
     #       name: '{{ include "common.names.fullname" . }}'
     #       port:
     #         name: testapi
-        ## This is required for
-        # serviceName: '{{ include "common.names.fullname" . }}'
-        # servicePort: testapi
+    ## This is required for
+    # serviceName: '{{ include "common.names.fullname" . }}'
+    # servicePort: testapi
     ## @param ingress.extraTls TLS configuration for additional hostname(s) to be covered with this ingress record
     ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
     ## e.g:
@@ -1132,7 +1124,7 @@ sdk-scheme-adapter-cmd-evt-handler:
   image:
     registry: docker.io
     repository: mojaloop/sdk-scheme-adapter
-    tag: v23.4.0
+    tag: v23.5.1
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1286,18 +1278,15 @@ sdk-scheme-adapter-cmd-evt-handler:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -1332,8 +1321,7 @@ sdk-scheme-adapter-cmd-evt-handler:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: sdk-scheme-adapter.local
     ## @param ingress.path Default path for the ingress record
@@ -1409,9 +1397,9 @@ sdk-scheme-adapter-cmd-evt-handler:
     #       name: '{{ include "common.names.fullname" . }}'
     #       port:
     #         name: testapi
-        ## This is required for
-        # serviceName: '{{ include "common.names.fullname" . }}'
-        # servicePort: testapi
+    ## This is required for
+    # serviceName: '{{ include "common.names.fullname" . }}'
+    # servicePort: testapi
     ## @param ingress.extraTls TLS configuration for additional hostname(s) to be covered with this ingress record
     ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
     ## e.g:

--- a/simulator/Chart.yaml
+++ b/simulator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Simulator Helm Chart for Simulators
 name: simulator
-version: 13.3.0
-appVersion: v12.1.0
+version: 13.4.0
+appVersion: v12.2.0
 maintainers:
   - name: Miguel de Barros
     email: miguel.debarros@modusbox.com

--- a/simulator/values.yaml
+++ b/simulator/values.yaml
@@ -5,7 +5,7 @@
 image:
   registry: docker.io
   repository: mojaloop/simulator
-  tag: v12.1.0
+  tag: v12.2.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -149,11 +149,11 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP: null 
+  clusterIP: null
   ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
   ##
-  loadBalancerIP: null 
+  loadBalancerIP: null
   ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
   ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
   ## e.g:
@@ -187,9 +187,9 @@ ingress:
   pathType: ImplementationSpecific
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
-  apiVersion: null 
-## @param ingress.hostname Default host for the ingress record
-##
+  apiVersion: null
+  ## @param ingress.hostname Default host for the ingress record
+  ##
   hostname: moja-simulator.local
   ## @param servicePort : port for the service
   ##
@@ -200,14 +200,14 @@ ingress:
   ## @param ingress.annotations Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
-  annotations: null 
-## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
-## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
-## You can:
-##   - Use the `ingress.secrets` parameter to create this TLS secret
-##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
-##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
-##
+  annotations: null
+  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+  ## You can:
+  ##   - Use the `ingress.secrets` parameter to create this TLS secret
+  ##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
+  ##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
+  ##
   tls: false
   ## @param ingress.certManager Add the corresponding annotations for cert-manager integration
   ##

--- a/thirdparty/Chart.yaml
+++ b/thirdparty/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: thirdparty
-version: 3.6.1
+version: 3.12.0
 description: Third Party API Support for Mojaloop
-appVersion: "auth-service: v15.0.0; als-consent-oracle: v0.2.2; thirdparty-sdk: v15.1.1"
+appVersion: "auth-service: v15.1.0; als-consent-oracle: v0.2.2; thirdparty-sdk: v15.1.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -16,7 +16,7 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: auth-svc
-    version: ">= 3.3.0"
+    version: ">= 3.4.0"
     repository: "file://./chart-auth-svc"
     condition: auth-svc.enabled
   - name: consent-oracle
@@ -24,12 +24,12 @@ dependencies:
     repository: "file://./chart-consent-oracle"
     condition: consent-oracle.enabled
   - name: tp-api-svc
-    version: ">= 3.3.0"
+    version: ">= 3.4.0"
     repository: "file://./chart-tp-api-svc"
     condition: tp-api-svc.enabled
   - name: mojaloop-simulator
     alias: thirdparty-simulator
-    version: ">= 15.2.1"
+    version: ">= 15.3.0"
     repository: "file://../mojaloop-simulator"
     condition: mojaloop-simulator.enabled
   - name: common

--- a/thirdparty/chart-auth-svc/Chart.yaml
+++ b/thirdparty/chart-auth-svc/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: auth-svc chart for Mojaloop Thirdparty Services
 name: auth-svc
-version: 3.3.0
-appVersion: v15.0.0
+version: 3.4.0
+appVersion: v15.1.0
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/thirdparty/chart-auth-svc/values.yaml
+++ b/thirdparty/chart-auth-svc/values.yaml
@@ -3,7 +3,7 @@ enabled: true
 image:
   registry: docker.io
   repository: mojaloop/auth-service
-  tag: v15.0.0
+  tag: v15.1.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -29,7 +29,7 @@ diagnosticMode:
   enabled: false
   ## @param diagnosticMode.command Command to override all containers in the deployment
   ##
-  command: 
+  command:
     - node
     - ./dist/src/cli.js
     - all
@@ -37,7 +37,6 @@ diagnosticMode:
   ##
   args:
     - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-  
   ## @param diagnosticMode.debug config to override all debug information
   ##
   debug:
@@ -108,10 +107,9 @@ config:
   ## Redis Configuration
   redis_host: 6379
   redis_port: auth-svc-redis-svc
-
 ## Svc config files
 config_files:
-  production.json: | 
+  production.json: |
     {
       "PORT": {{ .Values.service.internalPort }},
       "HOST": "0.0.0.0",
@@ -299,17 +297,15 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP:
-  ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
-  ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
-  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-  ## e.g:
-  ## loadBalancerSourceRanges:
-  ##   - 10.10.10.0/24
-  ##
+  clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+##
+  loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+## e.g:
+## loadBalancerSourceRanges:
+##   - 10.10.10.0/24
+##
   loadBalancerSourceRanges: []
   ## @param service.externalTrafficPolicy %%MAIN_CONTAINER_NAME%% service external traffic policy
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
@@ -339,9 +335,8 @@ ingress:
   pathType: ImplementationSpecific
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
-  apiVersion:
-  ## @param ingress.hostname Default host for the ingress record
-  ##
+  apiVersion: null ## @param ingress.hostname Default host for the ingress record
+##
   hostname: auth-service.local
   ## @param ingress.path Default path for the ingress record
   ## NOTE: You may need to set this to '/*' in order to use this with ALB ingress controllers

--- a/thirdparty/chart-tp-api-svc/Chart.yaml
+++ b/thirdparty/chart-tp-api-svc/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Thirdparty API Service chart for Mojaloop Thirdparty Overlay Services
 name: tp-api-svc
-version: 3.3.0
-appVersion: v14.0.0
+version: 3.4.0
+appVersion: v15.0.0
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/thirdparty/chart-tp-api-svc/values.yaml
+++ b/thirdparty/chart-tp-api-svc/values.yaml
@@ -3,7 +3,7 @@ enabled: true
 image:
   registry: docker.io
   repository: mojaloop/thirdparty-api-svc
-  tag: v14.0.0
+  tag: v15.0.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -29,7 +29,7 @@ diagnosticMode:
   enabled: false
   ## @param diagnosticMode.command Command to override all containers in the deployment
   ##
-  command: 
+  command:
     - node
     - ./dist/src/cli.js
     - all
@@ -37,7 +37,6 @@ diagnosticMode:
   ##
   args:
     - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-  
   ## @param diagnosticMode.debug config to override all debug information
   ##
   debug:
@@ -78,16 +77,13 @@ tolerations: []
 containerSecurityContext:
   enabled: true
   runAsUser: 1001
-
 # Add exta environment variables here
 env: []
-  # e.g. to change the Log Level:
-  # - name: LOG_LEVEL
-  #   value: debug
-
+# e.g. to change the Log Level:
+# - name: LOG_LEVEL
+#   value: debug
 ## Svc configs
 config: {}
-
 ## Svc config files
 config_files:
   default.json: |
@@ -169,17 +165,15 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP:
-  ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
-  ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
-  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-  ## e.g:
-  ## loadBalancerSourceRanges:
-  ##   - 10.10.10.0/24
-  ##
+  clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+##
+  loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+## e.g:
+## loadBalancerSourceRanges:
+##   - 10.10.10.0/24
+##
   loadBalancerSourceRanges: []
   ## @param service.externalTrafficPolicy %%MAIN_CONTAINER_NAME%% service external traffic policy
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
@@ -209,9 +203,8 @@ ingress:
   pathType: ImplementationSpecific
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
-  apiVersion:
-  ## @param ingress.hostname Default host for the ingress record
-  ##
+  apiVersion: null ## @param ingress.hostname Default host for the ingress record
+##
   hostname: tp-api-svc.local
   ## @param ingress.path Default path for the ingress record
   ## NOTE: You may need to set this to '/*' in order to use this with ALB ingress controllers

--- a/thirdparty/values.yaml
+++ b/thirdparty/values.yaml
@@ -4,7 +4,7 @@ auth-svc:
   image:
     registry: docker.io
     repository: mojaloop/auth-service
-    tag: v15.0.0
+    tag: v15.1.0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -30,7 +30,7 @@ auth-svc:
     enabled: false
     ## @param diagnosticMode.command Command to override all containers in the deployment
     ##
-    command: 
+    command:
       - node
       - ./dist/src/cli.js
       - all
@@ -38,7 +38,6 @@ auth-svc:
     ##
     args:
       - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-    
     ## @param diagnosticMode.debug config to override all debug information
     ##
     debug:
@@ -109,10 +108,9 @@ auth-svc:
     ## Redis Configuration
     redis_host: 6379
     redis_port: auth-svc-redis-svc
-
   ## Svc config files
   config_files:
-    production.json: | 
+    production.json: |
       {
         "PORT": {{ .Values.service.internalPort }},
         "HOST": "0.0.0.0",
@@ -295,18 +293,15 @@ auth-svc:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -341,8 +336,7 @@ auth-svc:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: auth-service.local
     ## @param ingress.path Default path for the ingress record
@@ -446,14 +440,13 @@ consent-oracle:
     enabled: false
     ## @param diagnosticMode.command Command to override all containers in the deployment
     ##
-    command: 
+    command:
       - node
       - ./dist/src/cli.js
     ## @param diagnosticMode.args Args to override all containers in the deployment
     ##
     args:
       - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-    
     ## @param diagnosticMode.debug config to override all debug information
     ##
     debug:
@@ -494,13 +487,11 @@ consent-oracle:
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
-
   # Add exta environment variables here
   env: []
-    # e.g.
-    # - name: LOG_LEVEL
-    #   value: debug
-
+  # e.g.
+  # - name: LOG_LEVEL
+  #   value: debug
   ## Svc configs
   config:
     ## DB Configuration
@@ -636,18 +627,15 @@ consent-oracle:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -682,8 +670,7 @@ consent-oracle:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: consent-oracle.local
     ## @param ingress.path Default path for the ingress record
@@ -761,7 +748,7 @@ tp-api-svc:
   image:
     registry: docker.io
     repository: mojaloop/thirdparty-api-svc
-    tag: v14.0.0
+    tag: v15.0.0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -787,7 +774,7 @@ tp-api-svc:
     enabled: false
     ## @param diagnosticMode.command Command to override all containers in the deployment
     ##
-    command: 
+    command:
       - node
       - ./dist/src/cli.js
       - all
@@ -795,7 +782,6 @@ tp-api-svc:
     ##
     args:
       - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-    
     ## @param diagnosticMode.debug config to override all debug information
     ##
     debug:
@@ -836,16 +822,13 @@ tp-api-svc:
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
-
   # Add exta environment variables here
   env: []
-    # e.g. to change the Log Level:
-    # - name: LOG_LEVEL
-    #   value: debug
-
+  # e.g. to change the Log Level:
+  # - name: LOG_LEVEL
+  #   value: debug
   ## Svc configs
   config: {}
-
   ## Svc config files
   config_files:
     default.json: |
@@ -922,18 +905,15 @@ tp-api-svc:
     ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
-      http:
-      https:
-    ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
+      http: null
+      https: null ## @param service.clusterIP %%MAIN_CONTAINER_NAME%% service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
-    clusterIP:
-    ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+    clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
-    loadBalancerIP:
-    ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+    loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
@@ -968,8 +948,7 @@ tp-api-svc:
     pathType: ImplementationSpecific
     ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
     ##
-    apiVersion:
-    ## @param ingress.hostname Default host for the ingress record
+    apiVersion: null ## @param ingress.hostname Default host for the ingress record
     ##
     hostname: tp-api-svc.local
     ## @param ingress.path Default path for the ingress record
@@ -1155,96 +1134,7 @@ thirdparty-simulator:
       config:
         thirdpartysdk:
           enabled: true
-          config: {
-            production.json: {
-              "control": {
-                "mgmtAPIWsUrl": "127.0.0.1",
-                "mgmtAPIWsPort": 4010
-              },
-              "inbound": {
-                "port": 4005,
-                "host": "0.0.0.0",
-                "pispTransactionMode": true,
-                "tls": {
-                  "mutualTLS": {
-                    "enabled": false
-                  },
-                  "creds": {
-                    "ca": "/secrets/dfsp_or_3ppi_client_cacert.pem",
-                    "cert": "/secrets/dfsp_or_3ppi_server_cert.pem",
-                    "key": "/secrets/dfsp_or_3ppi_server_key.key"
-                  }
-                }
-              },
-              "outbound": {
-                "port": 4006,
-                "host": "0.0.0.0",
-                "tls": {
-                  "mutualTLS": {
-                    "enabled": false
-                  },
-                  "creds": {
-                    "ca": "/secrets/hub_server_cacert.pem",
-                    "cert": "/secrets/dfsp_or_3ppi_client_cert.cer",
-                    "key": "/secrets/dfsp_or_3ppi_client_key.key"
-                  }
-                }
-              },
-              "requestProcessingTimeoutSeconds": 30,
-              "wso2": {
-                "auth": {
-                  "staticToken": "test-static-token",
-                  "tokenEndpoint": "",
-                  "clientKey": "test-client-key",
-                  "clientSecret": "test-client-secret",
-                  "refreshSeconds": 3600
-                }
-              },
-              "redis": {
-                "port": 6379,
-                "timeout": 100
-              },
-              "inspect": {
-                "depth": 4,
-                "showHidden": false,
-                "color": true
-              },
-              "shared": {
-                "authServiceParticipantId": "centralauth",
-                "thirdpartyRequestsEndpoint": "$release_name-tp-api-svc",
-                "servicesEndpoint": "$release_name-tp-api-svc",
-                "alsEndpoint": "$release_name-account-lookup-service",
-                "quotesEndpoint": "$release_name-quoting-service",
-                "transfersEndpoint": "$release_name-ml-api-adapter-service",
-                "dfspId": "$name",
-                "dfspBackendUri": "$full_name-backend:3000",
-                "dfspBackendHttpScheme": "http",
-                "dfspBackendVerifyAuthorizationPath": "verify-authorization",
-                "dfspBackendVerifyConsentPath": "verify-consent",
-                "sdkRequestToPayTransferUri": "0.0.0.0:3000/requestToPayTransfer",
-                "sdkOutgoingUri": "$full_name-scheme-adapter:4001",
-                "sdkOutgoingHttpScheme": "http",
-                "sdkOutgoingPartiesInformationPath": "parties/{Type}/{ID}/{SubId}",
-                "sdkNotifyAboutTransferUri": "ml-testing-toolkit:4040/thirdpartyRequests/transactions/{ID}",
-                "tempOverrideQuotesPartyIdType": "MSISDN",
-                "testShouldOverrideConsentId": true,
-                "testConsentRequestToConsentMap": {
-                    "76059a0a-684f-4002-a880-b01159afe119": "76059a0a-684f-4002-a880-b01159afe119",
-                    "6bf07f98-cfce-45ba-b048-7a86bac45d79": "be433b9e-9473-4b7d-bdd5-ac5b42463afb",
-                    "c51ec534-ee48-4575-b6a9-ead2955b8069": "46876aac-5db8-4353-bb3c-a6a905843ce7",
-                    "d51ec534-ee48-4575-b6a9-ead2955b8069": "23b07761-6b41-442a-b3d5-d876a6ea9ecc",
-                    "b5d6206c-4f06-497d-af15-ed866ea6958f": "2acf1dfa-ce45-486e-b19e-ae4ad9804a63"
-                  },
-                "testOverrideTransactionChallenge": "OWZhYjAxZTcwYjU4YzRhMzRmOWQwNzBmZjllZDFiNjc2NWVhMzA1NGI1MWZjZThjZGFjNDEyZDBmNmM2MWFhMQ"
-              },
-              "pm4mlEnabled": false,
-              "validateInboundJws": false,
-              "jwsSign": false,
-              "jwsSigningKey": "/jwsSigningKey.key",
-              "jwsVerificationKeysDirectory": null
-            }
-          }
-
+          config: {production.json: {"control": {"mgmtAPIWsUrl": "127.0.0.1", "mgmtAPIWsPort": 4010}, "inbound": {"port": 4005, "host": "0.0.0.0", "pispTransactionMode": true, "tls": {"mutualTLS": {"enabled": false}, "creds": {"ca": "/secrets/dfsp_or_3ppi_client_cacert.pem", "cert": "/secrets/dfsp_or_3ppi_server_cert.pem", "key": "/secrets/dfsp_or_3ppi_server_key.key"}}}, "outbound": {"port": 4006, "host": "0.0.0.0", "tls": {"mutualTLS": {"enabled": false}, "creds": {"ca": "/secrets/hub_server_cacert.pem", "cert": "/secrets/dfsp_or_3ppi_client_cert.cer", "key": "/secrets/dfsp_or_3ppi_client_key.key"}}}, "requestProcessingTimeoutSeconds": 30, "wso2": {"auth": {"staticToken": "test-static-token", "tokenEndpoint": "", "clientKey": "test-client-key", "clientSecret": "test-client-secret", "refreshSeconds": 3600}}, "redis": {"port": 6379, "timeout": 100}, "inspect": {"depth": 4, "showHidden": false, "color": true}, "shared": {"authServiceParticipantId": "centralauth", "thirdpartyRequestsEndpoint": "$release_name-tp-api-svc", "servicesEndpoint": "$release_name-tp-api-svc", "alsEndpoint": "$release_name-account-lookup-service", "quotesEndpoint": "$release_name-quoting-service", "transfersEndpoint": "$release_name-ml-api-adapter-service", "dfspId": "$name", "dfspBackendUri": "$full_name-backend:3000", "dfspBackendHttpScheme": "http", "dfspBackendVerifyAuthorizationPath": "verify-authorization", "dfspBackendVerifyConsentPath": "verify-consent", "sdkRequestToPayTransferUri": "0.0.0.0:3000/requestToPayTransfer", "sdkOutgoingUri": "$full_name-scheme-adapter:4001", "sdkOutgoingHttpScheme": "http", "sdkOutgoingPartiesInformationPath": "parties/{Type}/{ID}/{SubId}", "sdkNotifyAboutTransferUri": "ml-testing-toolkit:4040/thirdpartyRequests/transactions/{ID}", "tempOverrideQuotesPartyIdType": "MSISDN", "testShouldOverrideConsentId": true, "testConsentRequestToConsentMap": {"76059a0a-684f-4002-a880-b01159afe119": "76059a0a-684f-4002-a880-b01159afe119", "6bf07f98-cfce-45ba-b048-7a86bac45d79": "be433b9e-9473-4b7d-bdd5-ac5b42463afb", "c51ec534-ee48-4575-b6a9-ead2955b8069": "46876aac-5db8-4353-bb3c-a6a905843ce7", "d51ec534-ee48-4575-b6a9-ead2955b8069": "23b07761-6b41-442a-b3d5-d876a6ea9ecc", "b5d6206c-4f06-497d-af15-ed866ea6958f": "2acf1dfa-ce45-486e-b19e-ae4ad9804a63"}, "testOverrideTransactionChallenge": "OWZhYjAxZTcwYjU4YzRhMzRmOWQwNzBmZjllZDFiNjc2NWVhMzA1NGI1MWZjZThjZGFjNDEyZDBmNmM2MWFhMQ"}, "pm4mlEnabled": false, "validateInboundJws": false, "jwsSign": false, "jwsSigningKey": "/jwsSigningKey.key", "jwsVerificationKeysDirectory": null}}
         schemeAdapter:
           secrets:
             jws:
@@ -1987,12 +1877,10 @@ thirdparty-simulator:
   # your switch is using `FSPIOP-Source: peter` you will need a property `peter` in the following
   # object. Do not add the public keys of your simulators to this object. Instead, put them in
   # `mojaloop-simulator.simulators.$yourSimName.config.schemeAdapter.secrets.jws.publicKey`.
-  sharedJWSPubKeys:
-    # switch: |-
-    #   -----BEGIN PUBLIC KEY-----
-    #   blah blah blah
-    #   -----END PUBLIC KEY-----
-
+  sharedJWSPubKeys: null # switch: |-
+  #   -----BEGIN PUBLIC KEY-----
+  #   blah blah blah
+  #   -----END PUBLIC KEY-----
   defaults:
     # Changes to this object in the parent chart, for example 'mojaloop-simulator.defaults' will be
     # applied to all simulators deployed by this child chart.
@@ -2009,10 +1897,7 @@ thirdparty-simulator:
       ##   - myRegistryKeySecretName
       ##
       imagePullSecrets: []
-
-      cache:
-
-        # These will be supplied directly to the init containers array in the deployment for the
+      cache: # These will be supplied directly to the init containers array in the deployment for the
         # scheme adapter. They should look exactly as you'd declare them inside the deployment.
         # Example: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#init-containers-in-use
         # This init container will have the same environment variables as the main backend container,
@@ -2063,7 +1948,7 @@ thirdparty-simulator:
             publicKey: ''
         image:
           repository: mojaloop/sdk-scheme-adapter
-          tag: v23.4.0
+          tag: v23.5.1
           pullPolicy: IfNotPresent
           command: '[ "yarn", "start:api-svc" ]'
         <<: *defaultProbes
@@ -2386,85 +2271,8 @@ thirdparty-simulator:
                 target:
                   type: Utilization
                   averageUtilization: 80
-        config: 
-            production.json: {
-                "control": {
-                  "mgmtAPIWsUrl": "127.0.0.1",
-                  "mgmtAPIWsPort": 4010
-                },
-                "inbound": {
-                  "port": 4005,
-                  "host": "0.0.0.0",
-                  "pispTransactionMode": true,
-                  "tls": {
-                    "mutualTLS": {
-                      "enabled": false
-                    },
-                    "creds": {
-                      "ca": "/secrets/dfsp_or_3ppi_client_cacert.pem",
-                      "cert": "/secrets/dfsp_or_3ppi_server_cert.pem",
-                      "key": "/secrets/dfsp_or_3ppi_server_key.key"
-                    }
-                  }
-                },
-                "outbound": {
-                  "port": 4006,
-                  "host": "0.0.0.0",
-                  "tls": {
-                    "mutualTLS": {
-                      "enabled": false
-                    },
-                    "creds": {
-                      "ca": "/secrets/hub_server_cacert.pem",
-                      "cert": "/secrets/dfsp_or_3ppi_client_cert.cer",
-                      "key": "/secrets/dfsp_or_3ppi_client_key.key"
-                    }
-                  }
-                },
-                "requestProcessingTimeoutSeconds": 30,
-                "wso2": {
-                  "auth": {
-                    "staticToken": "test-static-token",
-                    "tokenEndpoint": "",
-                    "clientKey": "test-client-key",
-                    "clientSecret": "test-client-secret",
-                    "refreshSeconds": 3600
-                  }
-                },
-                "redis": {
-                  "port": 6379,
-                  "timeout": 100
-                },
-                "inspect": {
-                  "depth": 4,
-                  "showHidden": false,
-                  "color": true
-                },
-                "shared": {
-                  "authServiceParticipantId": "centralauth",
-                  "thirdpartyRequestsEndpoint": "$release_name-tp-api-svc",
-                  "servicesEndpoint": "$release_name-tp-api-svc",
-                  "alsEndpoint": "$release_name-account-lookup-service",
-                  "quotesEndpoint": "$release_name-quoting-service",
-                  "transfersEndpoint": "$release_name-ml-api-adapter-service",
-                  "dfspId": "$name",
-                  "dfspBackendUri": "$full_name-backend:3000",
-                  "dfspBackendHttpScheme": "http",
-                  "dfspBackendVerifyAuthorizationPath": "verify-authorization",
-                  "dfspBackendVerifyConsentPath": "verify-consent",
-                  "sdkRequestToPayTransferUri": "0.0.0.0:3000/requestToPayTransfer",
-                  "sdkOutgoingUri": "$full_name-scheme-adapter:4001",
-                  "sdkOutgoingHttpScheme": "http",
-                  "sdkOutgoingPartiesInformationPath": "parties/{Type}/{ID}/{SubId}",
-                  "sdkNotifyAboutTransferUri": "ml-testing-toolkit:4040/thirdpartyRequests/transactions/{ID}"
-                },
-                "pm4mlEnabled": false,
-                "validateInboundJws": false,
-                "jwsSign": false,
-                "jwsSigningKey": "/jwsSigningKey.key",
-                "jwsVerificationKeysDirectory": null
-              }
-
+        config:
+            production.json: {"control": {"mgmtAPIWsUrl": "127.0.0.1", "mgmtAPIWsPort": 4010}, "inbound": {"port": 4005, "host": "0.0.0.0", "pispTransactionMode": true, "tls": {"mutualTLS": {"enabled": false}, "creds": {"ca": "/secrets/dfsp_or_3ppi_client_cacert.pem", "cert": "/secrets/dfsp_or_3ppi_server_cert.pem", "key": "/secrets/dfsp_or_3ppi_server_key.key"}}}, "outbound": {"port": 4006, "host": "0.0.0.0", "tls": {"mutualTLS": {"enabled": false}, "creds": {"ca": "/secrets/hub_server_cacert.pem", "cert": "/secrets/dfsp_or_3ppi_client_cert.cer", "key": "/secrets/dfsp_or_3ppi_client_key.key"}}}, "requestProcessingTimeoutSeconds": 30, "wso2": {"auth": {"staticToken": "test-static-token", "tokenEndpoint": "", "clientKey": "test-client-key", "clientSecret": "test-client-secret", "refreshSeconds": 3600}}, "redis": {"port": 6379, "timeout": 100}, "inspect": {"depth": 4, "showHidden": false, "color": true}, "shared": {"authServiceParticipantId": "centralauth", "thirdpartyRequestsEndpoint": "$release_name-tp-api-svc", "servicesEndpoint": "$release_name-tp-api-svc", "alsEndpoint": "$release_name-account-lookup-service", "quotesEndpoint": "$release_name-quoting-service", "transfersEndpoint": "$release_name-ml-api-adapter-service", "dfspId": "$name", "dfspBackendUri": "$full_name-backend:3000", "dfspBackendHttpScheme": "http", "dfspBackendVerifyAuthorizationPath": "verify-authorization", "dfspBackendVerifyConsentPath": "verify-consent", "sdkRequestToPayTransferUri": "0.0.0.0:3000/requestToPayTransfer", "sdkOutgoingUri": "$full_name-scheme-adapter:4001", "sdkOutgoingHttpScheme": "http", "sdkOutgoingPartiesInformationPath": "parties/{Type}/{ID}/{SubId}", "sdkNotifyAboutTransferUri": "ml-testing-toolkit:4040/thirdpartyRequests/transactions/{ID}"}, "pm4mlEnabled": false, "validateInboundJws": false, "jwsSign": false, "jwsSigningKey": "/jwsSigningKey.key", "jwsVerificationKeysDirectory": null}
         env:
           NODE_ENV: production
           INBOUND_LISTEN_PORT: 4005
@@ -2482,19 +2290,17 @@ thirdparty-simulator:
       #  - secretName: chart-example-tls
       #    hosts:
       #      - chart-example.local
-
     resources: {}
-      # We usually recommend not to specify default resources and to leave this as a conscious
-      # choice for the user. This also increases chances charts run on environments with little
-      # resources, such as Minikube. If you do want to specify resources, uncomment the following
-      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-      # limits:
-      #  cpu: 100m
-      #  memory: 128Mi
-      # requests:
-      #  cpu: 100m
-      #  memory: 128Mi
-
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
     ## Pod scheduling preferences.
     ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
     affinity: {}
@@ -2502,7 +2308,6 @@ thirdparty-simulator:
     ## Node labels for pod assignment
     ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
     nodeSelector: {}
-
     ## Set toleration for scheduler
     ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
     tolerations: []

--- a/transaction-requests-service/Chart.yaml
+++ b/transaction-requests-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Transaction-Requests-Service Helm chart for Kubernetes
 name: transaction-requests-service
-version: 13.3.0
+version: 13.5.0
 appVersion: "14.1.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png

--- a/transaction-requests-service/values.yaml
+++ b/transaction-requests-service/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/transaction-requests-service
-  tag: v14.1.2
+  tag: v14.2.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -99,7 +99,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.0
+    tag: v14.0.1
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:
@@ -208,12 +208,10 @@ service:
   ## e.g.:
   ## clusterIP: None
   ##
-  clusterIP:
-  ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
+  clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
   ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
+  loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
   ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
   ## e.g:
   ## loadBalancerSourceRanges:
@@ -246,8 +244,7 @@ ingress:
   pathType: ImplementationSpecific
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
-  apiVersion:
-  ## @param ingress.hostname Default host for the ingress record
+  apiVersion: null ## @param ingress.hostname Default host for the ingress record
   ##
   hostname: transaction-request-service.local
   ## @param servicePort : port for the service
@@ -259,8 +256,7 @@ ingress:
   ## @param ingress.annotations Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
-  annotations:
-  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+  annotations: null ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
   ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
   ## You can:
   ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -280,12 +276,11 @@ ingress:
   ##   - name: transfer-api-svc.local
   ##     path: /
   ##
-  extraHosts:
-  extraPaths:
-  extraTls:
-  secrets:
+  extraHosts: null
+  extraPaths: null
+  extraTls: null
+  secrets: null
   className: "nginx"
-
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
# Helm Release Notes

Date | Revision | Description
---------|----------|---------
2024-07-09 | 0 | Initial draft

## 0. Summary

Enhancements and breaking changes to the [v16.0.0 Release](https://github.com/mojaloop/helm/blob/main/.changelog/release-v16.0.0.md), which includes:

_Release summary points go here..._

## 1. New Features
* **mojaloop/#3984** update ci, deps and audit ([mojaloop/#135](https://github.com/mojaloop/auth-service/pull/135)), closes [mojaloop/#3984](https://github.com/mojaloop/project/issues/3984)
* **mojaloop/#109** parameterize switch id ([mojaloop/#109](https://github.com/mojaloop/bulk-api-adapter/pull/109)), closes [mojaloop/#109](https://github.com/mojaloop/project/issues/109)
* **mojaloop/#: used https.Agent for WSO2 requests in api-svc (** used https.Agent for WSO2 requests in api-svc ([mojaloop/#457](https://github.com/mojaloop/sdk-scheme-adapter/pull/457)), closes [mojaloop/#: used https.Agent for WSO2 requests in api-svc (](https://github.com/mojaloop/project/issues/: used https.Agent for WSO2 requests in api-svc ()
* **mojaloop/#260** parameterize switch id ([mojaloop/#260](https://github.com/mojaloop/simulator/pull/260)), closes [mojaloop/#260](https://github.com/mojaloop/project/issues/260)
* **mojaloop/#3984** parameterize switch id ([mojaloop/#94](https://github.com/mojaloop/thirdparty-api-svc/pull/94)), closes [mojaloop/#3984](https://github.com/mojaloop/project/issues/3984)
* **mojaloop/#103** parameterize switch id ([mojaloop/#103](https://github.com/mojaloop/transaction-requests-service/pull/103)), closes [mojaloop/#103](https://github.com/mojaloop/project/issues/103)

## 2. Bug Fixes
* **mojaloop/#3829** added jwsSigner defining to PUT /participants callback ([mojaloop/#472](https://github.com/mojaloop/account-lookup-service/pull/472)), closes [mojaloop/#3829](https://github.com/mojaloop/project/issues/3829)
* **mojaloop/#3750** add timer for party lookup in cache ([mojaloop/#471](https://github.com/mojaloop/sdk-scheme-adapter/pull/471)), closes [mojaloop/#3750](https://github.com/mojaloop/project/issues/3750)

## 3. Application Versions

1. bulk-api-adapter: v17.0.0 ->                     [v17.1.0](https://github.com/mojaloop/bulk-api-adapter/releases/v17.1.0)                     ([Compare](https://github.com/mojaloop/bulk-api-adapter/compare/v17.0.0...v17.1.0))
2. event-sidecar: v14.0.0 ->                     [v14.0.1](https://github.com/mojaloop/event-sidecar/releases/v14.0.1)                     ([Compare](https://github.com/mojaloop/event-sidecar/compare/v14.0.0...v14.0.1))
3. ml-testing-toolkit-ui: v15.4.2 ->                     [v15.5.0](https://github.com/mojaloop/ml-testing-toolkit-ui/releases/v15.5.0)                     ([Compare](https://github.com/mojaloop/ml-testing-toolkit-ui/compare/v15.4.2...v15.5.0))
4. auth-service: v15.0.0 ->                     [v15.1.0](https://github.com/mojaloop/auth-service/releases/v15.1.0)                     ([Compare](https://github.com/mojaloop/auth-service/compare/v15.0.0...v15.1.0))
5. ml-testing-toolkit: v17.1.1 ->                     [v17.2.3](https://github.com/mojaloop/ml-testing-toolkit/releases/v17.2.3)                     ([Compare](https://github.com/mojaloop/ml-testing-toolkit/compare/v17.1.1...v17.2.3))
6. transaction-requests-service: v14.1.2 ->                     [v14.2.0](https://github.com/mojaloop/transaction-requests-service/releases/v14.2.0)                     ([Compare](https://github.com/mojaloop/transaction-requests-service/compare/v14.1.2...v14.2.0))
7. ml-api-adapter: v14.0.5 ->                     [v14.0.7](https://github.com/mojaloop/ml-api-adapter/releases/v14.0.7)                     ([Compare](https://github.com/mojaloop/ml-api-adapter/compare/v14.0.5...v14.0.7))
8. sdk-scheme-adapter: v23.4.0 ->                     [v23.5.1](https://github.com/mojaloop/sdk-scheme-adapter/releases/v23.5.1)                     ([Compare](https://github.com/mojaloop/sdk-scheme-adapter/compare/v23.4.0...v23.5.1))
9. thirdparty-api-svc: v14.0.0 ->                     [v15.0.0](https://github.com/mojaloop/thirdparty-api-svc/releases/v15.0.0)                     ([Compare](https://github.com/mojaloop/thirdparty-api-svc/compare/v14.0.0...v15.0.0))
10. account-lookup-service: v15.2.3 ->                     [v15.3.4](https://github.com/mojaloop/account-lookup-service/releases/v15.3.4)                     ([Compare](https://github.com/mojaloop/account-lookup-service/compare/v15.2.3...v15.3.4))
11. simulator: v12.1.0 ->                     [v12.2.0](https://github.com/mojaloop/simulator/releases/v12.2.0)                     ([Compare](https://github.com/mojaloop/simulator/compare/v12.1.0...v12.2.0))
12. central-ledger: v17.6.0 ->                     [v17.6.1](https://github.com/mojaloop/central-ledger/releases/v17.6.1)                     ([Compare](https://github.com/mojaloop/central-ledger/compare/v17.6.0...v17.6.1))
13. central-event-processor: [v12.1.0](https://github.com/mojaloop/central-event-processor/releases/v12.1.0)
14. als-oracle-pathfinder: [v12.1.0](https://github.com/mojaloop/als-oracle-pathfinder/releases/v12.1.0)
15. ml-testing-toolkit-client-lib: [v1.2.2](https://github.com/mojaloop/ml-testing-toolkit-client-lib/releases/v1.2.2)
16. mojaloop-simulator: [v15.0.0](https://github.com/mojaloop/mojaloop-simulator/releases/v15.0.0)
17. als-consent-oracle: [v0.2.2](https://github.com/mojaloop/als-consent-oracle/releases/v0.2.2)
18. quoting-service: [v15.7.0](https://github.com/mojaloop/quoting-service/releases/v15.7.0)
19. thirdparty-sdk: [v15.1.1](https://github.com/mojaloop/thirdparty-sdk/releases/v15.1.1)
20. event-stream-processor: [v12.0.0-snapshot.9](https://github.com/mojaloop/event-stream-processor/releases/v12.0.0-snapshot.9)
21. central-settlement: [v16.0.0](https://github.com/mojaloop/central-settlement/releases/v16.0.0)
22. email-notifier: [v14.0.0](https://github.com/mojaloop/email-notifier/releases/v14.0.0)

## 4. API Versions

This release supports the following versions of the [Mojaloop family of APIs](https://docs.mojaloop.io/api):

| API         | Supported Versions                                                                                                                                    | Notes |
| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
| FSPIOP      | [v1.1](https://docs.mojaloop.io/api/fspiop/v1.1/api-definition.html), [v1.0](https://docs.mojaloop.io/api/fspiop/v1.0/api-definition.html) |       |
| Settlements | [v2.0](https://docs.mojaloop.io/api/settlement)                                                                                            |       |
| Admin       | [v1.0](https://docs.mojaloop.io/api/administration/central-ledger-api.html)                                                                |       |
| Oracle      | [v1.0](https://docs.mojaloop.io/legacy/api/als-oracle-api-specification.html)                                                              |       |
| Thirdparty  | [v1.0](https://docs.mojaloop.io/api/thirdparty)                                                                                            |       |

## 5. Testing notes

1. This release has been validated against the following Dependency Test Matrix:

    | Dependency | Version |  Notes   |
    | ---------- | ------- | --- |
    | Kubernetes | v1.29 | [AWS EKS](https://aws.amazon.com/eks/), [AWS EKS Supported Version Notes](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)  |
    | containerd  |  v1.6.19  |  |
    | Nginx Ingress Controller | [helm-ingress-nginx-4.7.0](https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.7.0) / [ingress-controller-v1.8.0](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.8.0) |     |
    |  Amazon Linux   |  v2   |     |
    |  MySQL   |  bitnami/mysql:8.0.32-debian-11-r0   |     |
    |  Kafka   |  bitnami/kafka:3.3.1-debian-11-r1   |     |
    |  Redis   |  bitnami/redis:7.0.5-debian-11-r7   |     |
    |  MongoDB   |  bitnami/mongodb:6.0.2-debian-11-r11   |     |
    |  Testing Toolkit Test Cases   |  [v16.1.0](https://github.com/mojaloop/testing-toolkit-test-cases/releases/tag/v16.1.0)   |     |
    |  example-mojaloop-backend   |  v15.0.0   |  [README](https://github.com/mojaloop/helm/blob/main/example-mojaloop-backend/README.md)   |

2. It is recommended that all Mojaloop deployments are verified using the [Mojaloop Testing Toolkit](https://docs.mojaloop.io/documentation/mojaloop-technical-overview/ml-testing-toolkit/). More information can be found in the [Mojaloop Deployment Guide](https://docs.mojaloop.io/documentation/deployment-guide).

3. The [testing-toolkit-test-cases](https://github.com/mojaloop/testing-toolkit-test-cases/releases) (See above Dependency Test Matrix for exact version required for this release) Golden Path collections expects:
    - the Quoting service operating mode to be set quoting-service.config.simple_routing_mode_enabled=true (in helm mojaloop/values.yaml under quoting-service config). If this is incorrectly configured, it will result in several failures in the quoting-service tests (7 expected failures). If this is disabled, ensure that you update the corresponding test-case environment variable parameter **SIMPLE_ROUTING_MODE_ENABLED** ( in helm mojaloop/values.yaml ml-testing-toolkit -> extraEnvironments.hub-k8s-default-environment.json.inputValues) to match.
    - the **on-us transfers** (in mojaloop/values.yaml "enable_on_us_transfers: false" under centralledger-handler-transfer-prepare -> config and  cl-handler-bulk-transfer-prepare -> config) configuration to be disabled. The test-case environment variable parameter (**ON_US_TRANSFERS_ENABLED** (in helm mojaloop/values.yaml ml-testing-toolkit -> extraEnvironments.hub-k8s-default-environment.json.inputValues), the same name used on postman collections) must similarly match this value.

4. Simulators
    - We recommend using Testing Toolkit instead of Postman which is better suited for the async nature of the Mojaloop API specification (see above)
    - [Mojaloop-Simulator](https://github.com/mojaloop/mojaloop-simulator) is enabled by default (six instances used for single transfers usually and three more specific to bulk).
    - Ensure that correct Postman Scripts are used if you wish to test against the Mojaloop-Simulators:
        - Setup Mojaloop Hub: [MojaloopHub_Setup](https://github.com/mojaloop/postman/blob/v12.0.0/MojaloopHub_Setup.postman_collection.json)
        - Setup Mojaloop Simulators for testing : [MojaloopSims_Onboarding](https://github.com/mojaloop/postman/blob/v12.0.0/MojaloopSims_Onboarding.postman_collection.json)
        - Golden path tests: [Golden_Path_Mojaloop](https://github.com/mojaloop/postman/blob/v12.0.0/Golden_Path_Mojaloop.postman_collection.json)
    - Legacy Simulators are still required and deployed by default; disabling this will cause issues since there is Account Lookup directory mocking functionality in this service.

5. Thirdparty Testing Toolkit Test Collections are not repeatable. Please refer to the following issue for more information [#2717 - Thirdparty TTK Test-Collection is not repeatable](https://github.com/mojaloop/project/issues/2717). It is possible to manually cleanup persistent data to re-run the test if required.

6. Bulk API Helm Tests

    Refer to the [Testing Deployments](https://github.com/mojaloop/helm/blob/main/README.md#testing-deployments) section in the main README for detailed information on how to enable bulk-api-adapter tests.

7. Thirdparty API Helm Tests

    Refer to [thirdparty/README.md#validating-and-testing-the-3p-api](https://github.com/mojaloop/helm/blob/main/thirdparty/README.md#validating-and-testing-the-3p-api) on how to enabled and execute Thirdparty verification tests.

8. Testing the Bulk functionality including "sdk-scheme-adapter"

    For details regarding deployment and validation of simulators needed for bulk (for adoption provided in sdk-scheme-adapter) refer to [deploying Mojaloop TTK simulators](https://github.com/mojaloop/helm/blob/main/mojaloop-ttk-simulators/README.md).

## 6. Breaking Changes


### central-ledger
  * config/default.json: (https://github.com/mojaloop/central-ledger/blob/4165045e2c8d0cfb15730bd9090eeca6e6bba606/config%2Fdefault.json)
### bulk-api-adapter
  * config/default.json: (https://github.com/mojaloop/bulk-api-adapter/blob/6ce22e8fb8d5d9bc1e0d9f7501f04f0abef7bf99/config%2Fdefault.json)
  * docker/bulk-api-adapter/default.json: (https://github.com/mojaloop/bulk-api-adapter/blob/6ce22e8fb8d5d9bc1e0d9f7501f04f0abef7bf99/docker%2Fbulk-api-adapter%2Fdefault.json)
### transaction-requests-service
  * config/default.json: (https://github.com/mojaloop/transaction-requests-service/blob/e8d0289ed82977d4c2ae5ef43933ff3356189f39/config%2Fdefault.json)
### thirdparty-api-svc
  * config/default.json: (https://github.com/mojaloop/thirdparty-api-svc/blob/288270cc576ca957f000d519858f7638e7945ffa/config%2Fdefault.json)

## 7. Known Issues

1. [#2119 - Idempotency for duplicate quote request](https://github.com/mojaloop/project/issues/2119)
2. [#2322 - Helm install failing with with "medium to large" release names](https://github.com/mojaloop/project/issues/2322)
3. [#2317 - Mojaloop Helm deployments are not compatible when deployed to ARM-arch based hosts](https://github.com/mojaloop/project/issues/2317)
4. [#2435 - Quoting-Service is incorrectly handling failed responses to FSPs when forwarding requests](https://github.com/mojaloop/project/issues/2435)
5. Test issues causing instability/intermitant failures on Test Case Results
    1. [#2717 - Thirdparty TTK Test-Collection is not repeatable](https://github.com/mojaloop/project/issues/2717)
    2. [#2925 - Helm Test Intermittent failure with 'Generic ID not found](https://github.com/mojaloop/project/issues/2925)

## 8. Contributors

- Organizations: BMGF, InFiTX, MLF
- Individuals: @TWith2Sugars, @dependabot[bot], @devarsh10, @elnyry-sam-k, @geka-evk, @kalinkrustev, @kleyow, @oderayi, @vijayg10

*Note: companies are in alphabetical order, individuals are in no particular order.*

**Full Changelog**: https://github.com/mojaloop/helm/compare/v16.0.0...v16.1.0
