### PR TITLE
fix(csi-1351): set default log transport to console

### DIFF
--- a/account-lookup-service/chart-admin/values.yaml
+++ b/account-lookup-service/chart-admin/values.yaml
@@ -131,7 +131,7 @@ config:
 
   # Log config
   log_level: info
-  log_transport: file
+  log_transport: console
 
   error_handling:
     include_cause_extension: false

--- a/account-lookup-service/chart-handler-timeout/values.yaml
+++ b/account-lookup-service/chart-handler-timeout/values.yaml
@@ -135,7 +135,7 @@ config:
 
   # Log config
   log_level: info
-  log_transport: file
+  log_transport: console
 
   error_handling:
     include_cause_extension: false

--- a/account-lookup-service/chart-service/values.yaml
+++ b/account-lookup-service/chart-service/values.yaml
@@ -135,7 +135,7 @@ config:
 
   # Log config
   log_level: info
-  log_transport: file
+  log_transport: console
 
   error_handling:
     include_cause_extension: false

--- a/account-lookup-service/values.yaml
+++ b/account-lookup-service/values.yaml
@@ -69,7 +69,7 @@ account-lookup-service:
     central_services_port: 80
     # Log config
     log_level: info
-    log_transport: file
+    log_transport: console
 
     error_handling:
       include_cause_extension: false
@@ -454,7 +454,7 @@ account-lookup-service-admin:
       # -----END RSA PRIVATE KEY-----
     # Log config
     log_level: info
-    log_transport: file
+    log_transport: console
 
     # Thirdparty API Config
     featureEnableExtendedPartyIdType: false
@@ -722,7 +722,7 @@ account-lookup-service-handler-timeout:
     central_services_port: 80
     # Log config
     log_level: info
-    log_transport: file
+    log_transport: console
 
     error_handling:
       include_cause_extension: false

--- a/bulk-api-adapter/chart-handler-notification/values.yaml
+++ b/bulk-api-adapter/chart-handler-notification/values.yaml
@@ -126,7 +126,7 @@ config:
     callback:
       rejectUnauthorized: true
   log_level: 'info'
-  log_transport: file
+  log_transport: console
 
   # Protocol versions used for validating (VALIDATELIST) incoming FSPIOP API Headers (Content-type, Accept),
   # and for generating requests/callbacks from the Switch itself (DEFAULT value)

--- a/bulk-api-adapter/chart-service/values.yaml
+++ b/bulk-api-adapter/chart-service/values.yaml
@@ -120,7 +120,7 @@ config:
     callback:
       rejectUnauthorized: true
   log_level: 'info'
-  log_transport: file
+  log_transport: console
 
   # Protocol versions used for validating (VALIDATELIST) incoming FSPIOP API Headers (Content-type, Accept),
   # and for generating requests/callbacks from the Switch itself (DEFAULT value)

--- a/bulk-api-adapter/values.yaml
+++ b/bulk-api-adapter/values.yaml
@@ -125,7 +125,7 @@ bulk-api-adapter-service:
       callback:
         rejectUnauthorized: true
     log_level: 'info'
-    log_transport: file
+    log_transport: console
 
     # Protocol versions used for validating (VALIDATELIST) incoming FSPIOP API Headers (Content-type, Accept),
     # and for generating requests/callbacks from the Switch itself (DEFAULT value)
@@ -430,7 +430,7 @@ bulk-api-adapter-handler-notification:
       callback:
         rejectUnauthorized: true
     log_level: 'info'
-    log_transport: file
+    log_transport: console
 
     # Protocol versions used for validating (VALIDATELIST) incoming FSPIOP API Headers (Content-type, Accept),
     # and for generating requests/callbacks from the Switch itself (DEFAULT value)

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
@@ -170,7 +170,7 @@ config:
 
   ## Node Configuration
   log_level: 'info'
-  log_transport: file
+  log_transport: console
 
   ## Cache configuration
   cache_max_byte_size: 10000000

--- a/bulk-centralledger/chart-handler-bulk-transfer-get/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-get/values.yaml
@@ -170,7 +170,7 @@ config:
 
   ## Node Configuration
   log_level: 'info'
-  log_transport: file
+  log_transport: console
 
   ## Cache configuration
   cache_max_byte_size: 10000000

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
@@ -170,7 +170,7 @@ config:
 
   ## Node Configuration
   log_level: 'info'
-  log_transport: file
+  log_transport: console
 
   ## Cache configuration
   cache_max_byte_size: 10000000

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
@@ -165,7 +165,7 @@ config:
 
   ## Node Configuration
   log_level: 'info'
-  log_transport: file
+  log_transport: console
 
   ## Cache configuration
   cache_max_byte_size: 10000000

--- a/bulk-centralledger/values.yaml
+++ b/bulk-centralledger/values.yaml
@@ -169,7 +169,7 @@ cl-handler-bulk-transfer-prepare:
 
     ## Node Configuration
     log_level: 'info'
-    log_transport: file
+    log_transport: console
 
     ## Cache configuration
     cache_max_byte_size: 10000000
@@ -543,7 +543,7 @@ cl-handler-bulk-transfer-fulfil:
 
     ## Node Configuration
     log_level: 'info'
-    log_transport: file
+    log_transport: console
 
     ## Cache configuration
     cache_max_byte_size: 10000000
@@ -923,7 +923,7 @@ cl-handler-bulk-transfer-processing:
 
     ## Node Configuration
     log_level: 'info'
-    log_transport: file
+    log_transport: console
 
     ## Cache configuration
     cache_max_byte_size: 10000000
@@ -1303,7 +1303,7 @@ cl-handler-bulk-transfer-get:
 
     ## Node Configuration
     log_level: 'info'
-    log_transport: file
+    log_transport: console
 
     ## Cache configuration
     cache_max_byte_size: 10000000

--- a/centraleventprocessor/values.yaml
+++ b/centraleventprocessor/values.yaml
@@ -108,7 +108,7 @@ config:
   hub_participant:
     name: Hub
   log_level: info
-  log_transport: file
+  log_transport: console
 
 ## @param initContainers Add additional init containers to the %%MAIN_CONTAINER_NAME%% pod(s)
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/

--- a/centralledger/chart-handler-admin-transfer/values.yaml
+++ b/centralledger/chart-handler-admin-transfer/values.yaml
@@ -202,7 +202,7 @@ config:
   ## Log Configuration
   log_level: info
   log_filter: 'error, warn, info'
-  log_transport: file
+  log_transport: console
 
   ## Tracing Configuration
   event_trace_vendor: mojaloop

--- a/centralledger/chart-handler-timeout/values.yaml
+++ b/centralledger/chart-handler-timeout/values.yaml
@@ -202,7 +202,7 @@ config:
   ## Log Configuration
   log_level: info
   log_filter: 'error, warn, info'
-  log_transport: file
+  log_transport: console
 
   ## Tracing Configuration
   event_trace_vendor: mojaloop

--- a/centralledger/chart-handler-transfer-fulfil/values.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/values.yaml
@@ -202,7 +202,7 @@ config:
   ## Node Configuration
   log_level: 'info'
   log_filter: 'error, warn, info'
-  log_transport: file
+  log_transport: console
 
   ## Tracing Configuration
   event_trace_vendor: mojaloop

--- a/centralledger/chart-handler-transfer-get/values.yaml
+++ b/centralledger/chart-handler-transfer-get/values.yaml
@@ -202,7 +202,7 @@ config:
   ## Node Configuration
   log_level: 'info'
   log_filter: 'error, warn, info'
-  log_transport: file
+  log_transport: console
 
   ## Condig for tracing
   event_trace_vendor: mojaloop

--- a/centralledger/chart-handler-transfer-position-batch/values.yaml
+++ b/centralledger/chart-handler-transfer-position-batch/values.yaml
@@ -204,7 +204,7 @@ config:
   ## Node Configuration
   log_level: 'info'
   log_filter: 'error, warn, info'
-  log_transport: file
+  log_transport: console
 
   ## Tracing Configuration
   event_trace_vendor: mojaloop

--- a/centralledger/chart-handler-transfer-position/values.yaml
+++ b/centralledger/chart-handler-transfer-position/values.yaml
@@ -202,7 +202,7 @@ config:
   ## Node Configuration
   log_level: 'info'
   log_filter: 'error, warn, info'
-  log_transport: file
+  log_transport: console
 
   ## Tracing Configuration
   event_trace_vendor: mojaloop

--- a/centralledger/chart-handler-transfer-prepare/values.yaml
+++ b/centralledger/chart-handler-transfer-prepare/values.yaml
@@ -202,7 +202,7 @@ config:
   ## Node Configuration
   log_level: 'info'
   log_filter: 'error, warn, info'
-  log_transport: file
+  log_transport: console
 
   ## Tracing Configuration
   event_trace_vendor: mojaloop

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -195,7 +195,7 @@ config:
   ## Log Configuration
   log_level: info
   log_filter: 'error, warn, info'
-  log_transport: file
+  log_transport: console
   ## Enable local logging of events being recorded
   log_events_locally_enabled: false
 

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -212,7 +212,7 @@ centralledger-service:
     ## Log Configuration
     log_level: info
     log_filter: 'error, warn, info'
-    log_transport: file
+    log_transport: console
     ## Enable local logging of events being recorded
     log_events_locally_enabled: false
 
@@ -607,7 +607,7 @@ centralledger-handler-transfer-prepare:
     ## Node Configuration
     log_level: 'info'
     log_filter: 'error, warn, info'
-    log_transport: file
+    log_transport: console
 
     ## Tracing Configuration
     event_trace_vendor: mojaloop
@@ -1022,7 +1022,7 @@ centralledger-handler-transfer-position:
     ## Node Configuration
     log_level: 'info'
     log_filter: 'error, warn, info'
-    log_transport: file
+    log_transport: console
 
     ## Tracing Configuration
     event_trace_vendor: mojaloop
@@ -1434,7 +1434,7 @@ centralledger-handler-transfer-position-batch:
     ## Node Configuration
     log_level: 'info'
     log_filter: 'error, warn, info'
-    log_transport: file
+    log_transport: console
 
     ## Tracing Configuration
     event_trace_vendor: mojaloop
@@ -1852,7 +1852,7 @@ centralledger-handler-transfer-get:
     ## Node Configuration
     log_level: 'info'
     log_filter: 'error, warn, info'
-    log_transport: file
+    log_transport: console
 
     ## Condig for tracing
     event_trace_vendor: mojaloop
@@ -2264,7 +2264,7 @@ centralledger-handler-transfer-fulfil:
     ## Node Configuration
     log_level: 'info'
     log_filter: 'error, warn, info'
-    log_transport: file
+    log_transport: console
 
     ## Tracing Configuration
     event_trace_vendor: mojaloop
@@ -2681,7 +2681,7 @@ centralledger-handler-timeout:
     ## Log Configuration
     log_level: info
     log_filter: 'error, warn, info'
-    log_transport: file
+    log_transport: console
 
     ## Tracing Configuration
     event_trace_vendor: mojaloop
@@ -3093,7 +3093,7 @@ centralledger-handler-admin-transfer:
     ## Log Configuration
     log_level: info
     log_filter: 'error, warn, info'
-    log_transport: file
+    log_transport: console
 
     ## Tracing Configuration
     event_trace_vendor: mojaloop

--- a/centralsettlement/chart-service/values.yaml
+++ b/centralsettlement/chart-service/values.yaml
@@ -254,7 +254,7 @@ config:
 
   ## Log config
   log_level: info
-  log_transport: file
+  log_transport: console
 
   ## Tracing Configuration
   event_trace_vendor: mojaloop

--- a/centralsettlement/values.yaml
+++ b/centralsettlement/values.yaml
@@ -249,7 +249,7 @@ centralsettlement-service:
 
     ## Log config
     log_level: info
-    log_transport: file
+    log_transport: console
 
     ## Tracing Configuration
     event_trace_vendor: mojaloop
@@ -691,7 +691,7 @@ centralsettlement-handler-deferredsettlement:
 
     ## Log config
     log_level: info
-    log_transport: file
+    log_transport: console
 
     ## Tracing Configuration
     event_trace_vendor: mojaloop
@@ -1135,7 +1135,7 @@ centralsettlement-handler-grosssettlement:
 
     ## Log config
     log_level: info
-    log_transport: file
+    log_transport: console
 
     ## Tracing Configuration
     event_trace_vendor: mojaloop
@@ -1578,7 +1578,7 @@ centralsettlement-handler-rules:
 
     ## Log config
     log_level: info
-    log_transport: file
+    log_transport: console
 
     ## Tracing Configuration
     event_trace_vendor: mojaloop

--- a/emailnotifier/values.yaml
+++ b/emailnotifier/values.yaml
@@ -99,7 +99,7 @@ config:
   hub_participant:
     name: Hub
   log_level: info
-  log_transport: file
+  log_transport: console
 
 ## @param initContainers Add additional init containers to the %%MAIN_CONTAINER_NAME%% pod(s)
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -190,7 +190,7 @@ config:
   ## Log Configuration
   log_level: info
   log_filter: 'error, warn, info'
-  log_transport: file
+  log_transport: console
 
   ## Health Check endpoint
   central_services_health_endpoint_param: '/health'

--- a/ml-api-adapter/chart-service/values.yaml
+++ b/ml-api-adapter/chart-service/values.yaml
@@ -177,7 +177,7 @@ config:
   ## Log Configuration
   log_level: info
   log_filter: 'error, warn, info'
-  log_transport: file
+  log_transport: console
 
   ## Health Check endpoint
   central_services_health_endpoint_param: '/health'

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -170,7 +170,7 @@ ml-api-adapter-service:
     ## Log Configuration
     log_level: info
     log_filter: 'error, warn, info'
-    log_transport: file
+    log_transport: console
 
     ## Health Check endpoint
     central_services_health_endpoint_param: '/health'
@@ -489,7 +489,7 @@ ml-api-adapter-handler-notification:
     ## Log Configuration
     log_level: info
     log_filter: 'error, warn, info'
-    log_transport: file
+    log_transport: console
 
     ## Health Check endpoint
     central_services_health_endpoint_param: '/health'

--- a/mojaloop-bulk/values.yaml
+++ b/mojaloop-bulk/values.yaml
@@ -140,7 +140,7 @@ bulk-api-adapter:
         callback:
           rejectUnauthorized: true
       log_level: 'info'
-      log_transport: file
+      log_transport: console
 
       # Protocol versions used for validating (VALIDATELIST) incoming FSPIOP API Headers (Content-type, Accept),
       # and for generating requests/callbacks from the Switch itself (DEFAULT value)
@@ -458,7 +458,7 @@ bulk-api-adapter:
         callback:
           rejectUnauthorized: true
       log_level: 'info'
-      log_transport: file
+      log_transport: console
 
       # Protocol versions used for validating (VALIDATELIST) incoming FSPIOP API Headers (Content-type, Accept),
       # and for generating requests/callbacks from the Switch itself (DEFAULT value)
@@ -840,7 +840,7 @@ bulk-centralledger:
 
       ## Node Configuration
       log_level: 'info'
-      log_transport: file
+      log_transport: console
 
       ## Cache configuration
       cache_max_byte_size: 10000000
@@ -1224,7 +1224,7 @@ bulk-centralledger:
 
       ## Node Configuration
       log_level: 'info'
-      log_transport: file
+      log_transport: console
 
       ## Cache configuration
       cache_max_byte_size: 10000000
@@ -1614,7 +1614,7 @@ bulk-centralledger:
 
       ## Node Configuration
       log_level: 'info'
-      log_transport: file
+      log_transport: console
 
       ## Cache configuration
       cache_max_byte_size: 10000000
@@ -2004,7 +2004,7 @@ bulk-centralledger:
 
       ## Node Configuration
       log_level: 'info'
-      log_transport: file
+      log_transport: console
 
       ## Cache configuration
       cache_max_byte_size: 10000000

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -231,7 +231,7 @@ account-lookup-service:
 
       # Log config
       log_level: info
-      log_transport: file
+      log_transport: console
 
       central_shared_end_point_cache:
         expiresIn: 180000
@@ -671,7 +671,7 @@ account-lookup-service:
       run_migrations: false
       # Log config
       log_level: info
-      log_transport: file
+      log_transport: console
 
       # Thirdparty API Config
       featureEnableExtendedPartyIdType: false
@@ -948,7 +948,7 @@ account-lookup-service:
 
       # Log config
       log_level: info
-      log_transport: file
+      log_transport: console
 
       central_shared_end_point_cache:
         expiresIn: 180000
@@ -1698,7 +1698,7 @@ quoting-service:
       db_debug: false
       simple_routing_mode_enabled: true
       log_level: info
-      log_transport: file
+      log_transport: console
 
       protocol_versions: {"CONTENT": {"DEFAULT": "2.0", "VALIDATELIST": ["1", "1.0", "1.1", "2", "2.0"]}, "ACCEPT": {"DEFAULT": "2", "VALIDATELIST": ["1", "1.0", "1.1", "2", "2.0"]}}
       # A comma-separated list of events that should return immediately instead of waiting for the event promises to resolve
@@ -1808,7 +1808,7 @@ quoting-service:
       db_debug: false
       simple_routing_mode_enabled: true
       log_level: info
-      log_transport: file
+      log_transport: console
 
       protocol_versions: {"CONTENT": {"DEFAULT": "2.0", "VALIDATELIST": ["1", "1.0", "1.1", "2", "2.0"]}, "ACCEPT": {"DEFAULT": "2", "VALIDATELIST": ["1", "1.0", "1.1", "2", "2.0"]}}
       # A comma-separated list of events that should return immediately instead of waiting for the event promises to resolve
@@ -2045,7 +2045,7 @@ ml-api-adapter:
       ## Log Configuration
       log_level: info
       log_filter: 'error, warn, info'
-      log_transport: file
+      log_transport: console
 
       ## Tracing Configuration
       event_trace_vendor: mojaloop
@@ -2323,7 +2323,7 @@ ml-api-adapter:
       ## Log Configuration
       log_level: info
       log_filter: 'error, warn, info'
-      log_transport: file
+      log_transport: console
 
       ## Tracing Configuration
       event_trace_vendor: mojaloop
@@ -2658,7 +2658,7 @@ centralledger:
 
       ## Log Configuration
       log_level: info
-      log_transport: file
+      log_transport: console
 
       # A comma-separated list of events that should return immediately instead of waiting for the event promises to resolve
       # Any combination of: `log,audit,trace`
@@ -2978,7 +2978,7 @@ centralledger:
 
       ## Log Configuration
       log_level: info
-      log_transport: file
+      log_transport: console
 
       # A comma-separated list of events that should return immediately instead of waiting for the event promises to resolve
       # Any combination of: `log,audit,trace`
@@ -3320,7 +3320,7 @@ centralledger:
 
       ## Log Configuration
       log_level: info
-      log_transport: file
+      log_transport: console
 
       # A comma-separated list of events that should return immediately instead of waiting for the event promises to resolve
       # Any combination of: `log,audit,trace`
@@ -3660,7 +3660,7 @@ centralledger:
 
       ## Log Configuration
       log_level: info
-      log_transport: file
+      log_transport: console
 
       # A comma-separated list of events that should return immediately instead of waiting for the event promises to resolve
       # Any combination of: `log,audit,trace`
@@ -4005,7 +4005,7 @@ centralledger:
 
       ## Log Configuration
       log_level: info
-      log_transport: file
+      log_transport: console
 
       # A comma-separated list of events that should return immediately instead of waiting for the event promises to resolve
       # Any combination of: `log,audit,trace`
@@ -4344,7 +4344,7 @@ centralledger:
 
       ## Log Configuration
       log_level: info
-      log_transport: file
+      log_transport: console
 
       # A comma-separated list of events that should return immediately instead of waiting for the event promises to resolve
       # Any combination of: `log,audit,trace`
@@ -4688,7 +4688,7 @@ centralledger:
 
       ## Log Configuration
       log_level: info
-      log_transport: file
+      log_transport: console
 
       # A comma-separated list of events that should return immediately instead of waiting for the event promises to resolve
       # Any combination of: `log,audit,trace`
@@ -5027,7 +5027,7 @@ centralledger:
 
       ## Log Configuration
       log_level: info
-      log_transport: file
+      log_transport: console
 
       # A comma-separated list of events that should return immediately instead of waiting for the event promises to resolve
       # Any combination of: `log,audit,trace`
@@ -5459,7 +5459,7 @@ centralsettlement:
 
       ## Log config
       log_level: info
-      log_transport: file
+      log_transport: console
 
       ## Tracing Configuration
       event_trace_vendor: mojaloop
@@ -5889,7 +5889,7 @@ centralsettlement:
 
       ## Log config
       log_level: info
-      log_transport: file
+      log_transport: console
 
       ## Tracing Configuration
       event_trace_vendor: mojaloop
@@ -6321,7 +6321,7 @@ centralsettlement:
 
       ## Log config
       log_level: info
-      log_transport: file
+      log_transport: console
 
       ## Tracing Configuration
       event_trace_vendor: mojaloop
@@ -6753,7 +6753,7 @@ centralsettlement:
 
       ## Log config
       log_level: info
-      log_transport: file
+      log_transport: console
 
       ## Tracing Configuration
       event_trace_vendor: mojaloop
@@ -7161,7 +7161,7 @@ transaction-requests-service:
     protocol_versions: {"CONTENT": {"DEFAULT": "2.0", "VALIDATELIST": ["1", "1.0", "1.1", "2", "2.0"]}, "ACCEPT": {"DEFAULT": "2", "VALIDATELIST": ["1", "1.0", "1.1", "2", "2.0"]}}
 
     log_level: info
-    log_transport: file
+    log_transport: console
 
     error_handling:
       include_cause_extension: false

--- a/quoting-service/chart-handler/values.yaml
+++ b/quoting-service/chart-handler/values.yaml
@@ -173,7 +173,7 @@ config:
   db_debug: false
   simple_routing_mode_enabled: true
   log_level: info
-  log_transport: file
+  log_transport: console
 
   ## Kafka Configuration (used for sidecar)
   # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.

--- a/quoting-service/chart-service/values.yaml
+++ b/quoting-service/chart-service/values.yaml
@@ -170,7 +170,7 @@ config:
   db_debug: false
   simple_routing_mode_enabled: true
   log_level: info
-  log_transport: file
+  log_transport: console
 
   ## Kafka Configuration (used for sidecar)
   # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.

--- a/quoting-service/values.yaml
+++ b/quoting-service/values.yaml
@@ -184,7 +184,7 @@ quoting-service: # API
     db_debug: false
     simple_routing_mode_enabled: true
     log_level: info
-    log_transport: file
+    log_transport: console
 
     ## Kafka Configuration (used for sidecar)
     # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.
@@ -552,7 +552,7 @@ quoting-service-handler:
     db_debug: false
     simple_routing_mode_enabled: true
     log_level: info
-    log_transport: file
+    log_transport: console
 
     ## Kafka Configuration (used for sidecar)
     # this can be set if the dependency chart for kafka is disabled. If 'kafka_host' is commented out, then the name of the dependency chart will be used.

--- a/transaction-requests-service/values.yaml
+++ b/transaction-requests-service/values.yaml
@@ -147,7 +147,7 @@ config:
   protocol_versions: {"CONTENT": {"DEFAULT": "2.0", "VALIDATELIST": ["1", "1.0", "1.1", "2", "2.0"]}, "ACCEPT": {"DEFAULT": "2", "VALIDATELIST": ["1", "1.0", "1.1", "2", "2.0"]}}
 
   log_level: 'info'
-  log_transport: 'file'
+  log_transport: console
 
   error_handling:
     include_cause_extension: false


### PR DESCRIPTION
- Set default log transport to `console`, fixes `undefined` being logged in most pods

**GP Test Result**
![image](https://github.com/user-attachments/assets/b5f18285-561a-4a97-a583-026182dbeebd)
