### PR TITLE
fix: changes to kafka config to add protocol info and disable zookeeper

### DIFF
--- a/example-mojaloop-backend/Chart.yaml
+++ b/example-mojaloop-backend/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Example Helm chart for mojaloop backend dependencies
 name: example-mojaloop-backend
-version: 15.7.0
-appVersion: "nginx: 4.4.2; mysql: 9.19.1; kafka: 26.8.5; mongodb: 14.8.3; redis: 18.12.1"
+version: 16.0.0
+appVersion: "nginx: 4.4.2; mysql: 9.19.1; kafka: 29.3.9; mongodb: 14.8.3; redis: 18.12.1"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -13,6 +13,8 @@ maintainers:
     email: miguel.debarros@modusbox.com
   - name: Vijay Kumar Guthi
     email: vijaya.guthi@modusbox.com
+  - name: Sam Kummary
+    email: skummary@mojaloop.io
 dependencies:
   - name: kafka
     alias: kafka
@@ -23,7 +25,7 @@ dependencies:
       - dependency
       - backend
       - kafka
-    version: 26.8.5
+    version: 29.3.9
   ## mysql database
   - name: mysql
     alias: mysql

--- a/example-mojaloop-backend/values.yaml
+++ b/example-mojaloop-backend/values.yaml
@@ -19,6 +19,31 @@ kafka:
     ##
     enabled: false
 
+  listeners:
+    client:
+      protocol: PLAINTEXT
+    controller:
+      protocol: PLAINTEXT
+    interbroker:
+      protocol: PLAINTEXT
+    external:
+      protocol: PLAINTEXT
+
+  extraConfig: |-
+    offsets.topic.replication.factor=1
+    default.replication.factor=1
+    transaction.state.log.replication.factor=1
+  
+  controller:
+    replicaCount: 1
+    persistence:
+      enabled: false
+    logPersistence:
+      enabled: false
+  broker:
+    persistence:
+      enabled: false
+  
   ## ZooKeeper chart configuration
   ## https://github.com/bitnami/charts/blob/main/bitnami/zookeeper/values.yaml
   ##
@@ -30,6 +55,8 @@ kafka:
     ## @param zookeeper.persistence.accessModes Persistent Volume access modes
     ## @param zookeeper.persistence.size Persistent Volume size
     ##
+    enabled: false
+    
     persistence:
       enabled: false
 

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
-version: 16.0.3
+version: 16.0.4
 appVersion: "ml-api-adapter: v14.0.5; central-ledger: v17.6.1; account-lookup-service: v15.2.3; quoting-service: v15.7.0; central-settlement: v16.0.0; bulk-api-adapter: v17.0.0; transaction-requests-service: v14.1.2; simulator: v12.1.0; mojaloop-simulator: v15.0.0; sdk-scheme-adapter: v23.4.0; auth-service: v15.0.0; als-consent-oracle: v0.2.2; thirdparty-sdk: v15.1.1; ml-testing-toolkit: v17.0.0; ml-testing-toolkit-ui: v15.4.2;"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png


### PR DESCRIPTION
Deployments using default configuration having handshake issues without this config when mojaloop is deployed on the backend following the instructions here: https://docs.mojaloop.io/technical/deployment-guide/#_5-mojaloop

This fixes it and has been tested a few times. Thanks to Vijay and the FX PR 