### PR TITLE
chore: update text to indicate helm test commands only apply if the ml ttk is enabled

### DIFF
--- a/mojaloop/templates/NOTES.txt
+++ b/mojaloop/templates/NOTES.txt
@@ -32,6 +32,9 @@ To view the post-hook test report, you can use the following command:
 
 {{- if or (index .Values "ml-ttk-test-setup" "tests" "enabled") (index .Values "ml-ttk-test-val-gp" "tests" "tests") }}
 
+**NOTE**: The below commands to test a Mojaloop deployment are ONLY applicable if the Mojaloop Testing Toolkit (TTK) is enabled
+These commands will not apply if the TTK is disabled in a particular deployment.
+
 Use the following command to execute Test cases:
 
   $ helm -n {{ .Release.Namespace }} test {{ .Release.Name }}


### PR DESCRIPTION
Update text to indicate helm test commands only apply if the ml ttk is enabled)

Related to issue: https://github.com/mojaloop/project/issues/3149