### PR TITLE
chore: add config that exposes liveness/readiness metrics

### DIFF
--- a/monitoring/promfana/values.yaml
+++ b/monitoring/promfana/values.yaml
@@ -1328,6 +1328,31 @@ prometheus:
               target_label: __metrics_path__
               replacement: /api/v1/nodes/$1/proxy/metrics
 
+        - job_name: 'kubelet-probes'
+          # Default to scraping over https. If required, just disable this or change to
+          # `http`.
+          scheme: https
+          tls_config:
+            ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            # If your node certificates are self-signed or use a different CA to the
+            # master CA, then disable certificate verification below. Note that
+            # certificate verification is an integral part of a secure infrastructure
+            # so this should only be disabled in a controlled environment. You can
+            # disable certificate verification by uncommenting the line below.
+            #
+            insecure_skip_verify: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          kubernetes_sd_configs:
+            - role: node
+          relabel_configs:
+            - action: labelmap
+              regex: __meta_kubernetes_node_label_(.+)
+            - target_label: __address__
+              replacement: kubernetes.default.svc:443
+            - source_labels: [__meta_kubernetes_node_name]
+              regex: (.+)
+              target_label: __metrics_path__
+              replacement: /api/v1/nodes/${1}/proxy/metrics/probes
 
         - job_name: 'kubernetes-nodes-cadvisor'
 


### PR DESCRIPTION
https://github.com/kubernetes/kube-state-metrics/issues/699#issuecomment-1063868264

This should enable `prober_probe` metrics.
Then we should be able to get liveness and readiness check failures with below
```
prober_probe_total{probe_type="Readiness",result="failed"}
prober_probe_total{probe_type="Liveness",result="failed"}
```
