### PR TITLE
add connection manager chart @v0.7.7

### DIFF
--- a/connection-manager/.helmignore
+++ b/connection-manager/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/connection-manager/Chart.yaml
+++ b/connection-manager/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+appVersion: "0.7.7"
+description: Connection Manager Helm chart for Kubernetes
+name: connection-manager
+version: 0.7.7
+keywords:
+  - connection-manager
+sources:
+  - https://github.com/pm4ml/connection-manager-api
+  - https://github.com/pm4ml/connection-manager-ui
+maintainers:
+  - name: Ramiro González Maciel
+    email: ramiro@modusbox.com
+  - name: Ivan Annovazzi
+    email: ivan.annovazzi@modusbox.com

--- a/connection-manager/README.md
+++ b/connection-manager/README.md
@@ -1,0 +1,98 @@
+# Connection Manager
+
+Connection Manager simplifies a DFSP connecting to a Mojaloop Hub.
+
+One of the largest challenges that faces any DFSP is connecting to the Hub, then installing and maintaining the certificates required to connect to and validate other DFSPs. Connection Manager from ModusBox aims to simplify that whole process by providing a pre-configured environment that has already tested:
+
+- End Points for Connectivity - automatically configured and negotiated with the Hub
+- Key Exchange and Management for connectivity to the Hub and Other DFSPs
+  - JWS
+  - X509
+  - ILP Condition management
+
+## Configuration
+
+The following table lists the parameters you are expected to edit for your deployment of the Connection Manager.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `db.host` | `localhost` | Hostname of database |
+| `db.user` | `root` | Username for authenticating to database |
+| `db.password` | `changeme` | Password for `db.user` |
+| `db.schema` | `tsp` | Name of database table |
+| `db.port` | `3306` | TCP port to connect to database |
+| `api.url` | `https://localhost` | Base URL used by frontend to connect to the API server |
+
+If `api.oauth.enabled` is set to `"TRUE"` then the following fields must also be configured.
+And also `ui.oauth.enabled` must be set to `"TRUE"`
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `api.oauth.issuer` | `https://localhost/oauth2/token` | OAuth2 Token issuer |
+| `api.oauth.key` | `mysecretkey` | OAuth2 Client Key |
+| `api.oauth.secret` | `mysecret` | OAuth2 Client Secret |
+| `api.oauth.resetPassword.issuer` | `https://localhost/scim2/Users` | OAuth2 Reset password issuer |
+| `api.oauth.resetPassword.user` | `myuser` | OAuth2 Reset password operation user |
+| `api.oauth.resetPassword.pass` | `changeme` | OAuth2 Reset password operation password |
+
+To configure an MCM environment declaratively, rather than by calling the API after server start,
+configure the following fields:
+
+| Parameter | Default | Description |
+| `api.env.name` | `null` | If specified, an environment with this name will be created before server start |
+| `api.env.{cn,c,l,o,ou,st}` | `null` | X509 attributes for the environment. All optional. |
+
+## Developer/Debugging Configuration
+
+The following table lists further configuration parameters of the Connection Manager. These parameters should __not__ be edited during normal operations. They are provided to aid developement and debugging only.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `ui.disabled` | Not set | If set to `true` this disabled the UI frontend |
+| `api.disabled` | Not set | If set to `true` this disables the API backend |
+| `api.auth_enabled` | `"FALSE"` | Enables authentication to the API.  Set to `"TRUE"` to enable. __MUST__ be a string. Must have the same value of `ui.auth_enabled` __WARNING__ Disabling authentication increases the chance of a success attack on your deployment. |
+| `ui.auth_enabled` | `"FALSE"` | Enables authentication to the UI. Must have the same value of `api.auth_enabled` It cannot be one enabled and the other don't |
+| `imagePullPolicy` | `ifNotPresent` | Container pull policy |
+| `ui.image.name` | foo | name of UI frontend Docker Image |
+| `ui.image.version` | Chart version specific | The version of the UI frontend Docker Image |
+| `api.image.name` | foo | Name of API backend Docker Image |
+| `api.image.version` | Chart version specific | The version of the API bakcend Docker Image |
+| `ui.ports.containerPort` | `8080` | port the UI frontend runs on |
+| `ui.ports.nodePort` | foo | NodePort used by Kubernetes |
+| `api.ports.containerPort` | `8080` | port the API backend runs on |
+| `api.ports.nodePort` | foo | NodePort used by Kubernetes |
+
+## Updating this Chart
+
+There are 2 reasons to update this chart:
+
+1. There is a new version of one of the microservices used by this chart
+2. There is an edit needed for this chart
+
+For either case please follow the below process.
+
+### New Microservice Version
+
+Using standard new feature process update the following files:
+
+- [values.yaml](values.yaml)
+  - Edit either `api.image.version` or `ui.image.version` with the latest version
+- [Chart.yaml](Chart.yaml)
+  - Increment `appVersion` as appropriate
+  - Increment `version`
+
+Updates to `version` are to be done in the following manner:
+
+- Increment the patch level if no changes to the Chart is needed
+- Increment the minor level if a new field is added to the Chart
+- Increment the major level if any field is removed
+
+### Edit the Chart
+
+Using standard new feature process update the Chart as necessary. Then update the `version` field in [Chart.yaml](Chart.yaml).
+
+Updates to `version` are to be done in the following manner:
+
+- Increment the patch level if no changes to the Chart is needed
+- Increment the minor level if a new field is added to the Chart
+- Increment the major level if any field is removed

--- a/connection-manager/templates/NOTES.txt
+++ b/connection-manager/templates/NOTES.txt
@@ -1,0 +1,25 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named: {{ .Release.Name }}.
+
+To learn more about this release: https://github.com/modusbox/helm/releases/tag/connection-manager-{{ .Chart.Version }}
+
+To learn more about this deployment, try:
+
+  $ helm status {{ .Release.Name }}
+
+{{- if (index .Values "tests" "api" "enabled") }}
+
+Use the following command to execute Test cases:
+
+  $ helm -n {{ .Release.Namespace }} test {{ .Release.Name }}
+
+Use the following command to execute Test cases and print logs to console:
+
+  $ helm -n {{ .Release.Namespace }} test {{ .Release.Name }} --logs
+
+View Test logs with the following commands:
+
+  $ kubectl -n {{ .Release.Namespace }} logs pod/{{ include "connection-manager.fullname" . }}-api-test
+
+{{- end}}

--- a/connection-manager/templates/_helpers.tpl
+++ b/connection-manager/templates/_helpers.tpl
@@ -1,0 +1,46 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "connection-manager.name" -}}
+{{- default $.Chart.Name $.Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "connection-manager.fullname" -}}
+{{- if $.Values.fullnameOverride -}}
+{{- $.Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default $.Chart.Name $.Values.nameOverride -}}
+{{- if contains $name $.Release.Name -}}
+{{- $.Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" $.Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "connection-manager.chart" -}}
+{{- printf "%s-%s" $.Chart.Name $.Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "connection-manager.labels" -}}
+app.kubernetes.io/name: {{ include "connection-manager.name" . }}
+helm.sh/chart: {{ include "connection-manager.chart" . }}
+app.kubernetes.io/instance: {{ $.Release.Name }}
+{{- if $.Chart.AppVersion }}
+app.kubernetes.io/version: {{ $.Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ $.Release.Service }}
+app.kubernetes.io/part-of: ConnectionManager
+{{- end -}}

--- a/connection-manager/templates/api-configmap.yaml
+++ b/connection-manager/templates/api-configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "connection-manager.fullname" . }}-api-tls-configmap
+  labels:
+    app.kubernetes.io/name: {{ include "connection-manager.fullname" . }}-api-tls-configmap
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+data:
+  tlsClientCSRParameters.json: {{ .Values.config.tlsClientCSRParametersData | quote }}
+  tlsServerCSRParameters.json: {{ .Values.config.tlsServerCSRParametersData | quote }}
+  caCSRParameters.json: {{ .Values.config.caCSRParametersData | quote }}
+

--- a/connection-manager/templates/api-deployment.yaml
+++ b/connection-manager/templates/api-deployment.yaml
@@ -1,0 +1,193 @@
+{{- if not .Values.api.disabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "connection-manager.fullname" . }}-api
+  labels:
+    app.kubernetes.io/component: api
+{{ include "connection-manager.labels" . | indent 4 }}
+spec:
+  replicas: 1
+  strategy: {}
+  selector:
+    matchLabels: &labels
+      app.kubernetes.io/name: {{ include "connection-manager.fullname" . }}-api
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+{{- with .Values.api.annotations }}
+      annotations:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+      labels: *labels
+    spec:
+      {{- if .Values.api.serviceAccount.serviceAccountNameOverride }}
+      serviceAccountName: {{ .Values.api.serviceAccount.serviceAccountNameOverride }}
+      {{- else }}
+      serviceAccountName: {{ include "connection-manager.fullname" . }}-api
+      {{- end }}
+      containers:
+        - name: connection-manager-api
+          {{- with .Values.api }}
+          image: "{{ .image.name }}:{{ .image.version }}"
+          ports:
+            - containerPort: {{ .ports.containerPort }}
+          {{- end }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          env:
+            - name: DATABASE_HOST
+              value: {{ .Values.db.host }}
+            - name: DATABASE_USER
+              value: {{ .Values.db.user }}
+            {{- if .Values.db.passwordSecret }}
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.db.passwordSecret }}
+                  key: {{ .Values.db.passwordSecretKey }}
+            {{- else }}
+            - name: DATABASE_PASSWORD
+              value: {{ .Values.db.password }}
+            {{- end }}
+            - name: DATABASE_SCHEMA
+              value: {{ .Values.db.schema }}
+            - name: DATABASE_PORT
+              value: {{ .Values.db.port | quote }}
+            - name: PORT
+              value: {{ .Values.api.ports.containerPort | quote }}
+            - name: AUTH_ENABLED
+              value: {{ .Values.api.oauth.enabled | quote }}
+            - name: OAUTH2_ISSUER
+              value: {{ .Values.api.oauth.issuer }}
+            - name: APP_OAUTH_CLIENT_KEY
+              value: {{ .Values.api.oauth.key }}
+            {{- if .Values.api.oauth.clientSecretSecret }}
+            - name: APP_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.oauth.clientSecretSecret }}
+                  key: {{ .Values.api.oauth.clientSecretSecretKey }}
+            {{- else }}
+            - name: APP_OAUTH_CLIENT_SECRET
+              value: {{ .Values.api.oauth.secret }}
+            {{- end }}
+            - name: AUTH_2FA_ENABLED
+              value: {{ .Values.api.auth2fa.enabled | quote }}
+            - name: TOTP_ADMIN_ISSUER
+              value: {{ .Values.api.totp.admin.issuer }}
+            - name: TOTP_ADMIN_AUTH_USER
+              value: {{ .Values.api.totp.admin.user }}
+            - name: TOTP_ADMIN_AUTH_PASSWORD
+              value: {{ .Values.api.totp.admin.password }}
+            - name: TOTP_LABEL
+              value: {{ .Values.api.totp.label }}
+            - name: TOTP_ISSUER
+              value: {{ .Values.api.totp.issuer }}
+            - name: WSO2_MANAGER_SERVICE_URL
+              value: {{ .Values.api.wso2.manager.service.url }}
+            - name: WSO2_MANAGER_SERVICE_USER
+              value: {{ .Values.api.wso2.manager.service.user }}
+            - name: WSO2_MANAGER_SERVICE_PASSWORD
+              value: {{ .Values.api.wso2.manager.service.pass }}
+            - name: OAUTH_RESET_PASSWORD_ISSUER
+              value: {{ .Values.api.oauth.resetPassword.issuer }}
+            - name: OAUTH_RESET_PASSWORD_AUTH_USER
+              value: {{ .Values.api.oauth.resetPassword.user }}
+            - name: OAUTH_RESET_PASSWORD_AUTH_PASSWORD
+              value: {{ .Values.api.oauth.resetPassword.pass }}
+            {{- if .Values.api.extraTLS.certChain.enabled }}
+            - name: EXTRA_CERTIFICATE_CHAIN_FILE_NAME
+              value: /mcm_secrets/extraTLS_cert_chain.pem
+            {{- end }}
+            {{- if .Values.api.extraTLS.rootCert.enabled }}
+            - name: EXTRA_ROOT_CERT_FILE_NAME
+              value: /mcm_secrets/extraTLS_root_cert.pem
+            {{- end }}
+            {{- if .Values.api.wso2TokenIssuer.cert.enabled }}
+            - name: CERTIFICATE_FILE_NAME
+              value: /mcm_secrets/wso2_token_issuer_cert.pem
+            {{- end }}
+            {{- if .Values.api.wso2TokenIssuer.embeddedCertificate.enabled }}
+            - name: EMBEDDED_CERTIFICATE
+              value: .Values.api.wso2TokenIssuer.embeddedCertificate.stringValue
+            {{- end }}
+            {{- if .Values.api.vault.auth.k8s.enabled }}
+            - name: VAULT_AUTH_METHOD
+              value: K8S
+            - name: VAULT_K8S_TOKEN_FILE
+              value: {{ .Values.api.vault.auth.k8s.token }}
+            - name: VAULT_K8S_ROLE
+              value: {{ .Values.api.vault.auth.k8s.role }}
+            - name: VAULT_K8S_AUTH_MOUNT_POINT
+              value: {{ .Values.api.vault.auth.k8s.mountPoint }}
+            {{- else if .Values.api.vault.auth.appRole.enabled }}
+            - name: VAULT_AUTH_METHOD
+              value: APP_ROLE
+            - name: VAULT_ROLE_ID_FILE
+              value: {{ .Values.api.vault.auth.appRole.roleId }}
+            - name: VAULT_ROLE_SECRET_ID_FILE
+              value: {{ .Values.api.vault.auth.appRole.roleSecretId }}
+            {{- end }}
+            - name: VAULT_ENDPOINT
+              value: {{ .Values.api.vault.endpoint }}
+            - name: VAULT_MOUNT_PKI
+              value: {{ .Values.api.vault.mounts.pki }}
+            - name: VAULT_MOUNT_INTERMEDIATE_PKI
+              value: {{ .Values.api.vault.mounts.intermediatePki }}
+            - name: VAULT_MOUNT_KV
+              value: {{ .Values.api.vault.mounts.kv }}
+            - name: VAULT_PKI_SERVER_ROLE
+              value: {{ .Values.api.vault.pkiServerRole }}
+            - name: VAULT_PKI_CLIENT_ROLE
+              value: {{ .Values.api.vault.pkiClientRole }}
+            - name: VAULT_SIGN_EXPIRY_HOURS
+              value: {{ .Values.api.vault.signExpiryHours | quote }}
+            - name: CLIENT_CSR_PARAMETERS
+              value: /resources/tlsClientCSRParameters.json
+            - name: SERVER_CSR_PARAMETERS
+              value: /resources/tlsServerCSRParameters.json
+            - name: CA_CSR_PARAMETERS
+              value: /resources/caCSRParameters.json
+            - name: VAULT_MOUNT_DFSP_CLIENT_CERT_BUNDLE
+              value: {{ .Values.api.vault.mounts.dfspClientCertBundle | quote }}
+            - name: VAULT_MOUNT_DFSP_INT_IP_WHITELIST_BUNDLE
+              value: {{ .Values.api.vault.mounts.dfspInternalIPWhitelistBundle | quote }}
+            - name: VAULT_MOUNT_DFSP_EXT_IP_WHITELIST_BUNDLE
+              value: {{ .Values.api.vault.mounts.dfspExternalIPWhitelistBundle | quote }}
+            - name: SWITCH_FQDN
+              value: {{ .Values.api.switchFQDN | quote }}
+            - name: PRIVATE_KEY_LENGTH
+              value: {{ .Values.api.vault.keyLength | quote }}
+            - name: CERT_MANAGER_ENABLED
+              value: {{ .Values.api.certManager.enabled | quote }}
+            - name: CERT_MANAGER_SERVER_CERT_SECRET_NAME
+              value: {{ .Values.api.certManager.serverCertSecretName | quote }}
+            - name: CERT_MANAGER_SERVER_CERT_SECRET_NAMESPACE
+              value: {{ .Values.api.certManager.serverCertSecretNamespace | quote }}
+          resources: {}
+          volumeMounts:
+          - name: {{ .Release.Name }}-secret-volume
+            readOnly: true
+            mountPath: /mcm_secrets
+          - name: tls-configmap
+            mountPath: /resources
+          stdin: true
+          tty: true
+      volumes:
+        - name: {{ .Release.Name }}-secret-volume
+          secret:
+            secretName: {{ .Release.Name }}-secret
+        - name: tls-configmap
+          configMap:
+            name: {{ include "connection-manager.fullname" . }}-api-tls-configmap
+            items:
+            - key: tlsClientCSRParameters.json
+              path: tlsClientCSRParameters.json
+            - key: tlsServerCSRParameters.json
+              path: tlsServerCSRParameters.json
+            - key: caCSRParameters.json
+              path: caCSRParameters.json
+      hostname: connection-manager-api
+      restartPolicy: Always
+status: {}
+{{- end -}}

--- a/connection-manager/templates/api-secret.yaml
+++ b/connection-manager/templates/api-secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secret
+type: Opaque
+data:
+  dummy: RFVNTVk=
+{{- if .Values.api.extraTLS.certChain.enabled }}
+  extraTLS_cert_chain.pem: {{ .Values.api.extraTLS.certChain.stringValue | b64enc }}
+{{- end }}
+{{- if .Values.api.extraTLS.rootCert.enabled }}
+  extraTLS_root_cert.pem: {{ .Values.api.extraTLS.rootCert.stringValue | b64enc }}
+{{- end }}
+{{- if .Values.api.wso2TokenIssuer.cert.enabled }}
+  wso2_token_issuer_cert.pem: {{ .Values.api.wso2TokenIssuer.cert.stringValue | b64enc }}
+{{- end }}

--- a/connection-manager/templates/api-service.yaml
+++ b/connection-manager/templates/api-service.yaml
@@ -1,0 +1,23 @@
+{{- if not .Values.api.disabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "connection-manager.fullname" . }}-api
+  labels:
+    app.kubernetes.io/component: api
+{{ include "connection-manager.labels" . | indent 4 }}
+spec:
+  type: "NodePort"
+  ports:
+    {{- with .Values.api }}
+    - name: {{ .ports.containerPort | quote }}
+      port: {{ .ports.containerPort }}
+      targetPort: {{ .ports.containerPort }}
+      nodePort: {{ .ports.nodePort }}
+    {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ include "connection-manager.fullname" . }}-api
+    app.kubernetes.io/instance: {{ .Release.Name }}
+status:
+  loadBalancer: {}
+{{- end -}}

--- a/connection-manager/templates/ingress.yaml
+++ b/connection-manager/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $k8sVer := .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" $k8sVer -}}
+apiVersion: networking.k8s.io/v1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ include "connection-manager.fullname" . }}-ingress
+{{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if semverCompare ">=1.19-0" $k8sVer }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /api/
+            {{- if semverCompare ">=1.19-0" $k8sVer }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend:
+            {{- if semverCompare ">=1.19-0" $k8sVer }}
+              service:
+                name: {{ include "connection-manager.fullname" . }}-api
+                port:
+                  number: {{ .Values.api.ports.containerPort }}
+            {{- else }}
+              serviceName: {{ include "connection-manager.fullname" . }}-api
+              servicePort: {{ .Values.api.ports.containerPort }}
+            {{- end }}
+          - path: /
+            {{- if semverCompare ">=1.19-0" $k8sVer }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend:
+            {{- if semverCompare ">=1.19-0" $k8sVer }}
+              service:
+                name: {{ include "connection-manager.fullname" . }}-ui
+                port:
+                  number: {{ .Values.ui.ports.containerPort }}
+            {{- else }}
+              serviceName: {{ include "connection-manager.fullname" . }}-ui
+              servicePort: {{ .Values.ui.ports.containerPort }}
+            {{- end }}
+{{- end -}}

--- a/connection-manager/templates/migrations.yaml
+++ b/connection-manager/templates/migrations.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.migrations.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{.Release.Name}}-migration-job
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-migration-job"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      containers:
+      - name: db-migration
+          {{- with .Values.api }}
+        image: "{{ .image.name }}:{{ .image.version }}"
+          {{- end }}
+        command:
+        - /usr/local/bin/npm
+        args:
+        - run
+        - migrate-and-seed
+        env:
+        - name: DATABASE_HOST
+          value: {{ .Values.db.host }}
+        - name: DATABASE_USER
+          value: {{ .Values.db.user }}
+        {{- if .Values.db.passwordSecret }}
+        - name: DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.db.passwordSecret }}
+              key: {{ .Values.db.passwordSecretKey }}
+        {{- else }}
+        - name: DATABASE_PASSWORD
+          value: {{ .Values.db.password }}
+        {{- end }}
+        - name: DATABASE_SCHEMA
+          value: {{ .Values.db.schema }}
+        - name: DATABASE_PORT
+          value: {{ .Values.db.port | quote }}
+      restartPolicy: OnFailure
+  backoffLimit: 20
+{{- end}}

--- a/connection-manager/templates/role.yaml
+++ b/connection-manager/templates/role.yaml
@@ -1,0 +1,22 @@
+{{- if and (not .Values.api.disabled) (.Values.api.rbac.enabled) -}}
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "connection-manager.fullname" . }}-api
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/component: api
+{{ include "connection-manager.labels" . | indent 4 }}
+
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+
+{{- end -}}

--- a/connection-manager/templates/rolebinding-cert-manager.yaml
+++ b/connection-manager/templates/rolebinding-cert-manager.yaml
@@ -1,0 +1,19 @@
+{{- if and (not .Values.api.disabled) (.Values.api.rbac.enabled) -}}
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "connection-manager.fullname" . }}-api-cert-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    {{- if .Values.api.serviceAccountNameOverride }}
+    name: {{ .Values.api.serviceAccountNameOverride }}
+    {{- else }}
+    name: {{ include "connection-manager.fullname" . }}-api
+    {{- end }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/connection-manager/templates/rolebinding-vault.yaml
+++ b/connection-manager/templates/rolebinding-vault.yaml
@@ -1,0 +1,19 @@
+{{- if and (not .Values.api.disabled) (.Values.api.rbac.enabled) -}}
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "connection-manager.fullname" . }}-api-vault
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    {{- if .Values.api.serviceAccountNameOverride }}
+    name: {{ .Values.api.serviceAccountNameOverride }}
+    {{- else }}
+    name: {{ include "connection-manager.fullname" . }}-api
+    {{- end }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/connection-manager/templates/service-account.yaml
+++ b/connection-manager/templates/service-account.yaml
@@ -1,0 +1,15 @@
+{{- if and (not .Values.api.disabled) (not .Values.api.serviceAccount.externallyManaged) -}}
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  {{- if .Values.api.serviceAccount.serviceAccountNameOverride }}
+  name: {{ .Values.api.serviceAccount.serviceAccountNameOverride }}
+  {{- else }}
+  name: {{ include "connection-manager.fullname" . }}-api
+  {{- end }}
+  labels:
+    app.kubernetes.io/component: api
+{{ include "connection-manager.labels" . | indent 4 }}
+
+{{- end -}}

--- a/connection-manager/templates/tests/api-test-runner.yaml
+++ b/connection-manager/templates/tests/api-test-runner.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.tests.api.enabled -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "connection-manager.fullname" . }}-api-test
+  labels:
+    app.kubernetes.io/component: test-api
+{{ include "connection-manager.labels" . | indent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: {{ .Values.tests.api.weight | quote }}
+    helm.sh/hook-delete-policy: {{ .Values.tests.api.deletePolicy }}
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test-runner
+      image: ubuntu
+      command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "----- Install dependencies -----"
+          apt-get update
+          apt-get -y install curl git
+          curl -o- $NVM_SCRIPT | bash
+          echo "----- Downloading $TEST_SCRIPT -----"
+          curl $TEST_SCRIPT --output /tmp/script.sh
+          echo "----- Running $TEST_SCRIPT -----"
+          bash -i /tmp/script.sh
+          set +e
+      env:
+        - name: NVM_SCRIPT
+          value: {{ printf "https://raw.githubusercontent.com/nvm-sh/nvm/%s/install.sh"  .Values.tests.api.nvm.version | quote }}
+        - name: TEST_SCRIPT
+          value: {{ tpl .Values.tests.api.script . | quote }}
+        - name: GIT_URL
+          value: {{ tpl .Values.tests.api.git.url . | quote }}
+        - name: GIT_TAG
+          value: {{ tpl .Values.tests.api.git.tag . | quote }}
+        - name: TARGET_DIR
+          value: {{ tpl .Values.tests.api.targetDirectory . | quote }}
+        {{- range $name, $value := .Values.tests.api.env }}
+        - name: {{ $name }}
+          value: {{ tpl $value $ | quote }}
+        {{- end }}
+{{- end}}

--- a/connection-manager/templates/ui-deployment.yaml
+++ b/connection-manager/templates/ui-deployment.yaml
@@ -1,0 +1,64 @@
+{{- if not .Values.ui.disabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "connection-manager.fullname" . }}-ui
+  labels:
+    app.kubernetes.io/component: ui
+{{ include "connection-manager.labels" . | indent 4 }}
+spec:
+  replicas: 1
+  strategy: {}
+  selector:
+    matchLabels: &labels
+      app.kubernetes.io/name: {{ include "connection-manager.fullname" .}}-ui
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels: *labels
+    spec:
+      containers:
+        - name: connection-manager-ui
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          env:
+            - name: API_BASE_URL
+              value: {{ .Values.api.url | quote }}
+            - name: CHECK_SESSION_URL
+              value: {{ .Values.ui.checkSessionUrl | quote }}
+            - name: LOGIN_URL
+              value: {{ .Values.ui.loginUrl | quote }}
+            - name: LOGIN_PROVIDER
+              value: {{ .Values.ui.loginProvider | quote }}
+            - name: LOGOUT_URL
+              value: {{ .Values.ui.logoutUrl | quote }}
+            {{- with .Values.ui.oauth }}
+            - name: AUTH_ENABLED
+              value: {{ .enabled | quote }}
+            - name: UI_OIDC_LOGIN_REDIRECT_URL
+              value: "{{ .hubOidcProviderUrl }}/auth"
+            - name: OIDC_TOKEN_PROVIDER_URL
+              value: "{{ .hubOidcProviderUrl }}/token"
+            - name: OIDC_CLIENT_ID
+              value: {{ .clientId | quote }}
+            - name: OIDC_CLIENT_SECRET
+              {{- if .clientSecretName }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .clientSecretName }}
+                  key: {{ .clientSecretKey }}
+              {{- else }}
+              value: {{ .clientSecret }}
+              {{- end }}
+            {{- end }}
+          {{- with .Values.ui }}
+          image: "{{ .image.name }}:{{ .image.version }}"
+          ports:
+            - containerPort: {{ .ports.containerPort }}
+          {{- end }}
+          resources: {}
+          stdin: true
+          tty: true
+      hostname: connection-manager-ui
+      restartPolicy: Always
+status: {}
+{{- end -}}

--- a/connection-manager/templates/ui-service.yaml
+++ b/connection-manager/templates/ui-service.yaml
@@ -1,0 +1,23 @@
+{{- if not .Values.ui.disabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "connection-manager.fullname" . }}-ui
+  labels:
+    app.kubernetes.io/component: ui
+{{ include "connection-manager.labels" . | indent 4 }}
+spec:
+  type: "NodePort"
+  ports:
+    {{- with .Values.ui }}
+    - name: {{ .ports.containerPort | quote }}
+      port: {{ .ports.containerPort }}
+      targetPort: {{ .ports.containerPort }}
+      nodePort: {{ .ports.nodePort }} 
+    {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ include "connection-manager.fullname" . }}-ui
+    app.kubernetes.io/instance: {{ .Release.Name }}
+status:
+  loadBalancer: {}
+{{- end -}}

--- a/connection-manager/values.yaml
+++ b/connection-manager/values.yaml
@@ -1,0 +1,200 @@
+api:
+  disabled: false
+  image:
+    name: ghcr.io/modusbox/connection-manager-api
+    version: v1.9.6
+  ports:
+    containerPort: 3001
+    nodePort: 31057
+  oauth:
+    enabled: "FALSE"
+    issuer: https://localhost/oauth2/token
+    key: mysecretkey
+    secret: changeme
+    resetPassword:
+      issuer: https://localhost/scim2/Users
+      user: myuser
+      pass: changeme
+  url: https://localhost
+  auth2fa:
+    enabled: "FALSE"
+  totp:
+    admin:
+      issuer: https://localhost/totp
+      user: myuser
+      password: changeme
+    label: MCM
+    issuer: MCM
+  wso2:
+    manager:
+      service:
+        url: https://localhost:9443/services/RemoteUserStoreManagerService.RemoteUserStoreManagerServiceHttpsSoap12Endpoint
+        user: myuser
+        pass: changeme
+  extraTLS:
+    certChain:
+      enabled: 0
+      stringValue: this_is_a_default
+    rootCert:
+      enabled: 0
+      stringValue: this_is_a_default
+  wso2TokenIssuer:
+    cert:
+      enabled: 0
+      stringValue: this_is_a_default
+    embeddedCertificate:
+      enabled: 0
+      stringValue: this_is_a_default
+  switchFQDN: switch.example.com
+  certManager:
+    enabled: false
+    serverCertSecretName: dummy
+    serverCertSecretNamespace: dummy
+  vault:
+    auth:
+      k8s:
+        enabled: true
+        token: /var/run/secrets/kubernetes.io/serviceaccount/token
+        mountPoint: kubernetes
+        role: demo
+      appRole:
+        enabled: false
+        roleId: /vault/role-id
+        roleSecretId: /vault/role-secret-id
+    endpoint: http://vault:8200
+    mounts:
+      pki: pki
+      intermediatePki: pki_int
+      kv: secrets
+      dfspClientCertBundle: secret/onboarding_pm4mls
+      dfspInternalIPWhitelistBundle: secret/whitelist_pm4mls
+      dfspExternalIPWhitelistBundle: secret/whitelist_fsps
+    pkiServerRole: server-role
+    pkiClientRole: client-role
+    signExpiryHours: 43800
+    keyLength: 2048
+  serviceAccount:
+    externallyManaged: false
+    serviceAccountNameOverride: null
+  rbac:
+    enabled: true
+  annotations: {}
+
+ui:
+  disabled: false
+  checkSessionUrl: ''
+  loginUrl: ''
+  loginProvider: ''
+  logoutUrl: ''
+  image:
+    name: ghcr.io/pm4ml/connection-manager-ui
+    version: 1.8.4
+  ports:
+    containerPort: 8080
+    nodePort: 31627
+  oauth:
+    enabled: false
+    hubOidcProviderUrl: https://changeme
+    clientId: mcm-portal
+    clientSecret: changeme
+#    clientSecretName: changeme
+#    clientSecretKey: changeme
+
+migrations:
+  enabled: true
+
+db:
+  user: mcm
+  password: changeme
+  host: localhost
+  port: 3306
+  schema: mcm
+
+ingress:
+  enabled: true
+  host: localhost
+  annotations: {}
+  tls: []
+  pathType: ImplementationSpecific
+  className: "nginx"
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+# development friendly variables
+imagePullPolicy: IfNotPresent
+
+config:
+  tlsClientCSRParametersData: |-
+    {
+      "subject": {
+        "CN": "test_client_mcm",
+        "E": "mcm@test.com",
+        "O": "test",
+        "OU": "test",
+        "C": "US",
+        "ST": "test",
+        "L": "test"
+      },
+      "extensions": {
+        "subjectAltName": {
+          "dns": [
+          ],
+          "ips": [
+          ]
+        }
+      }
+    }
+  tlsServerCSRParametersData: |-
+    {
+      "subject": {
+        "CN": "test_client_mcm",
+        "E": "mcm@test.com",
+        "O": "test",
+        "OU": "test",
+        "C": "US",
+        "ST": "test",
+        "L": "test"
+      },
+      "extensions": {
+        "subjectAltName": {
+          "dns": [
+          ],
+          "ips": [
+          ]
+        }
+      }
+    }
+  caCSRParametersData: |-
+    {
+      "CN": "CA",
+      "E": "ca@test.com",
+      "O": "test",
+      "OU": "test",
+      "C": "US",
+      "ST": "test",
+      "L": "test"
+    }
+
+tests:
+  api:
+    enabled: true
+    weight: -5
+    deletePolicy: before-hook-creation
+    script: "https://raw.githubusercontent.com/modusbox/connection-manager-api/{{ .Values.api.image.version }}/scripts/run-functional-tests.sh"
+    git:
+      url: https://github.com/modusbox/connection-manager-api.git
+      tag: "{{ .Values.api.image.version }}"
+    targetDirectory: /tmp/tests
+    nvm:
+      version: v0.39.1
+    # Configuration Ref: https://github.com/modusbox/connection-manager-api/tree/master/functional-tests#configuration
+    env:
+      # MCM API URL e.g. http(s)://<host>:<port>/api
+      APP_ENDPOINT: 'http://{{ include "connection-manager.fullname" . }}-api:3001/api'
+      # MCM OAuth Client Key
+      APP_OAUTH_CLIENT_KEY: '{{ if eq (.Values.api.oauth.enabled | toString | lower) "true" }}{{ .Values.api.oauth.key }}{{ end }}'
+      # MCM OAuth Client Secret
+      APP_OAUTH_CLIENT_SECRET: '{{ if eq (.Values.api.oauth.enabled | toString | lower) "true" }}{{ .Values.api.oauth.secret }}{{ end }}'
+      # OAuth Issuer URL e.g. http(s)://<host>:<port>/oauth2/token
+      # Note: `client_credentials` grant_type must be supported
+      OAUTH2_ISSUER: '{{ if eq (.Values.api.oauth.enabled | toString | lower) "true" }}{{ .Values.api.oauth.issuer }}{{ end }}'


### PR DESCRIPTION
Adding connection manager chart from pm4ml org repo. This will now be hosted here. Chart is added at v0.7.7 to enable this known stable build to be used initially. Version to be bumped once this version is published.