### PR TITLE
[auto] feat: release candidate for  v17.1.0

### DIFF
--- a/.changelog/release-v17.1.0.md
+++ b/.changelog/release-v17.1.0.md
@@ -1,0 +1,167 @@
+# Helm Release Notes
+
+Date | Revision | Description
+---------|----------|---------
+2025-08-05 | 0 | Initial draft
+
+## 0. Summary
+
+Enhancements and breaking changes to the [v17.0.0 Release](https://github.com/mojaloop/helm/blob/main/.changelog/release-v17.0.0.md), which includes:
+
+_Release summary points go here..._
+
+## 1. New Features
+* **mojaloop/#541** reset party mappings in inter-scheme scenario ([mojaloop/#541](https://github.com/mojaloop/account-lookup-service/pull/541)), closes [mojaloop/#541](https://github.com/mojaloop/project/issues/541)
+* **mojaloop/#546** refactored oracleRequest ([mojaloop/#546](https://github.com/mojaloop/account-lookup-service/pull/546)), closes [mojaloop/#546](https://github.com/mojaloop/project/issues/546)
+* **mojaloop/#549** use updated AxiosHttpRequester ([mojaloop/#549](https://github.com/mojaloop/account-lookup-service/pull/549)), closes [mojaloop/#549](https://github.com/mojaloop/project/issues/549)
+* **mojaloop/#556** used ha timeout design with redlock impl ([mojaloop/#556](https://github.com/mojaloop/account-lookup-service/pull/556)), closes [mojaloop/#556](https://github.com/mojaloop/project/issues/556)
+* **mojaloop/#1172** timeout handler distributed lock ([mojaloop/#1172](https://github.com/mojaloop/central-ledger/pull/1172)), closes [mojaloop/#1172](https://github.com/mojaloop/project/issues/1172)
+* **mojaloop/#1185** moved distLock to central-services-shared ([mojaloop/#1185](https://github.com/mojaloop/central-ledger/pull/1185)), closes [mojaloop/#1185](https://github.com/mojaloop/project/issues/1185)
+* **mojaloop/#407** improved logging;  added BaseQuotesModel ([mojaloop/#407](https://github.com/mojaloop/quoting-service/pull/407)), closes [mojaloop/#407](https://github.com/mojaloop/project/issues/407)
+* **mojaloop/#409** use updated AxiosHttpRequester ([mojaloop/#409](https://github.com/mojaloop/quoting-service/pull/409)), closes [mojaloop/#409](https://github.com/mojaloop/project/issues/409)
+* **mojaloop/#572** use updated AxiosHttpRequester ([mojaloop/#572](https://github.com/mojaloop/sdk-scheme-adapter/pull/572)), closes [mojaloop/#572](https://github.com/mojaloop/project/issues/572)
+* **mojaloop/#574** added InboundPingModel ([mojaloop/#574](https://github.com/mojaloop/sdk-scheme-adapter/pull/574)), closes [mojaloop/#574](https://github.com/mojaloop/project/issues/574)
+
+## 2. Bug Fixes
+* **mojaloop/#547** delete participant audit ([mojaloop/#547](https://github.com/mojaloop/account-lookup-service/pull/547)), closes [mojaloop/#547](https://github.com/mojaloop/project/issues/547)
+* **mojaloop/#1173** fix issue with broker reporting OK when kafka is disconnected ([mojaloop/#1173](https://github.com/mojaloop/central-ledger/pull/1173)), closes [mojaloop/#1173](https://github.com/mojaloop/project/issues/1173)
+* **mojaloop/#1181** fixed issue with DIST_LOCK config ([mojaloop/#1181](https://github.com/mojaloop/central-ledger/pull/1181)), closes [mojaloop/#1181](https://github.com/mojaloop/project/issues/1181)
+* **mojaloop/#1182** fixed issue with DIST_LOCK config ([mojaloop/#1182](https://github.com/mojaloop/central-ledger/pull/1182)), closes [mojaloop/#1182](https://github.com/mojaloop/project/issues/1182)
+* **mojaloop/#1183** fixed misleading log ([mojaloop/#1183](https://github.com/mojaloop/central-ledger/pull/1183)), closes [mojaloop/#1183](https://github.com/mojaloop/project/issues/1183)
+* **mojaloop/#1189** switch to mysql2 client and update version for mysql v8 auth compatibility ([mojaloop/#1189](https://github.com/mojaloop/central-ledger/pull/1189)), closes [mojaloop/#1189](https://github.com/mojaloop/project/issues/1189)
+* **mojaloop/#600** improved error logs ([mojaloop/#600](https://github.com/mojaloop/ml-api-adapter/pull/600)), closes [mojaloop/#600](https://github.com/mojaloop/project/issues/600)
+
+## 3. Application Versions
+
+1. bulk-api-adapter: v17.1.9 ->                     [v17.2.2](https://github.com/mojaloop/bulk-api-adapter/releases/v17.2.2)                     ([Compare](https://github.com/mojaloop/bulk-api-adapter/compare/v17.1.9...v17.2.2))
+2. event-sidecar: v14.0.3 ->                     [v14.2.0](https://github.com/mojaloop/event-sidecar/releases/v14.2.0)                     ([Compare](https://github.com/mojaloop/event-sidecar/compare/v14.0.3...v14.2.0))
+3. ml-testing-toolkit-ui: v16.2.0 ->                     [v16.6.4](https://github.com/mojaloop/ml-testing-toolkit-ui/releases/v16.6.4)                     ([Compare](https://github.com/mojaloop/ml-testing-toolkit-ui/compare/v16.2.0...v16.6.4))
+4. als-oracle-pathfinder: v12.1.3 ->                     [v12.3.1](https://github.com/mojaloop/als-oracle-pathfinder/releases/v12.3.1)                     ([Compare](https://github.com/mojaloop/als-oracle-pathfinder/compare/v12.1.3...v12.3.1))
+5. auth-service: v15.1.2 ->                     [v15.2.7](https://github.com/mojaloop/auth-service/releases/v15.2.7)                     ([Compare](https://github.com/mojaloop/auth-service/compare/v15.1.2...v15.2.7))
+6. ml-testing-toolkit: v18.11.2 ->                     [v18.14.0](https://github.com/mojaloop/ml-testing-toolkit/releases/v18.14.0)                     ([Compare](https://github.com/mojaloop/ml-testing-toolkit/compare/v18.11.2...v18.14.0))
+7. als-msisdn-oracle-svc: v0.0.14 ->                     [v0.0.21](https://github.com/mojaloop/als-msisdn-oracle-svc/releases/v0.0.21)                     ([Compare](https://github.com/mojaloop/als-msisdn-oracle-svc/compare/v0.0.14...v0.0.21))
+8. transaction-requests-service: v14.3.9 ->                     [v14.4.5](https://github.com/mojaloop/transaction-requests-service/releases/v14.4.5)                     ([Compare](https://github.com/mojaloop/transaction-requests-service/compare/v14.3.9...v14.4.5))
+9. ml-api-adapter: v16.4.1 ->                     [v16.5.9](https://github.com/mojaloop/ml-api-adapter/releases/v16.5.9)                     ([Compare](https://github.com/mojaloop/ml-api-adapter/compare/v16.4.1...v16.5.9))
+10. ml-testing-toolkit-client-lib: v1.9.0 ->                     [v1.10.3](https://github.com/mojaloop/ml-testing-toolkit-client-lib/releases/v1.10.3)                     ([Compare](https://github.com/mojaloop/ml-testing-toolkit-client-lib/compare/v1.9.0...v1.10.3))
+11. callback-handler-simulator-svc:  ->                     [v0.1.3](https://github.com/mojaloop/callback-handler-simulator-svc/releases/v0.1.3)                     ([Compare](https://github.com/mojaloop/callback-handler-simulator-svc/compare/...v0.1.3))
+12. merchant-acquirer-backend:  ->                     [1.0.1](https://github.com/mojaloop/merchant-acquirer-backend/releases/1.0.1)                     ([Compare](https://github.com/mojaloop/merchant-acquirer-backend/compare/...1.0.1))
+13. sdk-scheme-adapter: v24.6.2 ->                     [v24.10.5](https://github.com/mojaloop/sdk-scheme-adapter/releases/v24.10.5)                     ([Compare](https://github.com/mojaloop/sdk-scheme-adapter/compare/v24.6.2...v24.10.5))
+14. mojaloop-simulator: v15.3.0 ->                     [v15.4.2](https://github.com/mojaloop/mojaloop-simulator/releases/v15.4.2)                     ([Compare](https://github.com/mojaloop/mojaloop-simulator/compare/v15.3.0...v15.4.2))
+15. thirdparty-api-svc: v15.0.2 ->                     [v15.1.2](https://github.com/mojaloop/thirdparty-api-svc/releases/v15.1.2)                     ([Compare](https://github.com/mojaloop/thirdparty-api-svc/compare/v15.0.2...v15.1.2))
+16. als-consent-oracle: v1.0.1 ->                     [v1.1.4](https://github.com/mojaloop/als-consent-oracle/releases/v1.1.4)                     ([Compare](https://github.com/mojaloop/als-consent-oracle/compare/v1.0.1...v1.1.4))
+17. account-lookup-service: v17.7.1 ->                     [v17.12.0](https://github.com/mojaloop/account-lookup-service/releases/v17.12.0)                     ([Compare](https://github.com/mojaloop/account-lookup-service/compare/v17.7.1...v17.12.0))
+18. simulator: v12.2.5 ->                     [v12.3.2](https://github.com/mojaloop/simulator/releases/v12.3.2)                     ([Compare](https://github.com/mojaloop/simulator/compare/v12.2.5...v12.3.2))
+19. merchant-acquirer-frontend:  ->                     [1.0.1](https://github.com/mojaloop/merchant-acquirer-frontend/releases/1.0.1)                     ([Compare](https://github.com/mojaloop/merchant-acquirer-frontend/compare/...1.0.1))
+20. quoting-service: v17.7.1 ->                     [v17.12.1](https://github.com/mojaloop/quoting-service/releases/v17.12.1)                     ([Compare](https://github.com/mojaloop/quoting-service/compare/v17.7.1...v17.12.1))
+21. merchant-registry-oracle:  ->                     [1.0.1](https://github.com/mojaloop/merchant-registry-oracle/releases/1.0.1)                     ([Compare](https://github.com/mojaloop/merchant-registry-oracle/compare/...1.0.1))
+22. central-ledger: v19.3.0 ->                     [v19.8.3](https://github.com/mojaloop/central-ledger/releases/v19.8.3)                     ([Compare](https://github.com/mojaloop/central-ledger/compare/v19.3.0...v19.8.3))
+23. ml-core-test-harness:  ->                     [v2.3.0](https://github.com/mojaloop/ml-core-test-harness/releases/v2.3.0)                     ([Compare](https://github.com/mojaloop/ml-core-test-harness/compare/...v2.3.0))
+24. central-settlement: v17.0.6 ->                     [v17.2.2](https://github.com/mojaloop/central-settlement/releases/v17.2.2)                     ([Compare](https://github.com/mojaloop/central-settlement/compare/v17.0.6...v17.2.2))
+25. email-notifier: v14.0.3 ->                     [v14.1.4](https://github.com/mojaloop/email-notifier/releases/v14.1.4)                     ([Compare](https://github.com/mojaloop/email-notifier/compare/v14.0.3...v14.1.4))
+26. central-event-processor: [v12.1.1](https://github.com/mojaloop/central-event-processor/releases/v12.1.1)
+27. inter-scheme-proxy-adapter: [v1.3.3](https://github.com/mojaloop/inter-scheme-proxy-adapter/releases/v1.3.3)
+28. thirdparty-sdk: [v15.1.3](https://github.com/mojaloop/thirdparty-sdk/releases/v15.1.3)
+29. event-stream-processor: [v12.0.0-snapshot.14](https://github.com/mojaloop/event-stream-processor/releases/v12.0.0-snapshot.14)
+
+## 4. API Versions
+
+This release supports the following versions of the [Mojaloop family of APIs](https://docs.mojaloop.io/api):
+
+| API         | Supported Versions                                                                                                                                    | Notes |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
+| FSPIOP      | [v1.1](https://docs.mojaloop.io/api/fspiop/v1.1/api-definition.html), [v1.0](https://docs.mojaloop.io/api/fspiop/v1.0/api-definition.html) |       |
+| Settlements | [v2.0](https://docs.mojaloop.io/api/settlement)                                                                                            |       |
+| Admin       | [v1.0](https://docs.mojaloop.io/api/administration/central-ledger-api.html)                                                                |       |
+| Oracle      | [v1.0](https://docs.mojaloop.io/legacy/api/als-oracle-api-specification.html)                                                              |       |
+| Thirdparty  | [v1.0](https://docs.mojaloop.io/api/thirdparty)                                                                                            |       |
+
+## 5. Testing notes
+
+1. This release has been validated against the following Dependency Test Matrix:
+
+    | Dependency | Version |  Notes   |
+    | ---------- | ------- | --- |
+    | Kubernetes | v1.29 | [AWS EKS](https://aws.amazon.com/eks/), [AWS EKS Supported Version Notes](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)  |
+    | containerd  |  v1.6.19  |  |
+    | Nginx Ingress Controller | [helm-ingress-nginx-4.7.0](https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.7.0) / [ingress-controller-v1.8.0](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.8.0) |     |
+    |  Amazon Linux   |  v2   |     |
+    |  MySQL   |  bitnami/mysql:8.0.32-debian-11-r0   |     |
+    |  Kafka   |  bitnami/kafka:3.3.1-debian-11-r1   |     |
+    |  Redis   |  bitnami/redis:7.0.5-debian-11-r7   |     |
+    |  MongoDB   |  bitnami/mongodb:6.0.2-debian-11-r11   |     |
+    |  Testing Toolkit Test Cases   |  [v17.1.0](https://github.com/mojaloop/testing-toolkit-test-cases/releases/tag/v17.1.0)   |     |
+    |  example-mojaloop-backend   |  v17.0.0   |  [README](https://github.com/mojaloop/helm/blob/main/example-mojaloop-backend/README.md)   |
+
+2. It is recommended that all Mojaloop deployments are verified using the [Mojaloop Testing Toolkit](https://docs.mojaloop.io/documentation/mojaloop-technical-overview/ml-testing-toolkit/). More information can be found in the [Mojaloop Deployment Guide](https://docs.mojaloop.io/documentation/deployment-guide).
+
+3. The [testing-toolkit-test-cases](https://github.com/mojaloop/testing-toolkit-test-cases/releases) (See above Dependency Test Matrix for exact version required for this release) Golden Path collections expects:
+    - the Quoting service operating mode to be set quoting-service.config.simple_routing_mode_enabled=true (in helm mojaloop/values.yaml under quoting-service config). If this is incorrectly configured, it will result in several failures in the quoting-service tests (7 expected failures). If this is disabled, ensure that you update the corresponding test-case environment variable parameter **SIMPLE_ROUTING_MODE_ENABLED** ( in helm mojaloop/values.yaml ml-testing-toolkit -> extraEnvironments.hub-k8s-default-environment.json.inputValues) to match.
+    - the **on-us transfers** (in mojaloop/values.yaml "enable_on_us_transfers: false" under centralledger-handler-transfer-prepare -> config and  cl-handler-bulk-transfer-prepare -> config) configuration to be disabled. The test-case environment variable parameter (**ON_US_TRANSFERS_ENABLED** (in helm mojaloop/values.yaml ml-testing-toolkit -> extraEnvironments.hub-k8s-default-environment.json.inputValues), the same name used on postman collections) must similarly match this value.
+
+4. Simulators
+    - We recommend using Testing Toolkit instead of Postman which is better suited for the async nature of the Mojaloop API specification (see above)
+    - [Mojaloop-Simulator](https://github.com/mojaloop/mojaloop-simulator) is enabled by default (six instances used for single transfers usually and three more specific to bulk).
+    - Ensure that correct Postman Scripts are used if you wish to test against the Mojaloop-Simulators:
+        - Setup Mojaloop Hub: [MojaloopHub_Setup](https://github.com/mojaloop/postman/blob/v12.0.0/MojaloopHub_Setup.postman_collection.json)
+        - Setup Mojaloop Simulators for testing : [MojaloopSims_Onboarding](https://github.com/mojaloop/postman/blob/v12.0.0/MojaloopSims_Onboarding.postman_collection.json)
+        - Golden path tests: [Golden_Path_Mojaloop](https://github.com/mojaloop/postman/blob/v12.0.0/Golden_Path_Mojaloop.postman_collection.json)
+    - Legacy Simulators are still required and deployed by default; disabling this will cause issues since there is Account Lookup directory mocking functionality in this service.
+
+5. Thirdparty Testing Toolkit Test Collections are not repeatable. Please refer to the following issue for more information [#2717 - Thirdparty TTK Test-Collection is not repeatable](https://github.com/mojaloop/project/issues/2717). It is possible to manually cleanup persistent data to re-run the test if required.
+
+6. Bulk API Helm Tests
+
+    Refer to the [Testing Deployments](https://github.com/mojaloop/helm/blob/main/README.md#testing-deployments) section in the main README for detailed information on how to enable bulk-api-adapter tests.
+
+7. Thirdparty API Helm Tests
+
+    Refer to [thirdparty/README.md#validating-and-testing-the-3p-api](https://github.com/mojaloop/helm/blob/main/thirdparty/README.md#validating-and-testing-the-3p-api) on how to enabled and execute Thirdparty verification tests.
+
+8. Testing the Bulk functionality including "sdk-scheme-adapter"
+
+    For details regarding deployment and validation of simulators needed for bulk (for adoption provided in sdk-scheme-adapter) refer to [deploying Mojaloop TTK simulators](https://github.com/mojaloop/helm/blob/main/mojaloop-ttk-simulators/README.md).
+
+## 6. Breaking Changes
+
+
+### central-ledger
+  * config/default.json: (https://github.com/mojaloop/central-ledger/blob/6d3f5a703954f5dd46c8c69f5827b24e4138cba5/config%2Fdefault.json)
+  * docker/central-ledger/default.json: (https://github.com/mojaloop/central-ledger/blob/6d3f5a703954f5dd46c8c69f5827b24e4138cba5/docker%2Fcentral-ledger%2Fdefault.json)
+  * migrations/310403_participantPositionChange-participantCurrencyId.js: (https://github.com/mojaloop/central-ledger/blob/6d3f5a703954f5dd46c8c69f5827b24e4138cba5/migrations%2F310403_participantPositionChange-participantCurrencyId.js)
+### als-msisdn-oracle-svc
+  * config/default.json: (https://github.com/mojaloop/als-msisdn-oracle-svc/blob/41f9f1e836663250de6bfc5d6fa898c6aef1b059/config%2Fdefault.json)
+### ml-api-adapter
+  * docker/central-ledger/default.json: (https://github.com/mojaloop/ml-api-adapter/blob/e51b271c85794132579429b8ff36a937cb087c99/docker%2Fcentral-ledger%2Fdefault.json)
+### quoting-service
+  * config/default.json: (https://github.com/mojaloop/quoting-service/blob/e4dd481c1dd8ef0dc5f4d353ee4ac1c7c0bcd7f1/config%2Fdefault.json)
+  * docker/central-ledger/default.json: (https://github.com/mojaloop/quoting-service/blob/e4dd481c1dd8ef0dc5f4d353ee4ac1c7c0bcd7f1/docker%2Fcentral-ledger%2Fdefault.json)
+  * docker/quoting-service/default.json: (https://github.com/mojaloop/quoting-service/blob/e4dd481c1dd8ef0dc5f4d353ee4ac1c7c0bcd7f1/docker%2Fquoting-service%2Fdefault.json)
+### central-settlement
+  * config/default.json: (https://github.com/mojaloop/central-settlement/blob/68a55c535102b3301d0f63fa6cc803541e49dab5/config%2Fdefault.json)
+  * docker/central-ledger/default.json: (https://github.com/mojaloop/central-settlement/blob/68a55c535102b3301d0f63fa6cc803541e49dab5/docker%2Fcentral-ledger%2Fdefault.json)
+  * docker/central-settlement/default.json: (https://github.com/mojaloop/central-settlement/blob/68a55c535102b3301d0f63fa6cc803541e49dab5/docker%2Fcentral-settlement%2Fdefault.json)
+### als-consent-oracle
+  * config/default.json: (https://github.com/mojaloop/als-consent-oracle/blob/2f04eeaa513025d8c77e78cc6d5e733c26441480/config%2Fdefault.json)
+### account-lookup-service
+  * config/default.json: (https://github.com/mojaloop/account-lookup-service/blob/42e14267b5c006b44342983bc85c29af98f78c1f/config%2Fdefault.json)
+  * docker/account-lookup-service/default.json: (https://github.com/mojaloop/account-lookup-service/blob/42e14267b5c006b44342983bc85c29af98f78c1f/docker%2Faccount-lookup-service%2Fdefault.json)
+  * docker/central-ledger/default.json: (https://github.com/mojaloop/account-lookup-service/blob/42e14267b5c006b44342983bc85c29af98f78c1f/docker%2Fcentral-ledger%2Fdefault.json)
+
+## 7. Known Issues
+
+1. [#2119 - Idempotency for duplicate quote request](https://github.com/mojaloop/project/issues/2119)
+2. [#2322 - Helm install failing with with "medium to large" release names](https://github.com/mojaloop/project/issues/2322)
+3. [#2317 - Mojaloop Helm deployments are not compatible when deployed to ARM-arch based hosts](https://github.com/mojaloop/project/issues/2317)
+4. [#2435 - Quoting-Service is incorrectly handling failed responses to FSPs when forwarding requests](https://github.com/mojaloop/project/issues/2435)
+5. Test issues causing instability/intermitant failures on Test Case Results
+    1. [#2717 - Thirdparty TTK Test-Collection is not repeatable](https://github.com/mojaloop/project/issues/2717)
+    2. [#2925 - Helm Test Intermittent failure with 'Generic ID not found](https://github.com/mojaloop/project/issues/2925)
+
+## 8. Contributors
+
+- Organizations: BMGF, InFiTX, MLF
+- Individuals: @dependabot[bot], @devarsh10, @geka-evk, @gibaros, @kalinkrustev, @kirgene, @kleyow, @oderayi, @s-prak, @shashi165, @vijayg10
+
+*Note: companies are in alphabetical order, individuals are in no particular order.*
+
+**Full Changelog**: https://github.com/mojaloop/helm/compare/v17.0.0...v17.1.0

--- a/account-lookup-service/Chart.yaml
+++ b/account-lookup-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 15.0.0
-appVersion: "account-lookup-service: v17.12.0; als-oracle-pathfinder: v12.1.3"
+version: 15.8.0
+appVersion: "account-lookup-service: v17.12.2; als-oracle-pathfinder: v12.3.1"
 description: Account Lookup Service Helm Chart for Mojaloop
 name: account-lookup-service
 maintainers:
@@ -10,23 +10,23 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: account-lookup-service
-    version: ">= 15.0.0"
+    version: ">= 15.3.0"
     repository: "file://./chart-service"
     condition: account-lookup-service.enabled
   - name: account-lookup-service-admin
-    version: ">= 15.0.0"
+    version: ">= 15.3.0"
     repository: "file://./chart-admin"
     condition: account-lookup-service-admin.enabled
   - name: account-lookup-service-handler-timeout
-    version: ">= 2.0.0"
+    version: ">= 2.3.0"
     repository: "file://./chart-handler-timeout"
     condition: account-lookup-service-handler-timeout.enabled
   - name: als-oracle-pathfinder
-    version: ">= 13.5.0"
+    version: ">= 13.7.0"
     repository: "file://../als-oracle-pathfinder"
     condition: als-oracle-pathfinder.enabled
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common

--- a/account-lookup-service/chart-admin/Chart.yaml
+++ b/account-lookup-service/chart-admin/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 15.0.0
-appVersion: v17.12.0
+version: 15.3.0
+appVersion: v17.12.2
 description: A Helm chart for Kubernetes
 name: account-lookup-service-admin
 maintainers:
@@ -11,7 +11,7 @@ maintainers:
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common
   - name: mojaloop-common

--- a/account-lookup-service/chart-admin/values.yaml
+++ b/account-lookup-service/chart-admin/values.yaml
@@ -5,7 +5,7 @@
 image:
   registry: docker.io
   repository: mojaloop/account-lookup-service
-  tag: v17.12.0
+  tag: v17.12.2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -87,7 +87,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.3
+    tag: v14.2.0
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:

--- a/account-lookup-service/chart-handler-timeout/Chart.yaml
+++ b/account-lookup-service/chart-handler-timeout/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 2.0.0
-appVersion: v17.12.0
+version: 2.3.0
+appVersion: v17.12.2
 description: A Helm chart for Kubernetes
 name: account-lookup-service-handler-timeout
 maintainers:
@@ -9,7 +9,7 @@ maintainers:
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common
   - name: mojaloop-common

--- a/account-lookup-service/chart-handler-timeout/values.yaml
+++ b/account-lookup-service/chart-handler-timeout/values.yaml
@@ -5,7 +5,7 @@
 image:
   registry: docker.io
   repository: mojaloop/account-lookup-service
-  tag: v17.12.0
+  tag: v17.12.2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -89,7 +89,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.3
+    tag: v14.2.0
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:

--- a/account-lookup-service/chart-service/Chart.yaml
+++ b/account-lookup-service/chart-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 15.0.0
-appVersion: v17.12.0
+version: 15.3.0
+appVersion: v17.12.2
 description: A Helm chart for Kubernetes
 name: account-lookup-service
 maintainers:
@@ -11,7 +11,7 @@ maintainers:
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common
   - name: mojaloop-common

--- a/account-lookup-service/chart-service/values.yaml
+++ b/account-lookup-service/chart-service/values.yaml
@@ -5,7 +5,7 @@
 image:
   registry: docker.io
   repository: mojaloop/account-lookup-service
-  tag: v17.12.0
+  tag: v17.12.2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -89,7 +89,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.3
+    tag: v14.2.0
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:

--- a/account-lookup-service/values.yaml
+++ b/account-lookup-service/values.yaml
@@ -7,7 +7,7 @@ account-lookup-service:
   image:
     registry: docker.io
     repository: mojaloop/account-lookup-service
-    tag: v17.12.0
+    tag: v17.12.2
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -322,7 +322,7 @@ account-lookup-service-admin:
   image:
     registry: docker.io
     repository: mojaloop/account-lookup-service
-    tag: v17.12.0
+    tag: v17.12.2
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -971,7 +971,7 @@ als-oracle-pathfinder:
   # Declare variables to be passed into your templates.
   image:
     repository: mojaloop/als-oracle-pathfinder
-    tag: v12.3.0
+    tag: v12.3.1
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/als-oracle-pathfinder/Chart.yaml
+++ b/als-oracle-pathfinder/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: A PathFinder oracle for ALS. Resolves MSISDN to participant ID.
 name: als-oracle-pathfinder
-version: 13.5.0
-appVersion: v12.1.3
+version: 13.7.0
+appVersion: v12.3.1
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -15,6 +15,6 @@ maintainers:
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common

--- a/als-oracle-pathfinder/values.yaml
+++ b/als-oracle-pathfinder/values.yaml
@@ -7,7 +7,7 @@ global: {}
 # Declare variables to be passed into your templates.
 image:
   repository: mojaloop/als-oracle-pathfinder
-  tag: v12.1.3
+  tag: v12.3.1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bulk-api-adapter/Chart.yaml
+++ b/bulk-api-adapter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: bulk-api-adapter Helm chart for Kubernetes
 name: bulk-api-adapter
-version: 14.10.0
-appVersion: v17.1.9
+version: 14.14.0
+appVersion: v17.2.2
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -16,15 +16,15 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: bulk-api-adapter-service
-    version: ">= 14.6.0"
+    version: ">= 14.8.0"
     repository: "file://./chart-service"
     condition: bulk-api-adapter-service.enabled
   - name: bulk-api-adapter-handler-notification
-    version: ">= 14.5.0"
+    version: ">= 14.7.0"
     repository: "file://./chart-handler-notification"
     condition: bulk-api-adapter-handler-notification.enabled
   - name: common
     repository: https://mojaloop.github.io/charts/repo
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common

--- a/bulk-api-adapter/chart-handler-notification/Chart.yaml
+++ b/bulk-api-adapter/chart-handler-notification/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: bulk-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: bulk-api-adapter-handler-notification
-version: 14.5.0
-appVersion: v17.1.9
+version: 14.7.0
+appVersion: v17.2.2
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -17,6 +17,6 @@ maintainers:
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common

--- a/bulk-api-adapter/chart-handler-notification/values.yaml
+++ b/bulk-api-adapter/chart-handler-notification/values.yaml
@@ -5,7 +5,7 @@
 image:
   registry: docker.io
   repository: mojaloop/bulk-api-adapter
-  tag: v17.1.9
+  tag: v17.2.2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bulk-api-adapter/chart-service/Chart.yaml
+++ b/bulk-api-adapter/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: bulk-api-adapter API component Helm chart for Kubernetes
 name: bulk-api-adapter-service
-version: 14.6.1
-appVersion: v17.1.9
+version: 14.8.0
+appVersion: v17.2.2
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -17,6 +17,6 @@ maintainers:
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common

--- a/bulk-api-adapter/chart-service/values.yaml
+++ b/bulk-api-adapter/chart-service/values.yaml
@@ -5,7 +5,7 @@
 image:
   registry: docker.io
   repository: mojaloop/bulk-api-adapter
-  tag: v17.1.9
+  tag: v17.2.2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bulk-api-adapter/values.yaml
+++ b/bulk-api-adapter/values.yaml
@@ -13,7 +13,7 @@ bulk-api-adapter-service:
   image:
     registry: docker.io
     repository: mojaloop/bulk-api-adapter
-    tag: v17.1.9
+    tag: v17.2.2
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -317,7 +317,7 @@ bulk-api-adapter-handler-notification:
   image:
     registry: docker.io
     repository: mojaloop/bulk-api-adapter
-    tag: v17.1.9
+    tag: v17.2.2
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bulk-centralledger/Chart.yaml
+++ b/bulk-centralledger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Bulk Services Helm chart for Kubernetes
 name: bulk-centralledger
-version: 14.16.0
-appVersion: v19.7.0
+version: 14.24.0
+appVersion: v19.8.3
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -16,15 +16,15 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: cl-handler-bulk-transfer-prepare
-    version: ">= 14.7.0"
+    version: ">= 14.9.0"
     repository: "file://./chart-handler-bulk-transfer-prepare"
     condition: cl-handler-bulk-transfer-prepare.enabled
   - name: cl-handler-bulk-transfer-fulfil
-    version: ">= 14.7.0"
+    version: ">= 14.9.0"
     repository: "file://./chart-handler-bulk-transfer-fulfil"
     condition: cl-handler-bulk-transfer-fulfil.enabled
   - name: cl-handler-bulk-transfer-processing
-    version: ">= 14.7.0"
+    version: ">= 14.9.0"
     repository: "file://./chart-handler-bulk-transfer-processing"
     condition: cl-handler-bulk-transfer-processing.enabled
   - name: cl-handler-bulk-transfer-get
@@ -33,6 +33,6 @@ dependencies:
     condition: cl-handler-bulk-transfer-get.enabled
   - name: common
     repository: https://mojaloop.github.io/charts/repo
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Bulk Transfer Fulfil Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-fulfil
-version: 14.7.0
-appVersion: v19.7.0
+version: 14.9.0
+appVersion: v19.8.3
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -17,7 +17,7 @@ maintainers:
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common
   - name: mojaloop-common

--- a/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-fulfil/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v19.8.0
+  tag: v19.8.3
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bulk-centralledger/chart-handler-bulk-transfer-get/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-get/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Bulk Transfer Get Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-get
-version: 14.7.0
-appVersion: v19.7.0
+version: 14.9.0
+appVersion: v19.8.3
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -17,7 +17,7 @@ maintainers:
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common
   - name: mojaloop-common

--- a/bulk-centralledger/chart-handler-bulk-transfer-get/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-get/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v19.8.0
+  tag: v19.8.3
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Bulk Transfer Prepare Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-prepare
-version: 14.7.0
-appVersion: v19.7.0
+version: 14.9.0
+appVersion: v19.8.3
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -17,7 +17,7 @@ maintainers:
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common
   - name: mojaloop-common

--- a/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-prepare/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v19.8.0
+  tag: v19.8.3
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Bulk Transfer Processing Handler Helm chart for Kubernetes
 name: cl-handler-bulk-transfer-processing
-version: 14.7.0
-appVersion: v19.7.0
+version: 14.9.0
+appVersion: v19.8.3
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -17,7 +17,7 @@ maintainers:
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common
   - name: mojaloop-common

--- a/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
+++ b/bulk-centralledger/chart-handler-bulk-transfer-processing/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v19.8.0
+  tag: v19.8.3
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bulk-centralledger/values.yaml
+++ b/bulk-centralledger/values.yaml
@@ -13,7 +13,7 @@ cl-handler-bulk-transfer-prepare:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v19.7.0
+    tag: v19.8.3
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -396,7 +396,7 @@ cl-handler-bulk-transfer-fulfil:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v19.7.0
+    tag: v19.8.3
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -767,7 +767,7 @@ cl-handler-bulk-transfer-processing:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v19.7.0
+    tag: v19.8.3
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1147,7 +1147,7 @@ cl-handler-bulk-transfer-get:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v19.7.0
+    tag: v19.8.3
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/centralledger/Chart.yaml
+++ b/centralledger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Helm chart for Kubernetes
 name: centralledger
-version: 14.41.2
-appVersion: v14.0.4
+version: 14.56.0
+appVersion: v19.8.3
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -16,31 +16,31 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: centralledger-service
-    version: ">= 14.7.2"
+    version: ">= 14.9.0"
     repository: "file://./chart-service"
     condition: centralledger-service.enabled
   - name: centralledger-handler-transfer-prepare
-    version: ">= 14.7.2"
+    version: ">= 14.9.0"
     repository: "file://./chart-handler-transfer-prepare"
     condition: centralledger-handler-transfer-prepare.enabled
   - name: centralledger-handler-transfer-position
-    version: ">= 14.7.2"
+    version: ">= 14.9.0"
     repository: "file://./chart-handler-transfer-position"
     condition: centralledger-handler-transfer-position.enabled
   - name: centralledger-handler-transfer-position-batch
-    version: ">= 14.7.2"
+    version: ">= 14.9.0"
     repository: "file://./chart-handler-transfer-position-batch"
     condition: centralledger-handler-transfer-position-batch.enabled
   - name: centralledger-handler-transfer-get
-    version: ">= 14.7.2"
+    version: ">= 14.9.0"
     repository: "file://./chart-handler-transfer-get"
     condition: centralledger-handler-transfer-get.enabled
   - name: centralledger-handler-transfer-fulfil
-    version: ">= 14.7.2"
+    version: ">= 14.9.0"
     repository: "file://./chart-handler-transfer-fulfil"
     condition: centralledger-handler-transfer-fulfil.enabled
   - name: centralledger-handler-timeout
-    version: ">= 14.7.2"
+    version: ">= 14.9.0"
     repository: "file://./chart-handler-timeout"
     condition: centralledger-handler-timeout.enabled
   - name: centralledger-handler-admin-transfer

--- a/centralledger/chart-handler-admin-transfer/Chart.yaml
+++ b/centralledger/chart-handler-admin-transfer/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-admin-transfer
-version: 14.7.4
-appVersion: v19.7.4
+version: 14.9.0
+appVersion: v19.8.3
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-admin-transfer/values.yaml
+++ b/centralledger/chart-handler-admin-transfer/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v19.8.0
+  tag: v19.8.3
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -96,7 +96,7 @@ sidecar:
   enabled: false
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.3
+    tag: v14.2.0
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:

--- a/centralledger/chart-handler-timeout/Chart.yaml
+++ b/centralledger/chart-handler-timeout/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Timeout Handler Helm chart for Kubernetes
 name: centralledger-handler-timeout
-version: 14.7.4
-appVersion: v19.7.4
+version: 14.9.0
+appVersion: v19.8.3
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-timeout/values.yaml
+++ b/centralledger/chart-handler-timeout/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v19.8.0
+  tag: v19.8.3
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -91,7 +91,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.3
+    tag: v14.2.0
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:

--- a/centralledger/chart-handler-transfer-fulfil/Chart.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Transfer Fulfil Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-fulfil
-version: 14.7.4
-appVersion: v19.7.4
+version: 14.9.0
+appVersion: v19.8.3
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-fulfil/values.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v19.8.0
+  tag: v19.8.3
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -96,7 +96,7 @@ sidecar:
   enabled: false
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.3
+    tag: v14.2.0
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:

--- a/centralledger/chart-handler-transfer-get/Chart.yaml
+++ b/centralledger/chart-handler-transfer-get/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Get Transfer Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-get
-version: 14.7.4
-appVersion: v19.7.4
+version: 14.9.0
+appVersion: v19.8.3
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-get/values.yaml
+++ b/centralledger/chart-handler-transfer-get/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v19.8.0
+  tag: v19.8.3
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -96,7 +96,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.3
+    tag: v14.2.0
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:

--- a/centralledger/chart-handler-transfer-position/Chart.yaml
+++ b/centralledger/chart-handler-transfer-position/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Transfer Position Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-position
-version: 14.7.4
-appVersion: v19.7.4
+version: 14.9.0
+appVersion: v19.8.3
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-position/values.yaml
+++ b/centralledger/chart-handler-transfer-position/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v19.8.0
+  tag: v19.8.3
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -96,7 +96,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.3
+    tag: v14.2.0
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:

--- a/centralledger/chart-handler-transfer-prepare/Chart.yaml
+++ b/centralledger/chart-handler-transfer-prepare/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Transfer Prepare Handler Helm chart for Kubernetes
 name: centralledger-handler-transfer-prepare
-version: 14.7.4
-appVersion: v19.7.4
+version: 14.9.0
+appVersion: v19.8.3
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-handler-transfer-prepare/values.yaml
+++ b/centralledger/chart-handler-transfer-prepare/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v19.8.0
+  tag: v19.8.3
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -96,7 +96,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.3
+    tag: v14.2.0
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:

--- a/centralledger/chart-service/Chart.yaml
+++ b/centralledger/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Ledger Service Helm chart for Kubernetes
 name: centralledger-service
-version: 14.7.4
-appVersion: v19.7.4
+version: 14.9.0
+appVersion: v19.8.3
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-ledger
-  tag: v19.8.0
+  tag: v19.8.3
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -89,7 +89,7 @@ sidecar:
   enabled: false
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.3
+    tag: v14.2.0
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -16,7 +16,7 @@ centralledger-service:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v19.8.0
+    tag: v19.8.3
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -409,7 +409,7 @@ centralledger-handler-transfer-prepare:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v19.8.0
+    tag: v19.8.3
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -824,7 +824,7 @@ centralledger-handler-transfer-position:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v19.8.0
+    tag: v19.8.3
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1654,7 +1654,7 @@ centralledger-handler-transfer-get:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v19.8.0
+    tag: v19.8.3
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2066,7 +2066,7 @@ centralledger-handler-transfer-fulfil:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v19.8.0
+    tag: v19.8.3
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2478,7 +2478,7 @@ centralledger-handler-timeout:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v19.8.0
+    tag: v19.8.3
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2895,7 +2895,7 @@ centralledger-handler-admin-transfer:
   image:
     registry: docker.io
     repository: mojaloop/central-ledger
-    tag: v19.8.0
+    tag: v19.8.3
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/centralsettlement/Chart.yaml
+++ b/centralsettlement/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Settlement Helm chart for Kubernetes
 name: centralsettlement
-version: 14.19.0
-appVersion: v17.2.0
+version: 14.31.0
+appVersion: v17.2.2
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -16,22 +16,22 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: centralsettlement-service
-    version: ">= 15.4.0"
+    version: ">= 15.6.0"
     repository: "file://./chart-service"
     alias: centralsettlement-service
     condition: centralsettlement-service.enabled
   - name: centralsettlement-service
-    version: ">= 15.4.0"
+    version: ">= 15.6.0"
     repository: "file://./chart-service"
     alias: centralsettlement-handler-deferredsettlement
     condition: centralsettlement-handler-deferredsettlement.enabled
   - name: centralsettlement-service
-    version: ">= 15.4.0"
+    version: ">= 15.6.0"
     repository: "file://./chart-service"
     alias: centralsettlement-handler-grosssettlement
     condition: centralsettlement-handler-grosssettlement.enabled
   - name: centralsettlement-service
-    version: ">= 15.4.0"
+    version: ">= 15.6.0"
     repository: "file://./chart-service"
     alias: centralsettlement-handler-rules
     condition: centralsettlement-handler-rules.enabled

--- a/centralsettlement/chart-service/Chart.yaml
+++ b/centralsettlement/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Central-Settlement helm chart for API services and handlers
 name: centralsettlement-service
-version: 15.4.0
-appVersion: v17.2.0
+version: 15.6.0
+appVersion: v17.2.2
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:

--- a/centralsettlement/chart-service/values.yaml
+++ b/centralsettlement/chart-service/values.yaml
@@ -8,7 +8,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-settlement
-  tag: v17.2.0
+  tag: v17.2.2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -91,7 +91,7 @@ sidecar:
   enabled: false
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.3
+    tag: v14.2.0
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:

--- a/centralsettlement/values.yaml
+++ b/centralsettlement/values.yaml
@@ -10,7 +10,7 @@ centralsettlement-service:
   image:
     registry: docker.io
     repository: mojaloop/central-settlement
-    tag: v17.2.0
+    tag: v17.2.2
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -90,7 +90,7 @@ centralsettlement-service:
     enabled: false
     image:
       repository: mojaloop/event-sidecar
-      tag: v14.0.3
+      tag: v14.2.0
       pullPolicy: IfNotPresent
       command: '["npm", "run", "start"]'
     service:
@@ -402,7 +402,7 @@ centralsettlement-handler-deferredsettlement:
   image:
     registry: docker.io
     repository: mojaloop/central-settlement
-    tag: v17.2.0
+    tag: v17.2.2
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -484,7 +484,7 @@ centralsettlement-handler-deferredsettlement:
     enabled: false
     image:
       repository: mojaloop/event-sidecar
-      tag: v14.0.3
+      tag: v14.2.0
       pullPolicy: IfNotPresent
       command: '["npm", "run", "start"]'
     service:
@@ -798,7 +798,7 @@ centralsettlement-handler-grosssettlement:
   image:
     registry: docker.io
     repository: mojaloop/central-settlement
-    tag: v17.2.0
+    tag: v17.2.2
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -880,7 +880,7 @@ centralsettlement-handler-grosssettlement:
     enabled: false
     image:
       repository: mojaloop/event-sidecar
-      tag: v14.0.3
+      tag: v14.2.0
       pullPolicy: IfNotPresent
       command: '["npm", "run", "start"]'
     service:
@@ -1193,7 +1193,7 @@ centralsettlement-handler-rules:
   image:
     registry: docker.io
     repository: mojaloop/central-settlement
-    tag: v17.2.0
+    tag: v17.2.2
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1275,7 +1275,7 @@ centralsettlement-handler-rules:
     enabled: false
     image:
       repository: mojaloop/event-sidecar
-      tag: v14.0.3
+      tag: v14.2.0
       pullPolicy: IfNotPresent
       command: '["npm", "run", "start"]'
     service:

--- a/emailnotifier/Chart.yaml
+++ b/emailnotifier/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Email Notifier For Mojaloop
 name: emailnotifier
-version: 13.5.0
-appVersion: v14.0.3
+version: 13.7.0
+appVersion: v14.1.4
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -17,6 +17,6 @@ maintainers:
 dependencies:
   - name: common
     repository: https://mojaloop.github.io/charts/repo
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common

--- a/emailnotifier/values.yaml
+++ b/emailnotifier/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/email-notifier
-  tag: v14.0.3
+  tag: v14.1.4
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/example-mojaloop-backend/Chart.yaml
+++ b/example-mojaloop-backend/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Example Helm chart for mojaloop backend dependencies
 name: example-mojaloop-backend
-version: 17.0.0
-appVersion: "nginx: 4.12.0; mysql: 9.19.1; kafka: 31.5.0; mongodb: 16.4.9; redis: 20.11.4"
+version: 17.7.0
+appVersion: "nginx: 4.12.0; mysql: 14.0.0; kafka: 32.3.10; mongodb: 16.5.36; redis: 21.2.14"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -25,7 +25,7 @@ dependencies:
       - dependency
       - backend
       - kafka
-    version: 31.5.0
+    version: 32.3.10
   ## mysql database
   - name: mysql
     alias: mysql
@@ -38,7 +38,7 @@ dependencies:
       - mysql
       - centralledger
       - account-lookup
-    version: 13.0.4
+    version: 14.0.0
   ## Bulk backend
   - name: mongodb
     alias: cl-mongodb
@@ -50,7 +50,7 @@ dependencies:
       - backend
       - mongodb
       - centralledger
-    version: 16.4.9
+    version: 16.5.36
   ## Central-event-processor backend
   - name: mongodb
     alias: cep-mongodb
@@ -62,7 +62,7 @@ dependencies:
       - backend
       - mongodb
       - centralledger
-    version: 16.4.9
+    version: 16.5.36
   - name: mongodb
     alias: ttk-mongodb
     condition: ttk-mongodb.enabled
@@ -73,7 +73,7 @@ dependencies:
       - backend
       - mongodb
       - centralledger
-    version: 16.4.9
+    version: 16.5.36
   ## Redis for SDK-Scheme-Adapter that are part of the TTKSims
   - name: redis
     alias: ttksims-redis
@@ -87,7 +87,7 @@ dependencies:
       - sdk
       - bulk
       - ttksims
-    version: 20.11.4
+    version: 21.2.14
   ## Redis for Thirdparty Auth-Service
   - name: redis
     alias: auth-svc-redis
@@ -99,7 +99,7 @@ dependencies:
       - backend
       - redis
       - thirdparty
-    version: 20.11.4
+    version: 21.2.14
   ## Redis Cluster for Proxy Cache
   - name: redis-cluster
     alias: proxy-cache-redis

--- a/ml-api-adapter/Chart.yaml
+++ b/ml-api-adapter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: ml-api-adapter Helm chart for Kubernetes
 name: ml-api-adapter
-version: 14.0.1
-appVersion: v16.5.6
+version: 14.7.0
+appVersion: v16.5.9
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -16,15 +16,15 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: ml-api-adapter-service
-    version: ">= 14.0.0"
+    version: ">= 14.3.0"
     repository: "file://./chart-service"
     condition: ml-api-adapter-service.enabled
   - name: ml-api-adapter-handler-notification
-    version: ">= 14.0.0"
+    version: ">= 14.3.0"
     repository: "file://./chart-handler-notification"
     condition: ml-api-adapter-handler-notification.enabled
   - name: common
     repository: https://mojaloop.github.io/charts/repo
-    version: 3.1.3
+    version: 3.1.5
     tags:
         - moja-common

--- a/ml-api-adapter/chart-handler-notification/Chart.yaml
+++ b/ml-api-adapter/chart-handler-notification/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: ml-api-adapter Handler for Notifications component Helm chart for Kubernetes
 name: ml-api-adapter-handler-notification
-version: 14.0.1
-appVersion: v16.5.6
+version: 14.3.0
+appVersion: v16.5.9
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -17,6 +17,6 @@ maintainers:
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common

--- a/ml-api-adapter/chart-handler-notification/values.yaml
+++ b/ml-api-adapter/chart-handler-notification/values.yaml
@@ -5,7 +5,7 @@
 image:
   registry: docker.io
   repository: mojaloop/ml-api-adapter
-  tag: v16.5.6
+  tag: v16.5.9
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -78,7 +78,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v16.3.2
+    tag: v16.5.9
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:

--- a/ml-api-adapter/chart-service/Chart.yaml
+++ b/ml-api-adapter/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: ml-api-adapter API component Helm chart for Kubernetes
 name: ml-api-adapter-service
-version: 14.0.1
-appVersion: v16.5.6
+version: 14.3.0
+appVersion: v16.5.9
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -17,6 +17,6 @@ maintainers:
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common

--- a/ml-api-adapter/chart-service/values.yaml
+++ b/ml-api-adapter/chart-service/values.yaml
@@ -4,7 +4,7 @@
 image:
   registry: docker.io
   repository: mojaloop/ml-api-adapter
-  tag: v16.5.6
+  tag: v16.5.9
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -70,7 +70,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.3
+    tag: v14.2.0
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:

--- a/ml-api-adapter/values.yaml
+++ b/ml-api-adapter/values.yaml
@@ -14,7 +14,7 @@ ml-api-adapter-service:
   image:
     registry: docker.io
     repository: mojaloop/ml-api-adapter
-    tag: v16.5.6
+    tag: v16.5.9
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -80,7 +80,7 @@ ml-api-adapter-service:
     enabled: true
     image:
       repository: mojaloop/event-sidecar
-      tag: v14.0.3
+      tag: v14.2.0
       pullPolicy: IfNotPresent
     readinessProbe:
       enabled: true
@@ -322,7 +322,7 @@ ml-api-adapter-handler-notification:
   image:
     registry: docker.io
     repository: mojaloop/ml-api-adapter
-    tag: v16.5.6
+    tag: v16.5.9
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -390,7 +390,7 @@ ml-api-adapter-handler-notification:
     enabled: true
     image:
       repository: mojaloop/event-sidecar
-      tag: v14.0.3
+      tag: v14.2.0
       pullPolicy: IfNotPresent
     readinessProbe:
       enabled: true

--- a/ml-operator/Chart.yaml
+++ b/ml-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ml-operator
 description: ml-operator makes running and managing a Mojaloop deployment easier
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: 0.1.3
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
@@ -15,6 +15,6 @@ maintainers:
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common

--- a/ml-testing-toolkit-cli/Chart.yaml
+++ b/ml-testing-toolkit-cli/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: ml-testing-toolkit-cli Helm chart for Kubernetes
 name: ml-testing-toolkit-cli
-version: 15.9.0
-appVersion: v1.9.0
+version: 15.11.0
+appVersion: v1.10.3
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -17,6 +17,6 @@ maintainers:
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common

--- a/ml-testing-toolkit/Chart.yaml
+++ b/ml-testing-toolkit/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: ml-testing-toolkit Helm chart for Kubernetes
 name: ml-testing-toolkit
-version: 17.7.1
-appVersion: "ml-testing-toolkit: v18.11.2; ml-testing-toolkit-ui: v16.2.0"
+version: 17.10.0
+appVersion: "ml-testing-toolkit: v18.14.0; ml-testing-toolkit-ui: v18.14.0"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -21,15 +21,15 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: ml-testing-toolkit-frontend
-    version: ">= 15.10.0"
+    version: ">= 15.12.0"
     repository: "file://./chart-frontend"
     condition: ml-testing-toolkit-frontend.enabled
   - name: ml-testing-toolkit-backend
-    version: ">= 17.0.0"
+    version: ">= 17.2.0"
     repository: "file://./chart-backend"
     condition: ml-testing-toolkit-backend.enabled
   - name: common
     repository: https://mojaloop.github.io/charts/repo
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common

--- a/ml-testing-toolkit/chart-backend/Chart.yaml
+++ b/ml-testing-toolkit/chart-backend/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: ml-testing-toolkit-backend Helm chart for Kubernetes
 name: ml-testing-toolkit-backend
-version: 17.0.0
-appVersion: v18.11.2
+version: 17.2.0
+appVersion: v18.14.0
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -19,6 +19,6 @@ maintainers:
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common

--- a/ml-testing-toolkit/chart-backend/values.yaml
+++ b/ml-testing-toolkit/chart-backend/values.yaml
@@ -6,10 +6,9 @@ enabled: true
 # Default values
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-
 image:
   repository: mojaloop/ml-testing-toolkit
-  tag: v18.13.2
+  tag: v18.14.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/ml-testing-toolkit/chart-frontend/Chart.yaml
+++ b/ml-testing-toolkit/chart-frontend/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: ml-testing-toolkit-frontend Helm chart for Kubernetes
 name: ml-testing-toolkit-frontend
-version: 15.10.0
-appVersion: v16.2.0
+version: 15.12.0
+appVersion: v16.6.4
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -17,6 +17,6 @@ maintainers:
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
         - moja-common

--- a/mojaloop-bulk/Chart.yaml
+++ b/mojaloop-bulk/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Mojaloop Bulk Helm chart for Kubernetes
 name: mojaloop-bulk
-version: 16.18.0
-appVersion: "bulk-api-adapter: v17.1.9; central-ledger: v19.7.0"
+version: 16.29.0
+appVersion: "bulk-api-adapter: v17.2.2; central-ledger: v19.8.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -15,15 +15,15 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: bulk-api-adapter
-    version: ">= 14.10.0"
+    version: ">= 14.14.0"
     repository: "file://../bulk-api-adapter"
     condition: bulk-api-adapter.enabled
   - name: bulk-centralledger
-    version: ">= 14.16.0"
+    version: ">= 14.24.0"
     repository: "file://../bulk-centralledger"
     condition: bulk-centralledger.enabled
   - name: common
     repository: https://mojaloop.github.io/charts/repo
-    version: 3.1.3
+    version: 3.1.5
     tags:
         - moja-common

--- a/mojaloop-bulk/values.yaml
+++ b/mojaloop-bulk/values.yaml
@@ -15,7 +15,7 @@ bulk-api-adapter:
     image:
       registry: docker.io
       repository: mojaloop/bulk-api-adapter
-      tag: v17.1.9
+      tag: v17.2.2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -332,7 +332,7 @@ bulk-api-adapter:
     image:
       registry: docker.io
       repository: mojaloop/bulk-api-adapter
-      tag: v17.1.9
+      tag: v17.2.2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -674,7 +674,7 @@ bulk-centralledger:
     image:
       registry: docker.io
       repository: mojaloop/central-ledger
-      tag: v19.3.0
+      tag: v19.8.3
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1067,7 +1067,7 @@ bulk-centralledger:
     image:
       registry: docker.io
       repository: mojaloop/central-ledger
-      tag: v19.3.0
+      tag: v19.8.3
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1448,7 +1448,7 @@ bulk-centralledger:
     image:
       registry: docker.io
       repository: mojaloop/central-ledger
-      tag: v19.3.0
+      tag: v19.8.3
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1838,7 +1838,7 @@ bulk-centralledger:
     image:
       registry: docker.io
       repository: mojaloop/central-ledger
-      tag: v19.3.0
+      tag: v19.8.3
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/mojaloop-simulator/Chart.yaml
+++ b/mojaloop-simulator/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 description: "Helm Chart for the Mojaloop (SDK-based) Simulator"
 name: mojaloop-simulator
-version: 15.7.0
-appVersion: "sdk-scheme-adapter: v24.6.2; mojaloop-simulator: v15.3.0; thirdparty-sdk: v15.1.3"
+version: 15.10.0
+appVersion: "sdk-scheme-adapter: v24.10.5; mojaloop-simulator: v15.4.2; thirdparty-sdk: v15.1.3"
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common
 maintainers:

--- a/mojaloop-simulator/values.yaml
+++ b/mojaloop-simulator/values.yaml
@@ -291,7 +291,7 @@ defaults:
           publicKey: ''
       image:
         repository: mojaloop/sdk-scheme-adapter
-        tag: v24.6.2
+        tag: v24.10.5
         pullPolicy: IfNotPresent
         command: '[ "yarn", "start:api-svc" ]'
       <<: *defaultProbes
@@ -463,7 +463,7 @@ defaults:
     backend:
       image:
         repository: mojaloop/mojaloop-simulator
-        tag: v15.3.0
+        tag: v15.4.2
         pullPolicy: IfNotPresent
       <<: *defaultProbes
       # These will be supplied directly to the init containers array in the deployment for the

--- a/mojaloop-ttk-simulators/Chart.yaml
+++ b/mojaloop-ttk-simulators/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: mojaloop-ttk-simulator Helm chart for Kubernetes
 name: mojaloop-ttk-simulators
-version: 3.0.0
-appVersion: "ml-testing-toolkit: v18.11.2; ml-testing-toolkit-ui: v16.2.0; sdk-scheme-adapter: v24.6.3"
+version: 3.3.0
+appVersion: "ml-testing-toolkit: v18.14.0; ml-testing-toolkit-ui: v16.6.4; sdk-scheme-adapter: v24.10.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -21,7 +21,7 @@ dependencies:
       - mojaloop-simulator
       - testing-toolkit
       - sdk-scheme-adapter
-    version: ">= 3.0.0"
+    version: ">= 3.1.0"
     condition: mojaloop-ttk-sim1-svc.enabled
   - name: mojaloop-ttk-sim2-svc
     repository: "file://./chart-sim2"
@@ -29,7 +29,7 @@ dependencies:
       - mojaloop-simulator
       - testing-toolkit
       - sdk-scheme-adapter
-    version: ">= 3.0.0"
+    version: ">= 3.1.0"
     condition: mojaloop-ttk-sim2-svc.enabled
   - name: mojaloop-ttk-sim3-svc
     repository: "file://./chart-sim3"
@@ -37,5 +37,5 @@ dependencies:
       - mojaloop-simulator
       - testing-toolkit
       - sdk-scheme-adapter
-    version: ">= 3.0.0"
+    version: ">= 3.1.0"
     condition: mojaloop-ttk-sim3-svc.enabled

--- a/mojaloop-ttk-simulators/chart-sim1/Chart.yaml
+++ b/mojaloop-ttk-simulators/chart-sim1/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: mojaloop-ttk-sim1-svc
-version: 3.0.0
+version: 3.1.0
 description: A Helm chart for Kubernetes
-appVersion: "ml-testing-toolkit: v18.11.2; ml-testing-toolkit-ui: v16.2.0; sdk-scheme-adapter: v24.6.3"
+appVersion: "ml-testing-toolkit: v18.14.0; ml-testing-toolkit-ui: v16.6.4; sdk-scheme-adapter: v24.10.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -34,4 +34,4 @@ dependencies:
     repository: "https://mojaloop.github.io/charts/repo"
     tags:
       - moja-common
-    version: 3.1.3
+    version: 3.1.5

--- a/mojaloop-ttk-simulators/chart-sim1/values.yaml
+++ b/mojaloop-ttk-simulators/chart-sim1/values.yaml
@@ -211,11 +211,11 @@ ml-testing-toolkit:
           }
         ]
       }
-      rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.2/test/func_bulk/config/ttk-ttksim1/spec_files/rules_response/default.json'
-      api_definitions__mojaloop_simulator_sim_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.2/test/func_bulk/config/ttk-ttksim1/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
-      api_definitions__mojaloop_simulator_sim_2.1__response_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.2/test/func_bulk/config/ttk-ttksim1/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/response_map.json'
-      api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.2/test/func_bulk/config/ttk-ttksim1/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
-      api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.2/test/func_bulk/config/ttk-ttksim1/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/callback_map.json'
+      rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim1/spec_files/rules_response/default.json'
+      api_definitions__mojaloop_simulator_sim_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim1/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
+      api_definitions__mojaloop_simulator_sim_2.1__response_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim1/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/response_map.json'
+      api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim1/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
+      api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim1/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/callback_map.json'
 
     ## @param initContainers Add additional init containers to the %%MAIN_CONTAINER_NAME%% pod(s)
     ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/

--- a/mojaloop-ttk-simulators/chart-sim2/Chart.yaml
+++ b/mojaloop-ttk-simulators/chart-sim2/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: mojaloop-ttk-sim2-svc
-version: 3.0.0
+version: 3.1.0
 description: A Helm chart for Kubernetes
-appVersion: "ml-testing-toolkit: v18.11.2; ml-testing-toolkit-ui: v16.2.0; sdk-scheme-adapter: v24.6.3"
+appVersion: "ml-testing-toolkit: v18.14.0; ml-testing-toolkit-ui: v16.6.4; sdk-scheme-adapter: v24.10.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -34,4 +34,4 @@ dependencies:
     repository: "https://mojaloop.github.io/charts/repo"
     tags:
       - moja-common
-    version: 3.1.3
+    version: 3.1.5

--- a/mojaloop-ttk-simulators/chart-sim2/values.yaml
+++ b/mojaloop-ttk-simulators/chart-sim2/values.yaml
@@ -206,11 +206,11 @@ ml-testing-toolkit:
           }
         ]
       }
-      rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.2/test/func_bulk/config/ttk-ttksim2/spec_files/rules_response/default.json'
-      api_definitions__mojaloop_simulator_sim_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.2/test/func_bulk/config/ttk-ttksim2/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
-      api_definitions__mojaloop_simulator_sim_2.1__response_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.2/test/func_bulk/config/ttk-ttksim2/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/response_map.json'
-      api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.2/test/func_bulk/config/ttk-ttksim2/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
-      api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.2/test/func_bulk/config/ttk-ttksim2/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/callback_map.json'
+      rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim2/spec_files/rules_response/default.json'
+      api_definitions__mojaloop_simulator_sim_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim2/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
+      api_definitions__mojaloop_simulator_sim_2.1__response_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim2/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/response_map.json'
+      api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim2/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
+      api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim2/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/callback_map.json'
 
   ## @param initContainers Add additional init containers to the %%MAIN_CONTAINER_NAME%% pod(s)
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/

--- a/mojaloop-ttk-simulators/chart-sim3/Chart.yaml
+++ b/mojaloop-ttk-simulators/chart-sim3/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: mojaloop-ttk-sim3-svc
-version: 3.0.0
+version: 3.1.0
 description: A Helm chart for Kubernetes
-appVersion: "ml-testing-toolkit: v18.11.2; ml-testing-toolkit-ui: v16.2.0; sdk-scheme-adapter: v24.6.3"
+appVersion: "ml-testing-toolkit: v18.14.0; ml-testing-toolkit-ui: v16.6.4; sdk-scheme-adapter: v24.10.5"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -34,4 +34,4 @@ dependencies:
     repository: "https://mojaloop.github.io/charts/repo"
     tags:
       - moja-common
-    version: 3.1.3
+    version: 3.1.5

--- a/mojaloop-ttk-simulators/chart-sim3/values.yaml
+++ b/mojaloop-ttk-simulators/chart-sim3/values.yaml
@@ -206,11 +206,11 @@ ml-testing-toolkit:
           }
         ]
       }
-      rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.2/test/func_bulk/config/ttk-ttksim3/spec_files/rules_response/default.json'
-      api_definitions__mojaloop_simulator_sim_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.2/test/func_bulk/config/ttk-ttksim3/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
-      api_definitions__mojaloop_simulator_sim_2.1__response_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.2/test/func_bulk/config/ttk-ttksim3/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/response_map.json'
-      api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.2/test/func_bulk/config/ttk-ttksim3/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
-      api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.2/test/func_bulk/config/ttk-ttksim3/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/callback_map.json'
+      rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim3/spec_files/rules_response/default.json'
+      api_definitions__mojaloop_simulator_sim_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim3/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
+      api_definitions__mojaloop_simulator_sim_2.1__response_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim3/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/response_map.json'
+      api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim3/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
+      api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim3/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/callback_map.json'
 
   ## @param initContainers Add additional init containers to the %%MAIN_CONTAINER_NAME%% pod(s)
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/

--- a/mojaloop/Chart.yaml
+++ b/mojaloop/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Mojaloop Helm chart for Kubernetes
 name: mojaloop
-version: 17.0.4
-appVersion: "ml-api-adapter: v16.5.6; central-ledger: v19.7.4; account-lookup-service: v17.12.0; quoting-service: v17.12.0; central-settlement: v17.2.0; bulk-api-adapter: v17.1.9; transaction-requests-service: v14.3.9; simulator: v12.2.5; mojaloop-simulator: v15.3.0; sdk-scheme-adapter: v24.6.3; auth-service: v15.2.5; als-consent-oracle: v1.1.2; thirdparty-sdk: v15.1.3; ml-testing-toolkit: v18.11.2; ml-testing-toolkit-ui: v16.2.0;"
+version: 17.1.0
+appVersion: "ml-api-adapter: v16.5.9; central-ledger: v19.8.3; account-lookup-service: v17.12.2; quoting-service: v17.12.1; central-settlement: v17.2.2; bulk-api-adapter: v17.2.2; transaction-requests-service: v14.4.5; simulator: v12.3.2; mojaloop-simulator: v15.4.2; sdk-scheme-adapter: v24.10.5; auth-service: v15.2.7; als-consent-oracle: v1.1.4; thirdparty-sdk: v15.1.3; ml-testing-toolkit: v18.14.0; ml-testing-toolkit-ui: v16.6.4;"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -15,27 +15,27 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: account-lookup-service
-    version: ">= 15.0.0"
+    version: ">= 15.8.0"
     repository: "file://../account-lookup-service"
     condition: account-lookup-service.enabled
   - name: quoting-service
-    version: ">= 16.0.0"
+    version: ">= 16.5.0"
     repository: "file://../quoting-service"
     condition: quoting-service.enabled
   - name: ml-api-adapter
-    version: ">= 14.0.0"
+    version: ">= 14.7.0"
     repository: "file://../ml-api-adapter"
     condition: ml-api-adapter.enabled
   - name: centralledger
-    version: ">= 14.41.2"
+    version: ">= 14.56.0"
     repository: "file://../centralledger"
     condition: centralledger.enabled
   - name: centralsettlement
-    version: ">= 14.19.0"
+    version: ">= 14.31.0"
     repository: "file://../centralsettlement"
     condition: centralsettlement.enabled
   - name: simulator
-    version: ">= 13.5.0"
+    version: ">= 13.7.0"
     repository: "file://../simulator"
     condition: simulator.enabled
   - name: als-msisdn-oracle
@@ -43,107 +43,107 @@ dependencies:
     repository: "file://../als-msisdn-oracle"
     condition: als-msisdn-oracle.enabled
   - name: mojaloop-simulator
-    version: ">= 15.7.0"
+    version: ">= 15.10.0"
     repository: "file://../mojaloop-simulator"
     condition: mojaloop-simulator.enabled
   - name: mojaloop-bulk
-    version: ">= 16.18.0"
+    version: ">= 16.29.0"
     repository: "file://../mojaloop-bulk"
     condition: mojaloop-bulk.enabled
   - name: transaction-requests-service
-    version: ">= 13.6.0"
+    version: ">= 13.9.0"
     repository: "file://../transaction-requests-service"
     condition: transaction-requests-service.enabled
   - name: thirdparty
-    version: ">= 3.18.0"
+    version: ">= 3.28.0"
     repository: "file://../thirdparty"
     condition: thirdparty.enabled
   - name: mojaloop-ttk-simulators
-    version: ">= 3.0.0"
+    version: ">= 3.3.0"
     repository: "file://../mojaloop-ttk-simulators"
     condition: mojaloop-ttk-simulators.enabled
   - name: common
     repository: https://mojaloop.github.io/charts/repo
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common
   - name: ml-testing-toolkit
-    version: ">= 17.7.1"
+    version: ">= 17.10.0"
     repository: "file://../ml-testing-toolkit"
     condition: ml-testing-toolkit.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-test-setup
-    version: ">= 15.9.0"
+    version: ">= 15.11.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-test-setup.tests.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-test-val-gp
-    version: ">= 15.9.0"
+    version: ">= 15.11.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-test-val-gp.tests.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-test-val-bulk
-    version: ">= 15.9.0"
+    version: ">= 15.11.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-test-val-bulk.tests.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-test-setup-tp
-    version: ">= 15.9.0"
+    version: ">= 15.11.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-test-setup-tp.tests.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-test-val-tp
-    version: ">= 15.9.0"
+    version: ">= 15.11.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-test-val-tp.tests.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-posthook-setup
-    version: ">= 15.9.0"
+    version: ">= 15.11.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-posthook-setup.postInstallHook.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-posthook-tests
-    version: ">= 15.9.0"
+    version: ">= 15.11.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-posthook-tests.postInstallHook.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-cronjob-tests
-    version: ">= 15.9.0"
+    version: ">= 15.11.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-cronjob-tests.scheduling.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-cronjob-cleanup
-    version: ">= 15.9.0"
+    version: ">= 15.11.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-cronjob-cleanup.scheduling.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-test-setup-sdk-bulk
-    version: ">= 15.9.0"
+    version: ">= 15.11.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-test-setup-sdk-bulk.tests.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-test-val-sdk-bulk
-    version: ">= 15.9.0"
+    version: ">= 15.11.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-test-val-sdk-bulk.tests.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-test-val-sdk-r2p
-    version: ">= 15.9.0"
+    version: ">= 15.11.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-test-val-sdk-r2p.tests.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-test-setup-interscheme
-    version: ">= 15.9.0"
+    version: ">= 15.11.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-test-setup-interscheme.tests.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-test-val-interscheme
-    version: ">= 15.9.0"
+    version: ">= 15.11.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-test-val-interscheme.tests.enabled
   - name: ml-testing-toolkit-cli
     alias: ml-ttk-test-cleanup
-    version: ">= 15.9.0"
+    version: ">= 15.11.0"
     repository: "file://../ml-testing-toolkit-cli"
     condition: ml-ttk-test-cleanup.tests.enabled
   - name: inter-scheme-proxy-adapter

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -183,7 +183,7 @@ account-lookup-service:
     image:
       registry: docker.io
       repository: mojaloop/account-lookup-service
-      tag: v17.12.0
+      tag: v17.12.2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -208,7 +208,7 @@ account-lookup-service:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v14.0.3
+        tag: v14.2.0
         pullPolicy: IfNotPresent
         command: '["npm", "run", "start"]'
       service:
@@ -509,7 +509,7 @@ account-lookup-service:
     image:
       registry: docker.io
       repository: mojaloop/account-lookup-service
-      tag: v17.12.0
+      tag: v17.12.2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -534,7 +534,7 @@ account-lookup-service:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v14.0.3
+        tag: v14.2.0
         pullPolicy: IfNotPresent
         command: '["npm", "run", "start"]'
       service:
@@ -1141,7 +1141,7 @@ account-lookup-service:
     # Declare variables to be passed into your templates.
     image:
       repository: mojaloop/als-oracle-pathfinder
-      tag: v12.1.3
+      tag: v12.3.1
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1567,8 +1567,7 @@ quoting-service:
     image:
       registry: docker.io
       repository: mojaloop/quoting-service
-      tag: v17.12.0
-
+      tag: v17.12.1
     config:
       hub_participant: *HUB_PARTICIPANT
       ## DB Configuration
@@ -1664,7 +1663,7 @@ quoting-service:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v14.0.3
+        tag: v14.2.0
         pullPolicy: IfNotPresent
       readinessProbe:
         enabled: true
@@ -1684,8 +1683,7 @@ quoting-service:
     image:
       registry: docker.io
       repository: mojaloop/quoting-service
-      tag: v17.12.0
-
+      tag: v17.12.1
     config:
       hub_participant: *HUB_PARTICIPANT
       ## DB Configuration
@@ -1806,7 +1804,7 @@ quoting-service:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v14.0.3
+        tag: v14.2.0
         pullPolicy: IfNotPresent
       readinessProbe:
         enabled: true
@@ -1831,7 +1829,7 @@ ml-api-adapter:
     image:
       registry: docker.io
       repository: mojaloop/ml-api-adapter
-      tag: v16.5.6
+      tag: v16.5.9
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1887,7 +1885,7 @@ ml-api-adapter:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v14.0.3
+        tag: v14.2.0
         pullPolicy: IfNotPresent
       readinessProbe:
         enabled: true
@@ -2100,7 +2098,7 @@ ml-api-adapter:
     image:
       registry: docker.io
       repository: mojaloop/ml-api-adapter
-      tag: v16.5.6
+      tag: v16.5.9
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2158,7 +2156,7 @@ ml-api-adapter:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v14.0.3
+        tag: v14.2.0
         pullPolicy: IfNotPresent
       readinessProbe:
         enabled: true
@@ -2436,7 +2434,7 @@ centralledger:
     image:
       registry: docker.io
       repository: mojaloop/central-ledger
-      tag: v19.8.0
+      tag: v19.8.3
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2506,7 +2504,7 @@ centralledger:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v14.0.3
+        tag: v14.2.0
         pullPolicy: IfNotPresent
       readinessProbe:
         enabled: true
@@ -2722,7 +2720,7 @@ centralledger:
     image:
       registry: docker.io
       repository: mojaloop/central-ledger
-      tag: v19.8.0
+      tag: v19.8.3
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2794,7 +2792,7 @@ centralledger:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v14.0.3
+        tag: v14.2.0
         pullPolicy: IfNotPresent
       readinessProbe:
         enabled: true
@@ -3012,7 +3010,7 @@ centralledger:
     image:
       registry: docker.io
       repository: mojaloop/central-ledger
-      tag: v19.8.0
+      tag: v19.8.3
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -3084,7 +3082,7 @@ centralledger:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v14.0.3
+        tag: v14.2.0
         pullPolicy: IfNotPresent
       readinessProbe:
         enabled: true
@@ -3300,7 +3298,7 @@ centralledger:
     image:
       registry: docker.io
       repository: mojaloop/central-ledger
-      tag: v19.8.0
+      tag: v19.8.3
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -3372,7 +3370,7 @@ centralledger:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v14.0.3
+        tag: v14.2.0
         pullPolicy: IfNotPresent
       readinessProbe:
         enabled: true
@@ -3593,7 +3591,7 @@ centralledger:
     image:
       registry: docker.io
       repository: mojaloop/central-ledger
-      tag: v19.8.0
+      tag: v19.8.3
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -3665,7 +3663,7 @@ centralledger:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v14.0.3
+        tag: v14.2.0
         pullPolicy: IfNotPresent
       readinessProbe:
         enabled: true
@@ -3880,7 +3878,7 @@ centralledger:
     image:
       registry: docker.io
       repository: mojaloop/central-ledger
-      tag: v19.8.0
+      tag: v19.8.3
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -3952,7 +3950,7 @@ centralledger:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v14.0.3
+        tag: v14.2.0
         pullPolicy: IfNotPresent
       readinessProbe:
         enabled: true
@@ -4167,7 +4165,7 @@ centralledger:
     image:
       registry: docker.io
       repository: mojaloop/central-ledger
-      tag: v19.8.0
+      tag: v19.8.3
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -4239,7 +4237,7 @@ centralledger:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v14.0.3
+        tag: v14.2.0
         pullPolicy: IfNotPresent
       readinessProbe:
         enabled: true
@@ -4459,7 +4457,7 @@ centralledger:
     image:
       registry: docker.io
       repository: mojaloop/central-ledger
-      tag: v19.8.0
+      tag: v19.8.3
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -4531,7 +4529,7 @@ centralledger:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v14.0.3
+        tag: v14.2.0
         pullPolicy: IfNotPresent
       readinessProbe:
         enabled: true
@@ -4745,7 +4743,7 @@ centralsettlement:
     image:
       registry: docker.io
       repository: mojaloop/central-settlement
-      tag: v17.2.0
+      tag: v17.2.2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -4815,7 +4813,7 @@ centralsettlement:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v14.0.3
+        tag: v14.2.0
         pullPolicy: IfNotPresent
         command: '["npm", "run", "start"]'
       service:
@@ -5122,7 +5120,7 @@ centralsettlement:
     image:
       registry: docker.io
       repository: mojaloop/central-settlement
-      tag: v17.2.0
+      tag: v17.2.2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -5194,7 +5192,7 @@ centralsettlement:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v14.0.3
+        tag: v14.2.0
         pullPolicy: IfNotPresent
         command: '["npm", "run", "start"]'
       service:
@@ -5503,7 +5501,7 @@ centralsettlement:
     image:
       registry: docker.io
       repository: mojaloop/central-settlement
-      tag: v17.2.0
+      tag: v17.2.2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -5575,7 +5573,7 @@ centralsettlement:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v14.0.3
+        tag: v14.2.0
         pullPolicy: IfNotPresent
         command: '["npm", "run", "start"]'
       service:
@@ -5884,7 +5882,7 @@ centralsettlement:
     image:
       registry: docker.io
       repository: mojaloop/central-settlement
-      tag: v17.2.0
+      tag: v17.2.2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -5956,7 +5954,7 @@ centralsettlement:
       enabled: false
       image:
         repository: mojaloop/event-sidecar
-        tag: v14.0.3
+        tag: v14.2.0
         pullPolicy: IfNotPresent
         command: '["npm", "run", "start"]'
       service:
@@ -6354,7 +6352,7 @@ transaction-requests-service:
   image:
     registry: docker.io
     repository: mojaloop/transaction-requests-service
-    tag: v14.3.9
+    tag: v14.4.5
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -6425,7 +6423,7 @@ transaction-requests-service:
     enabled: false
     image:
       repository: mojaloop/event-sidecar
-      tag: v14.0.3
+      tag: v14.2.0
       pullPolicy: IfNotPresent
       command: '["npm", "run", "start"]'
     service:
@@ -6609,7 +6607,7 @@ thirdparty:
     image:
       registry: docker.io
       repository: mojaloop/auth-service
-      tag: v15.2.5
+      tag: v15.2.7
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -7016,7 +7014,7 @@ thirdparty:
     image:
       registry: docker.io
       repository: mojaloop/als-consent-oracle
-      tag: v1.1.2
+      tag: v1.1.4
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -7275,7 +7273,7 @@ thirdparty:
     image:
       registry: docker.io
       repository: mojaloop/thirdparty-api-svc
-      tag: v15.0.2
+      tag: v15.1.2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -8453,7 +8451,7 @@ thirdparty:
               publicKey: ''
           image:
             repository: mojaloop/sdk-scheme-adapter
-            tag: v24.6.3
+            tag: v24.10.5
             pullPolicy: IfNotPresent
             command: '[ "yarn", "start:api-svc" ]'
           <<: *defaultProbes
@@ -8605,7 +8603,7 @@ thirdparty:
         backend:
           image:
             repository: mojaloop/mojaloop-simulator
-            tag: v15.3.0
+            tag: v15.4.2
             pullPolicy: IfNotPresent
           <<: *defaultProbes
           # These will be supplied directly to the init containers array in the deployment for the
@@ -8824,7 +8822,7 @@ simulator:
   image:
     registry: docker.io
     repository: mojaloop/simulator
-    tag: v12.2.5
+    tag: v12.3.2
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -9575,7 +9573,7 @@ mojaloop-simulator:
             publicKey: ''
         image:
           repository: mojaloop/sdk-scheme-adapter
-          tag: v24.6.3
+          tag: v24.10.5
           pullPolicy: IfNotPresent
           command: '[ "yarn", "start:api-svc" ]'
         <<: *defaultProbes
@@ -9729,7 +9727,7 @@ mojaloop-simulator:
       backend:
         image:
           repository: mojaloop/mojaloop-simulator
-          tag: v15.3.0
+          tag: v15.4.2
           pullPolicy: IfNotPresent
         <<: *defaultProbes
         # These will be supplied directly to the init containers array in the deployment for the
@@ -10167,11 +10165,11 @@ mojaloop-ttk-simulators:
               name: *TTK_MONGO_CONNECTION_STRING_SECRET_NAME
               key: *TTK_MONGO_CONNECTION_STRING_SECRET_KEY
         config_files:
-          rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.3/test/func_bulk/config/ttk-ttksim1/spec_files/rules_response/default.json'
-          api_definitions__mojaloop_simulator_sim_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.3/test/func_bulk/config/ttk-ttksim1/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
-          api_definitions__mojaloop_simulator_sim_2.1__response_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.3/test/func_bulk/config/ttk-ttksim1/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/response_map.json'
-          api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.3/test/func_bulk/config/ttk-ttksim1/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
-          api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.3/test/func_bulk/config/ttk-ttksim1/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/callback_map.json'
+          rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim1/spec_files/rules_response/default.json'
+          api_definitions__mojaloop_simulator_sim_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim1/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
+          api_definitions__mojaloop_simulator_sim_2.1__response_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim1/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/response_map.json'
+          api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim1/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
+          api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim1/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/callback_map.json'
         extraEnvironments:
           hub-k8s-default-environment.json: &ttksim1InputValues {"inputValues": {"HUB_NAME": *HUB_NAME, "TTKSIM1_FSPID": "ttksim1", "TTKSIM1_MSISDN_1": "16135551212", "TTKSIM1_MSISDN_1_FIRST_NAME": "ReceiverFirst", "TTKSIM1_MSISDN_1_LAST_NAME": "ReceiverLast", "TTKSIM1_CURRENCY": "XTS", "TTKSIM2_FSPID": "ttksim2", "TTKSIM2_MSISDN_1": "4561000001", "TTKSIM2_MSISDN_1_FIRST_NAME": "ReceiverFirst", "TTKSIM2_MSISDN_1_LAST_NAME": "ReceiverLast", "TTKSIM2_MSISDN_2": "4561000002", "TTKSIM2_MSISDN_2_FIRST_NAME": "ReceiverFirst", "TTKSIM2_MSISDN_2_LAST_NAME": "ReceiverLast", "TTKSIM2_PARTY_NOT_FOUND": "partynotfound", "TTKSIM2_PARTY_TIMES_OUT": "partytimesout", "TTKSIM2_CURRENCY": "XTS", "TTKSIM3_FSPID": "ttksim3", "TTKSIM3_MSISDN_1": "5671000001", "TTKSIM3_MSISDN_1_FIRST_NAME": "ReceiverFirst", "TTKSIM3_MSISDN_1_LAST_NAME": "ReceiverLast", "TTKSIM3_MSISDN_2": "5671000002", "TTKSIM3_MSISDN_2_FIRST_NAME": "ReceiverFirst", "TTKSIM3_MSISDN_2_LAST_NAME": "ReceiverLast", "TTKSIM3_CURRENCY": "XTS", "TTKSIM2_MSISDN_PREFIX": "4561", "TTKSIM3_MSISDN_PREFIX": "5671", "HOST_CENTRAL_LEDGER": "http://$release_name-centralledger-service", "HOST_CENTRAL_SETTLEMENT": "http://$release_name-centralsettlement-service/v2"}}
       ml-testing-toolkit-frontend:
@@ -10344,11 +10342,11 @@ mojaloop-ttk-simulators:
             adminApi:
               host: 'ttksim2.local'
         config_files:
-          rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.3/test/func_bulk/config/ttk-ttksim2/spec_files/rules_response/default.json'
-          api_definitions__mojaloop_simulator_sim_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.3/test/func_bulk/config/ttk-ttksim2/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
-          api_definitions__mojaloop_simulator_sim_2.1__response_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.3/test/func_bulk/config/ttk-ttksim2/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/response_map.json'
-          api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.3/test/func_bulk/config/ttk-ttksim2/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
-          api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.3/test/func_bulk/config/ttk-ttksim2/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/callback_map.json'
+          rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim2/spec_files/rules_response/default.json'
+          api_definitions__mojaloop_simulator_sim_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim2/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
+          api_definitions__mojaloop_simulator_sim_2.1__response_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim2/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/response_map.json'
+          api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim2/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
+          api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim2/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/callback_map.json'
       ml-testing-toolkit-frontend:
         ingress:
           enabled: true
@@ -10519,11 +10517,11 @@ mojaloop-ttk-simulators:
             adminApi:
               host: 'ttksim3.local'
         config_files:
-          rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.3/test/func_bulk/config/ttk-ttksim3/spec_files/rules_response/default.json'
-          api_definitions__mojaloop_simulator_sim_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.3/test/func_bulk/config/ttk-ttksim3/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
-          api_definitions__mojaloop_simulator_sim_2.1__response_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.3/test/func_bulk/config/ttk-ttksim3/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/response_map.json'
-          api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.3/test/func_bulk/config/ttk-ttksim3/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
-          api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.6.3/test/func_bulk/config/ttk-ttksim3/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/callback_map.json'
+          rules_response__default.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim3/spec_files/rules_response/default.json'
+          api_definitions__mojaloop_simulator_sim_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim3/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
+          api_definitions__mojaloop_simulator_sim_2.1__response_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim3/spec_files/api_definitions/sdk-scheme-adapter-backend-v2_1_0-openapi3-snippets_2.1/response_map.json'
+          api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__api_spec.yaml: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim3/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/api_spec.yaml'
+          api_definitions__mojaloop_sdk_outbound_scheme_adapter_2.1__callback_map.json: 'https://github.com/mojaloop/sdk-scheme-adapter/raw/v24.10.5/test/func_bulk/config/ttk-ttksim3/spec_files/api_definitions/sdk-scheme-adapter-outbound-v2_1_0-openapi3-snippets_2.1/callback_map.json'
       ml-testing-toolkit-frontend:
         ingress:
           enabled: true
@@ -10548,7 +10546,7 @@ mojaloop-bulk:
       image:
         registry: docker.io
         repository: mojaloop/bulk-api-adapter
-        tag: v17.1.9
+        tag: v17.2.2
         ## Specify a imagePullPolicy
         ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
         ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -10790,7 +10788,7 @@ mojaloop-bulk:
       image:
         registry: docker.io
         repository: mojaloop/bulk-api-adapter
-        tag: v17.1.9
+        tag: v17.2.2
         ## Specify a imagePullPolicy
         ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
         ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -11100,7 +11098,7 @@ mojaloop-bulk:
       image:
         registry: docker.io
         repository: mojaloop/central-ledger
-        tag: v19.8.0
+        tag: v19.8.3
         ## Specify a imagePullPolicy
         ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
         ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -11384,7 +11382,7 @@ mojaloop-bulk:
       image:
         registry: docker.io
         repository: mojaloop/central-ledger
-        tag: v19.8.0
+        tag: v19.8.3
         ## Specify a imagePullPolicy
         ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
         ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -11665,7 +11663,7 @@ mojaloop-bulk:
       image:
         registry: docker.io
         repository: mojaloop/central-ledger
-        tag: v19.8.0
+        tag: v19.8.3
         ## Specify a imagePullPolicy
         ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
         ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -12345,9 +12343,9 @@ ml-testing-toolkit:
       ## We can pass the JSON content as the value for the parameters
       ## Or we can pass a http/https URL for the JSON file as the value for the parameters. Then the file will be downloaded and replaced in the corresponding location.
       ## Ex: rules_callback__default.json: "https://raw.githubusercontent.com/mojaloop/ml-testing-toolkit/master/spec_files/rules_callback/default.json"
-      rules_callback__default.json: "https://github.com/mojaloop/testing-toolkit-test-cases/raw/v17.0.0/rules/hub/rules_callback/default.json"
-      rules_response__default.json: "https://github.com/mojaloop/testing-toolkit-test-cases/raw/v17.0.0/rules/hub/rules_response/default.json"
-      rules_validation__default.json: "https://github.com/mojaloop/testing-toolkit-test-cases/raw/v17.0.0/rules/hub/rules_validation/default.json"
+      rules_callback__default.json: "https://github.com/mojaloop/testing-toolkit-test-cases/raw/v17.1.0/rules/hub/rules_callback/default.json"
+      rules_response__default.json: "https://github.com/mojaloop/testing-toolkit-test-cases/raw/v17.1.0/rules/hub/rules_response/default.json"
+      rules_validation__default.json: "https://github.com/mojaloop/testing-toolkit-test-cases/raw/v17.1.0/rules/hub/rules_validation/default.json"
     # We can change the names of the simulators to configure the environment files for the testing toolkit.
     # If you change these values, you need to change the simulator names in the mojaloop-simulats->simulators section
     parameters: &simNames
@@ -12387,8 +12385,8 @@ ml-ttk-posthook-setup:
     weight: -5
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
-    testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/v17.0.0.zip
-    testCasesPathInZip: &ttkGitPathSetup testing-toolkit-test-cases-17.0.0/collections/hub/provisioning/for_golden_path
+    testCasesZipUrl: &ttkGitUrl https://github.com/mojaloop/testing-toolkit-test-cases/archive/v17.1.0.zip
+    testCasesPathInZip: &ttkGitPathSetup testing-toolkit-test-cases-17.1.0/collections/hub/provisioning/for_golden_path
     ttkBackendURL: http://$release_name-ml-testing-toolkit-backend:5050
   parameters:
     <<: *simNames
@@ -12401,7 +12399,7 @@ ml-ttk-posthook-tests:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: &ttkGitPathGP testing-toolkit-test-cases-17.0.0/collections/hub/golden_path
+    testCasesPathInZip: &ttkGitPathGP testing-toolkit-test-cases-17.1.0/collections/hub/golden_path
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
     ttkBackendURL: http://$release_name-ml-testing-toolkit-backend:5050
@@ -12502,7 +12500,7 @@ ml-ttk-cronjob-cleanup:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: &ttkGitPathCleanup testing-toolkit-test-cases-17.0.0/collections/hub/cleanup
+    testCasesPathInZip: &ttkGitPathCleanup testing-toolkit-test-cases-17.1.0/collections/hub/cleanup
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
     ttkBackendURL: http://$release_name-ml-testing-toolkit-backend:5050
@@ -12615,7 +12613,7 @@ ml-ttk-test-val-bulk:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: testing-toolkit-test-cases-17.0.0/collections/hub/other_tests/bulk_transfers
+    testCasesPathInZip: testing-toolkit-test-cases-17.1.0/collections/hub/other_tests/bulk_transfers
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
@@ -12660,7 +12658,7 @@ ml-ttk-test-setup-tp:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: testing-toolkit-test-cases-17.0.0/collections/hub/provisioning/for_thirdparty
+    testCasesPathInZip: testing-toolkit-test-cases-17.1.0/collections/hub/provisioning/for_thirdparty
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
@@ -12705,7 +12703,7 @@ ml-ttk-test-val-tp:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: testing-toolkit-test-cases-17.0.0/collections/hub/thirdparty
+    testCasesPathInZip: testing-toolkit-test-cases-17.1.0/collections/hub/thirdparty
     ttkBackendURL: http://$release_name-ml-testing-toolkit-backend:5050
     # awsS3FilePath: ttk-tests/reports
     testSuiteName: Thirdparty Tests
@@ -12748,7 +12746,7 @@ ml-ttk-test-setup-sdk-bulk:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: testing-toolkit-test-cases-17.0.0/collections/hub/provisioning/for_sdk_bulk
+    testCasesPathInZip: testing-toolkit-test-cases-17.1.0/collections/hub/provisioning/for_sdk_bulk
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
@@ -12793,7 +12791,7 @@ ml-ttk-test-val-sdk-bulk:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: testing-toolkit-test-cases-17.0.0/collections/hub/sdk_scheme_adapter/bulk/basic
+    testCasesPathInZip: testing-toolkit-test-cases-17.1.0/collections/hub/sdk_scheme_adapter/bulk/basic
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
@@ -12838,7 +12836,7 @@ ml-ttk-test-val-sdk-r2p:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: testing-toolkit-test-cases-17.0.0/collections/hub/sdk_scheme_adapter/request-to-pay/basic
+    testCasesPathInZip: testing-toolkit-test-cases-17.1.0/collections/hub/sdk_scheme_adapter/request-to-pay/basic
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
@@ -12883,7 +12881,7 @@ ml-ttk-test-setup-interscheme:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: testing-toolkit-test-cases-17.0.0/collections/hub/provisioning/for_inter_scheme
+    testCasesPathInZip: testing-toolkit-test-cases-17.1.0/collections/hub/provisioning/for_inter_scheme
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports
@@ -12908,7 +12906,7 @@ ml-ttk-test-val-interscheme:
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases
     testCasesZipUrl: *ttkGitUrl
-    testCasesPathInZip: testing-toolkit-test-cases-17.0.0/collections/hub/inter_scheme
+    testCasesPathInZip: testing-toolkit-test-cases-17.1.0/collections/hub/inter_scheme
     ## Optional config for uploading reports to S3 Buckets. If enabled: WS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION under the 'configCreds' is required.
     # awsS3BucketName: aws-s3-bucket-name
     # awsS3FilePath: ttk-tests/reports

--- a/quoting-service/Chart.yaml
+++ b/quoting-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Quoting-Service Helm chart for Kubernetes
 name: quoting-service
-version: 16.0.0
-appVersion: v17.12.0
+version: 16.5.0
+appVersion: v17.12.1
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -16,15 +16,15 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: quoting-service
-    version: ">= 16.0.0"
+    version: ">= 16.3.0"
     repository: "file://./chart-service"
     condition: quoting-service.enabled
   - name: quoting-service-handler
-    version: ">= 16.0.0"
+    version: ">= 16.3.0"
     repository: "file://./chart-handler"
     condition: quoting-service-handler.enabled
   - name: common
     repository: https://mojaloop.github.io/charts/repo
-    version: 3.1.3
+    version: 3.1.5
     tags:
         - moja-common

--- a/quoting-service/chart-handler/Chart.yaml
+++ b/quoting-service/chart-handler/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Quoting-Service Handler Helm chart for Kubernetes
 name: quoting-service-handler
-version: 16.0.0
-appVersion: v17.12.0
+version: 16.3.0
+appVersion: v17.12.1
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -16,7 +16,7 @@ maintainers:
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common
   - name: mojaloop-common

--- a/quoting-service/chart-handler/values.yaml
+++ b/quoting-service/chart-handler/values.yaml
@@ -7,7 +7,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/quoting-service
-  tag: v17.12.0
+  tag: v17.12.1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -92,7 +92,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.3
+    tag: v14.2.0
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:

--- a/quoting-service/chart-service/Chart.yaml
+++ b/quoting-service/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Quoting-Service API Helm chart for Kubernetes
 name: quoting-service
-version: 16.0.0
-appVersion: v17.12.0
+version: 16.3.0
+appVersion: v17.12.1
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -16,7 +16,7 @@ maintainers:
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common
   - name: mojaloop-common

--- a/quoting-service/chart-service/values.yaml
+++ b/quoting-service/chart-service/values.yaml
@@ -7,7 +7,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/quoting-service
-  tag: v17.12.0
+  tag: v17.12.1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -87,7 +87,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.3
+    tag: v14.2.0
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:

--- a/quoting-service/values.yaml
+++ b/quoting-service/values.yaml
@@ -13,7 +13,7 @@ quoting-service: # API
   image:
     registry: docker.io
     repository: mojaloop/quoting-service
-    tag: v17.12.0
+    tag: v17.12.1
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -383,7 +383,7 @@ quoting-service-handler:
   image:
     registry: docker.io
     repository: mojaloop/quoting-service
-    tag: v17.12.0
+    tag: v17.12.1
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/sdk-scheme-adapter/Chart.yaml
+++ b/sdk-scheme-adapter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: sdk-scheme-adapter Helm chart for Kubernetes
 name: sdk-scheme-adapter
-version: 2.0.0
-appVersion: v24.6.3
+version: 2.7.0
+appVersion: v24.10.5
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -20,24 +20,24 @@ dependencies:
     repository: "file://./chart-service"
     tags:
       - sdk-scheme-adapter
-    version: ">= 2.0.0"
+    version: ">= 2.2.0"
     condition: sdk-scheme-adapter-api-svc.enabled
   - name: sdk-scheme-adapter-svc
     alias: sdk-scheme-adapter-dom-evt-handler
     repository: "file://./chart-service"
     tags:
       - sdk-scheme-adapter
-    version: ">= 2.0.0"
+    version: ">= 2.2.0"
     condition: sdk-scheme-adapter-dom-evt-handler.enabled
   - name: sdk-scheme-adapter-svc
     alias: sdk-scheme-adapter-cmd-evt-handler
     repository: "file://./chart-service"
     tags:
       - sdk-scheme-adapter
-    version: ">= 2.0.0"
+    version: ">= 2.2.0"
     condition: sdk-scheme-adapter-cmd-evt-handler.enabled
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
     tags:
       - moja-common
-    version: 3.1.3
+    version: 3.1.5

--- a/sdk-scheme-adapter/chart-service/Chart.yaml
+++ b/sdk-scheme-adapter/chart-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: sdk-scheme-adapter-svc
-version: 2.0.0
+version: 2.2.0
 description: A Helm chart for Kubernetes
-appVersion: v24.6.3
+appVersion: v24.10.5
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -19,4 +19,4 @@ dependencies:
     repository: "https://mojaloop.github.io/charts/repo"
     tags:
       - moja-common
-    version: 3.1.3
+    version: 3.1.5

--- a/sdk-scheme-adapter/chart-service/values.yaml
+++ b/sdk-scheme-adapter/chart-service/values.yaml
@@ -318,7 +318,7 @@ containerSecurityContext:
 image:
   registry: docker.io
   repository: mojaloop/sdk-scheme-adapter
-  tag: v24.6.3
+  tag: v24.10.5
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -484,14 +484,14 @@ service:
   ## clusterIP: None
   ##
   clusterIP: null ## @param service.loadBalancerIP %%MAIN_CONTAINER_NAME%% service Load Balancer IP
-## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
-##
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+  ##
   loadBalancerIP: null ## @param service.loadBalancerSourceRanges %%MAIN_CONTAINER_NAME%% service Load Balancer sources
-## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-## e.g:
-## loadBalancerSourceRanges:
-##   - 10.10.10.0/24
-##
+  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ## e.g:
+  ## loadBalancerSourceRanges:
+  ##   - 10.10.10.0/24
+  ##
   loadBalancerSourceRanges: []
   ## @param service.externalTrafficPolicy %%MAIN_CONTAINER_NAME%% service external traffic policy
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
@@ -522,7 +522,7 @@ ingress:
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
   apiVersion: null ## @param ingress.hostname Default host for the ingress record
-##
+  ##
   hostname: sdk-scheme-adapter.local
   ## @param ingress.path Default path for the ingress record
   ## NOTE: You may need to set this to '/*' in order to use this with ALB ingress controllers

--- a/sdk-scheme-adapter/values.yaml
+++ b/sdk-scheme-adapter/values.yaml
@@ -300,7 +300,7 @@ sdk-scheme-adapter-api-svc:
   image:
     registry: docker.io
     repository: mojaloop/sdk-scheme-adapter
-    tag: v24.6.3
+    tag: v24.10.5
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -716,7 +716,7 @@ sdk-scheme-adapter-dom-evt-handler:
   image:
     registry: docker.io
     repository: mojaloop/sdk-scheme-adapter
-    tag: v24.6.3
+    tag: v24.10.5
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1135,7 +1135,7 @@ sdk-scheme-adapter-cmd-evt-handler:
   image:
     registry: docker.io
     repository: mojaloop/sdk-scheme-adapter
-    tag: v24.6.3
+    tag: v24.10.5
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/simulator/Chart.yaml
+++ b/simulator/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 description: Simulator Helm Chart for Simulators
 name: simulator
-version: 13.5.0
-appVersion: v12.2.5
+version: 13.7.0
+appVersion: v12.3.2
 maintainers:
   - name: Miguel de Barros
     email: miguel.debarros@modusbox.com
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common

--- a/simulator/values.yaml
+++ b/simulator/values.yaml
@@ -5,7 +5,7 @@
 image:
   registry: docker.io
   repository: mojaloop/simulator
-  tag: v12.2.5
+  tag: v12.3.2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/thirdparty/Chart.yaml
+++ b/thirdparty/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: thirdparty
-version: 3.18.0
+version: 3.28.0
 description: Third Party API Support for Mojaloop
-appVersion: "auth-service: v15.2.5; als-consent-oracle: v1.1.2; thirdparty-sdk: v15.1.3"
+appVersion: "auth-service: v15.2.7; als-consent-oracle: v1.1.4; thirdparty-sdk: v15.1.3"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -16,24 +16,24 @@ maintainers:
     email: steven.oderayi@infitx.com
 dependencies:
   - name: auth-svc
-    version: ">= 3.5.0"
+    version: ">= 3.7.0"
     repository: "file://./chart-auth-svc"
     condition: auth-svc.enabled
   - name: consent-oracle
-    version: ">= 0.9.0"
+    version: ">= 0.11.0"
     repository: "file://./chart-consent-oracle"
     condition: consent-oracle.enabled
   - name: tp-api-svc
-    version: ">= 3.5.0"
+    version: ">= 3.7.0"
     repository: "file://./chart-tp-api-svc"
     condition: tp-api-svc.enabled
   - name: mojaloop-simulator
     alias: thirdparty-simulator
-    version: ">= 15.7.0"
+    version: ">= 15.10.0"
     repository: "file://../mojaloop-simulator"
     condition: mojaloop-simulator.enabled
   - name: common
     repository: https://mojaloop.github.io/charts/repo
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common

--- a/thirdparty/chart-auth-svc/Chart.yaml
+++ b/thirdparty/chart-auth-svc/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: auth-svc chart for Mojaloop Thirdparty Services
 name: auth-svc
-version: 3.5.0
-appVersion: v15.2.5
+version: 3.7.0
+appVersion: v15.2.7
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -15,6 +15,6 @@ maintainers:
 dependencies:
   - name: common
     repository: https://mojaloop.github.io/charts/repo
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common

--- a/thirdparty/chart-auth-svc/values.yaml
+++ b/thirdparty/chart-auth-svc/values.yaml
@@ -3,7 +3,7 @@ enabled: true
 image:
   registry: docker.io
   repository: mojaloop/auth-service
-  tag: v15.2.5
+  tag: v15.2.7
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/thirdparty/chart-consent-oracle/Chart.yaml
+++ b/thirdparty/chart-consent-oracle/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: consent-oracle chart for Mojaloop Thirdparty Overlay Services
 name: consent-oracle
-version: 0.9.0
-appVersion: v1.1.2
+version: 0.11.0
+appVersion: v1.1.4
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -15,6 +15,6 @@ maintainers:
 dependencies:
   - name: common
     repository: https://mojaloop.github.io/charts/repo
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common

--- a/thirdparty/chart-consent-oracle/values.yaml
+++ b/thirdparty/chart-consent-oracle/values.yaml
@@ -3,7 +3,7 @@ enabled: true
 image:
   registry: docker.io
   repository: mojaloop/als-consent-oracle
-  tag: v1.1.2
+  tag: v1.1.4
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/thirdparty/chart-tp-api-svc/Chart.yaml
+++ b/thirdparty/chart-tp-api-svc/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Thirdparty API Service chart for Mojaloop Thirdparty Overlay Services
 name: tp-api-svc
-version: 3.5.0
-appVersion: v15.0.2
+version: 3.7.0
+appVersion: v15.1.2
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
 sources:
@@ -15,6 +15,6 @@ maintainers:
 dependencies:
   - name: common
     repository: "https://mojaloop.github.io/charts/repo"
-    version: 3.1.3
+    version: 3.1.5
     tags:
       - moja-common

--- a/thirdparty/chart-tp-api-svc/values.yaml
+++ b/thirdparty/chart-tp-api-svc/values.yaml
@@ -3,7 +3,7 @@ enabled: true
 image:
   registry: docker.io
   repository: mojaloop/thirdparty-api-svc
-  tag: v15.0.2
+  tag: v15.1.2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/thirdparty/values.yaml
+++ b/thirdparty/values.yaml
@@ -4,7 +4,7 @@ auth-svc:
   image:
     registry: docker.io
     repository: mojaloop/auth-service
-    tag: v15.2.5
+    tag: v15.2.7
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -419,7 +419,7 @@ consent-oracle:
   image:
     registry: docker.io
     repository: mojaloop/als-consent-oracle
-    tag: v1.1.2
+    tag: v1.1.4
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -760,7 +760,7 @@ tp-api-svc:
   image:
     registry: docker.io
     repository: mojaloop/thirdparty-api-svc
-    tag: v15.0.2
+    tag: v15.1.2
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1977,7 +1977,7 @@ thirdparty-simulator:
             publicKey: ''
         image:
           repository: mojaloop/sdk-scheme-adapter
-          tag: v24.6.2
+          tag: v24.10.5
           pullPolicy: IfNotPresent
           command: '[ "yarn", "start:api-svc" ]'
         <<: *defaultProbes
@@ -2129,7 +2129,7 @@ thirdparty-simulator:
       backend:
         image:
           repository: mojaloop/mojaloop-simulator
-          tag: v15.3.0
+          tag: v15.4.2
           pullPolicy: IfNotPresent
         <<: *defaultProbes
         # These will be supplied directly to the init containers array in the deployment for the

--- a/transaction-requests-service/Chart.yaml
+++ b/transaction-requests-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Transaction-Requests-Service Helm chart for Kubernetes
 name: transaction-requests-service
-version: 13.6.0
+version: 13.9.0
 appVersion: "14.1.2"
 home: http://mojaloop.io
 icon: http://mojaloop.io/images/logo.png
@@ -18,4 +18,4 @@ dependencies:
     repository: "https://mojaloop.github.io/charts/repo"
     tags:
       - moja-common
-    version: 3.1.3
+    version: 3.1.5

--- a/transaction-requests-service/values.yaml
+++ b/transaction-requests-service/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/transaction-requests-service
-  tag: v14.3.9
+  tag: v14.4.5
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -100,7 +100,7 @@ sidecar:
   enabled: true
   image:
     repository: mojaloop/event-sidecar
-    tag: v14.0.3
+    tag: v14.2.0
     pullPolicy: IfNotPresent
     command: '["npm", "run", "start"]'
   service:


### PR DESCRIPTION
# Helm Release Notes

Date | Revision | Description
---------|----------|---------
2025-08-05 | 0 | Initial draft

## 0. Summary

Enhancements and breaking changes to the [v17.0.0 Release](https://github.com/mojaloop/helm/blob/main/.changelog/release-v17.0.0.md), which includes:

_Release summary points go here..._

## 1. New Features
* **mojaloop/#541** reset party mappings in inter-scheme scenario ([mojaloop/#541](https://github.com/mojaloop/account-lookup-service/pull/541)), closes [mojaloop/#541](https://github.com/mojaloop/project/issues/541)
* **mojaloop/#546** refactored oracleRequest ([mojaloop/#546](https://github.com/mojaloop/account-lookup-service/pull/546)), closes [mojaloop/#546](https://github.com/mojaloop/project/issues/546)
* **mojaloop/#549** use updated AxiosHttpRequester ([mojaloop/#549](https://github.com/mojaloop/account-lookup-service/pull/549)), closes [mojaloop/#549](https://github.com/mojaloop/project/issues/549)
* **mojaloop/#556** used ha timeout design with redlock impl ([mojaloop/#556](https://github.com/mojaloop/account-lookup-service/pull/556)), closes [mojaloop/#556](https://github.com/mojaloop/project/issues/556)
* **mojaloop/#1172** timeout handler distributed lock ([mojaloop/#1172](https://github.com/mojaloop/central-ledger/pull/1172)), closes [mojaloop/#1172](https://github.com/mojaloop/project/issues/1172)
* **mojaloop/#1185** moved distLock to central-services-shared ([mojaloop/#1185](https://github.com/mojaloop/central-ledger/pull/1185)), closes [mojaloop/#1185](https://github.com/mojaloop/project/issues/1185)
* **mojaloop/#407** improved logging;  added BaseQuotesModel ([mojaloop/#407](https://github.com/mojaloop/quoting-service/pull/407)), closes [mojaloop/#407](https://github.com/mojaloop/project/issues/407)
* **mojaloop/#409** use updated AxiosHttpRequester ([mojaloop/#409](https://github.com/mojaloop/quoting-service/pull/409)), closes [mojaloop/#409](https://github.com/mojaloop/project/issues/409)
* **mojaloop/#572** use updated AxiosHttpRequester ([mojaloop/#572](https://github.com/mojaloop/sdk-scheme-adapter/pull/572)), closes [mojaloop/#572](https://github.com/mojaloop/project/issues/572)
* **mojaloop/#574** added InboundPingModel ([mojaloop/#574](https://github.com/mojaloop/sdk-scheme-adapter/pull/574)), closes [mojaloop/#574](https://github.com/mojaloop/project/issues/574)

## 2. Bug Fixes
* **mojaloop/#547** delete participant audit ([mojaloop/#547](https://github.com/mojaloop/account-lookup-service/pull/547)), closes [mojaloop/#547](https://github.com/mojaloop/project/issues/547)
* **mojaloop/#1173** fix issue with broker reporting OK when kafka is disconnected ([mojaloop/#1173](https://github.com/mojaloop/central-ledger/pull/1173)), closes [mojaloop/#1173](https://github.com/mojaloop/project/issues/1173)
* **mojaloop/#1181** fixed issue with DIST_LOCK config ([mojaloop/#1181](https://github.com/mojaloop/central-ledger/pull/1181)), closes [mojaloop/#1181](https://github.com/mojaloop/project/issues/1181)
* **mojaloop/#1182** fixed issue with DIST_LOCK config ([mojaloop/#1182](https://github.com/mojaloop/central-ledger/pull/1182)), closes [mojaloop/#1182](https://github.com/mojaloop/project/issues/1182)
* **mojaloop/#1183** fixed misleading log ([mojaloop/#1183](https://github.com/mojaloop/central-ledger/pull/1183)), closes [mojaloop/#1183](https://github.com/mojaloop/project/issues/1183)
* **mojaloop/#1189** switch to mysql2 client and update version for mysql v8 auth compatibility ([mojaloop/#1189](https://github.com/mojaloop/central-ledger/pull/1189)), closes [mojaloop/#1189](https://github.com/mojaloop/project/issues/1189)
* **mojaloop/#600** improved error logs ([mojaloop/#600](https://github.com/mojaloop/ml-api-adapter/pull/600)), closes [mojaloop/#600](https://github.com/mojaloop/project/issues/600)

## 3. Application Versions

1. bulk-api-adapter: v17.1.9 ->                     [v17.2.2](https://github.com/mojaloop/bulk-api-adapter/releases/v17.2.2)                     ([Compare](https://github.com/mojaloop/bulk-api-adapter/compare/v17.1.9...v17.2.2))
2. event-sidecar: v14.0.3 ->                     [v14.2.0](https://github.com/mojaloop/event-sidecar/releases/v14.2.0)                     ([Compare](https://github.com/mojaloop/event-sidecar/compare/v14.0.3...v14.2.0))
3. ml-testing-toolkit-ui: v16.2.0 ->                     [v16.6.4](https://github.com/mojaloop/ml-testing-toolkit-ui/releases/v16.6.4)                     ([Compare](https://github.com/mojaloop/ml-testing-toolkit-ui/compare/v16.2.0...v16.6.4))
4. als-oracle-pathfinder: v12.1.3 ->                     [v12.3.1](https://github.com/mojaloop/als-oracle-pathfinder/releases/v12.3.1)                     ([Compare](https://github.com/mojaloop/als-oracle-pathfinder/compare/v12.1.3...v12.3.1))
5. auth-service: v15.1.2 ->                     [v15.2.7](https://github.com/mojaloop/auth-service/releases/v15.2.7)                     ([Compare](https://github.com/mojaloop/auth-service/compare/v15.1.2...v15.2.7))
6. ml-testing-toolkit: v18.11.2 ->                     [v18.14.0](https://github.com/mojaloop/ml-testing-toolkit/releases/v18.14.0)                     ([Compare](https://github.com/mojaloop/ml-testing-toolkit/compare/v18.11.2...v18.14.0))
7. als-msisdn-oracle-svc: v0.0.14 ->                     [v0.0.21](https://github.com/mojaloop/als-msisdn-oracle-svc/releases/v0.0.21)                     ([Compare](https://github.com/mojaloop/als-msisdn-oracle-svc/compare/v0.0.14...v0.0.21))
8. transaction-requests-service: v14.3.9 ->                     [v14.4.5](https://github.com/mojaloop/transaction-requests-service/releases/v14.4.5)                     ([Compare](https://github.com/mojaloop/transaction-requests-service/compare/v14.3.9...v14.4.5))
9. ml-api-adapter: v16.4.1 ->                     [v16.5.9](https://github.com/mojaloop/ml-api-adapter/releases/v16.5.9)                     ([Compare](https://github.com/mojaloop/ml-api-adapter/compare/v16.4.1...v16.5.9))
10. ml-testing-toolkit-client-lib: v1.9.0 ->                     [v1.10.3](https://github.com/mojaloop/ml-testing-toolkit-client-lib/releases/v1.10.3)                     ([Compare](https://github.com/mojaloop/ml-testing-toolkit-client-lib/compare/v1.9.0...v1.10.3))
11. callback-handler-simulator-svc:  ->                     [v0.1.3](https://github.com/mojaloop/callback-handler-simulator-svc/releases/v0.1.3)                     ([Compare](https://github.com/mojaloop/callback-handler-simulator-svc/compare/...v0.1.3))
12. merchant-acquirer-backend:  ->                     [1.0.1](https://github.com/mojaloop/merchant-acquirer-backend/releases/1.0.1)                     ([Compare](https://github.com/mojaloop/merchant-acquirer-backend/compare/...1.0.1))
13. sdk-scheme-adapter: v24.6.2 ->                     [v24.10.5](https://github.com/mojaloop/sdk-scheme-adapter/releases/v24.10.5)                     ([Compare](https://github.com/mojaloop/sdk-scheme-adapter/compare/v24.6.2...v24.10.5))
14. mojaloop-simulator: v15.3.0 ->                     [v15.4.2](https://github.com/mojaloop/mojaloop-simulator/releases/v15.4.2)                     ([Compare](https://github.com/mojaloop/mojaloop-simulator/compare/v15.3.0...v15.4.2))
15. thirdparty-api-svc: v15.0.2 ->                     [v15.1.2](https://github.com/mojaloop/thirdparty-api-svc/releases/v15.1.2)                     ([Compare](https://github.com/mojaloop/thirdparty-api-svc/compare/v15.0.2...v15.1.2))
16. als-consent-oracle: v1.0.1 ->                     [v1.1.4](https://github.com/mojaloop/als-consent-oracle/releases/v1.1.4)                     ([Compare](https://github.com/mojaloop/als-consent-oracle/compare/v1.0.1...v1.1.4))
17. account-lookup-service: v17.7.1 ->                     [v17.12.0](https://github.com/mojaloop/account-lookup-service/releases/v17.12.0)                     ([Compare](https://github.com/mojaloop/account-lookup-service/compare/v17.7.1...v17.12.0))
18. simulator: v12.2.5 ->                     [v12.3.2](https://github.com/mojaloop/simulator/releases/v12.3.2)                     ([Compare](https://github.com/mojaloop/simulator/compare/v12.2.5...v12.3.2))
19. merchant-acquirer-frontend:  ->                     [1.0.1](https://github.com/mojaloop/merchant-acquirer-frontend/releases/1.0.1)                     ([Compare](https://github.com/mojaloop/merchant-acquirer-frontend/compare/...1.0.1))
20. quoting-service: v17.7.1 ->                     [v17.12.1](https://github.com/mojaloop/quoting-service/releases/v17.12.1)                     ([Compare](https://github.com/mojaloop/quoting-service/compare/v17.7.1...v17.12.1))
21. merchant-registry-oracle:  ->                     [1.0.1](https://github.com/mojaloop/merchant-registry-oracle/releases/1.0.1)                     ([Compare](https://github.com/mojaloop/merchant-registry-oracle/compare/...1.0.1))
22. central-ledger: v19.3.0 ->                     [v19.8.3](https://github.com/mojaloop/central-ledger/releases/v19.8.3)                     ([Compare](https://github.com/mojaloop/central-ledger/compare/v19.3.0...v19.8.3))
23. ml-core-test-harness:  ->                     [v2.3.0](https://github.com/mojaloop/ml-core-test-harness/releases/v2.3.0)                     ([Compare](https://github.com/mojaloop/ml-core-test-harness/compare/...v2.3.0))
24. central-settlement: v17.0.6 ->                     [v17.2.2](https://github.com/mojaloop/central-settlement/releases/v17.2.2)                     ([Compare](https://github.com/mojaloop/central-settlement/compare/v17.0.6...v17.2.2))
25. email-notifier: v14.0.3 ->                     [v14.1.4](https://github.com/mojaloop/email-notifier/releases/v14.1.4)                     ([Compare](https://github.com/mojaloop/email-notifier/compare/v14.0.3...v14.1.4))
26. central-event-processor: [v12.1.1](https://github.com/mojaloop/central-event-processor/releases/v12.1.1)
27. inter-scheme-proxy-adapter: [v1.3.3](https://github.com/mojaloop/inter-scheme-proxy-adapter/releases/v1.3.3)
28. thirdparty-sdk: [v15.1.3](https://github.com/mojaloop/thirdparty-sdk/releases/v15.1.3)
29. event-stream-processor: [v12.0.0-snapshot.14](https://github.com/mojaloop/event-stream-processor/releases/v12.0.0-snapshot.14)

## 4. API Versions

This release supports the following versions of the [Mojaloop family of APIs](https://docs.mojaloop.io/api):

| API         | Supported Versions                                                                                                                                    | Notes |
| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
| FSPIOP      | [v1.1](https://docs.mojaloop.io/api/fspiop/v1.1/api-definition.html), [v1.0](https://docs.mojaloop.io/api/fspiop/v1.0/api-definition.html) |       |
| Settlements | [v2.0](https://docs.mojaloop.io/api/settlement)                                                                                            |       |
| Admin       | [v1.0](https://docs.mojaloop.io/api/administration/central-ledger-api.html)                                                                |       |
| Oracle      | [v1.0](https://docs.mojaloop.io/legacy/api/als-oracle-api-specification.html)                                                              |       |
| Thirdparty  | [v1.0](https://docs.mojaloop.io/api/thirdparty)                                                                                            |       |

## 5. Testing notes

1. This release has been validated against the following Dependency Test Matrix:

    | Dependency | Version |  Notes   |
    | ---------- | ------- | --- |
    | Kubernetes | v1.29 | [AWS EKS](https://aws.amazon.com/eks/), [AWS EKS Supported Version Notes](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)  |
    | containerd  |  v1.6.19  |  |
    | Nginx Ingress Controller | [helm-ingress-nginx-4.7.0](https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.7.0) / [ingress-controller-v1.8.0](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.8.0) |     |
    |  Amazon Linux   |  v2   |     |
    |  MySQL   |  bitnami/mysql:8.0.32-debian-11-r0   |     |
    |  Kafka   |  bitnami/kafka:3.3.1-debian-11-r1   |     |
    |  Redis   |  bitnami/redis:7.0.5-debian-11-r7   |     |
    |  MongoDB   |  bitnami/mongodb:6.0.2-debian-11-r11   |     |
    |  Testing Toolkit Test Cases   |  [v17.1.0](https://github.com/mojaloop/testing-toolkit-test-cases/releases/tag/v17.1.0)   |     |
    |  example-mojaloop-backend   |  v17.0.0   |  [README](https://github.com/mojaloop/helm/blob/main/example-mojaloop-backend/README.md)   |

2. It is recommended that all Mojaloop deployments are verified using the [Mojaloop Testing Toolkit](https://docs.mojaloop.io/documentation/mojaloop-technical-overview/ml-testing-toolkit/). More information can be found in the [Mojaloop Deployment Guide](https://docs.mojaloop.io/documentation/deployment-guide).

3. The [testing-toolkit-test-cases](https://github.com/mojaloop/testing-toolkit-test-cases/releases) (See above Dependency Test Matrix for exact version required for this release) Golden Path collections expects:
    - the Quoting service operating mode to be set quoting-service.config.simple_routing_mode_enabled=true (in helm mojaloop/values.yaml under quoting-service config). If this is incorrectly configured, it will result in several failures in the quoting-service tests (7 expected failures). If this is disabled, ensure that you update the corresponding test-case environment variable parameter **SIMPLE_ROUTING_MODE_ENABLED** ( in helm mojaloop/values.yaml ml-testing-toolkit -> extraEnvironments.hub-k8s-default-environment.json.inputValues) to match.
    - the **on-us transfers** (in mojaloop/values.yaml "enable_on_us_transfers: false" under centralledger-handler-transfer-prepare -> config and  cl-handler-bulk-transfer-prepare -> config) configuration to be disabled. The test-case environment variable parameter (**ON_US_TRANSFERS_ENABLED** (in helm mojaloop/values.yaml ml-testing-toolkit -> extraEnvironments.hub-k8s-default-environment.json.inputValues), the same name used on postman collections) must similarly match this value.

4. Simulators
    - We recommend using Testing Toolkit instead of Postman which is better suited for the async nature of the Mojaloop API specification (see above)
    - [Mojaloop-Simulator](https://github.com/mojaloop/mojaloop-simulator) is enabled by default (six instances used for single transfers usually and three more specific to bulk).
    - Ensure that correct Postman Scripts are used if you wish to test against the Mojaloop-Simulators:
        - Setup Mojaloop Hub: [MojaloopHub_Setup](https://github.com/mojaloop/postman/blob/v12.0.0/MojaloopHub_Setup.postman_collection.json)
        - Setup Mojaloop Simulators for testing : [MojaloopSims_Onboarding](https://github.com/mojaloop/postman/blob/v12.0.0/MojaloopSims_Onboarding.postman_collection.json)
        - Golden path tests: [Golden_Path_Mojaloop](https://github.com/mojaloop/postman/blob/v12.0.0/Golden_Path_Mojaloop.postman_collection.json)
    - Legacy Simulators are still required and deployed by default; disabling this will cause issues since there is Account Lookup directory mocking functionality in this service.

5. Thirdparty Testing Toolkit Test Collections are not repeatable. Please refer to the following issue for more information [#2717 - Thirdparty TTK Test-Collection is not repeatable](https://github.com/mojaloop/project/issues/2717). It is possible to manually cleanup persistent data to re-run the test if required.

6. Bulk API Helm Tests

    Refer to the [Testing Deployments](https://github.com/mojaloop/helm/blob/main/README.md#testing-deployments) section in the main README for detailed information on how to enable bulk-api-adapter tests.

7. Thirdparty API Helm Tests

    Refer to [thirdparty/README.md#validating-and-testing-the-3p-api](https://github.com/mojaloop/helm/blob/main/thirdparty/README.md#validating-and-testing-the-3p-api) on how to enabled and execute Thirdparty verification tests.

8. Testing the Bulk functionality including "sdk-scheme-adapter"

    For details regarding deployment and validation of simulators needed for bulk (for adoption provided in sdk-scheme-adapter) refer to [deploying Mojaloop TTK simulators](https://github.com/mojaloop/helm/blob/main/mojaloop-ttk-simulators/README.md).

## 6. Breaking Changes


### central-ledger
  * config/default.json: (https://github.com/mojaloop/central-ledger/blob/6d3f5a703954f5dd46c8c69f5827b24e4138cba5/config%2Fdefault.json)
  * docker/central-ledger/default.json: (https://github.com/mojaloop/central-ledger/blob/6d3f5a703954f5dd46c8c69f5827b24e4138cba5/docker%2Fcentral-ledger%2Fdefault.json)
  * migrations/310403_participantPositionChange-participantCurrencyId.js: (https://github.com/mojaloop/central-ledger/blob/6d3f5a703954f5dd46c8c69f5827b24e4138cba5/migrations%2F310403_participantPositionChange-participantCurrencyId.js)
### als-msisdn-oracle-svc
  * config/default.json: (https://github.com/mojaloop/als-msisdn-oracle-svc/blob/41f9f1e836663250de6bfc5d6fa898c6aef1b059/config%2Fdefault.json)
### ml-api-adapter
  * docker/central-ledger/default.json: (https://github.com/mojaloop/ml-api-adapter/blob/e51b271c85794132579429b8ff36a937cb087c99/docker%2Fcentral-ledger%2Fdefault.json)
### quoting-service
  * config/default.json: (https://github.com/mojaloop/quoting-service/blob/e4dd481c1dd8ef0dc5f4d353ee4ac1c7c0bcd7f1/config%2Fdefault.json)
  * docker/central-ledger/default.json: (https://github.com/mojaloop/quoting-service/blob/e4dd481c1dd8ef0dc5f4d353ee4ac1c7c0bcd7f1/docker%2Fcentral-ledger%2Fdefault.json)
  * docker/quoting-service/default.json: (https://github.com/mojaloop/quoting-service/blob/e4dd481c1dd8ef0dc5f4d353ee4ac1c7c0bcd7f1/docker%2Fquoting-service%2Fdefault.json)
### central-settlement
  * config/default.json: (https://github.com/mojaloop/central-settlement/blob/68a55c535102b3301d0f63fa6cc803541e49dab5/config%2Fdefault.json)
  * docker/central-ledger/default.json: (https://github.com/mojaloop/central-settlement/blob/68a55c535102b3301d0f63fa6cc803541e49dab5/docker%2Fcentral-ledger%2Fdefault.json)
  * docker/central-settlement/default.json: (https://github.com/mojaloop/central-settlement/blob/68a55c535102b3301d0f63fa6cc803541e49dab5/docker%2Fcentral-settlement%2Fdefault.json)
### als-consent-oracle
  * config/default.json: (https://github.com/mojaloop/als-consent-oracle/blob/2f04eeaa513025d8c77e78cc6d5e733c26441480/config%2Fdefault.json)
### account-lookup-service
  * config/default.json: (https://github.com/mojaloop/account-lookup-service/blob/42e14267b5c006b44342983bc85c29af98f78c1f/config%2Fdefault.json)
  * docker/account-lookup-service/default.json: (https://github.com/mojaloop/account-lookup-service/blob/42e14267b5c006b44342983bc85c29af98f78c1f/docker%2Faccount-lookup-service%2Fdefault.json)
  * docker/central-ledger/default.json: (https://github.com/mojaloop/account-lookup-service/blob/42e14267b5c006b44342983bc85c29af98f78c1f/docker%2Fcentral-ledger%2Fdefault.json)

## 7. Known Issues

1. [#2119 - Idempotency for duplicate quote request](https://github.com/mojaloop/project/issues/2119)
2. [#2322 - Helm install failing with with "medium to large" release names](https://github.com/mojaloop/project/issues/2322)
3. [#2317 - Mojaloop Helm deployments are not compatible when deployed to ARM-arch based hosts](https://github.com/mojaloop/project/issues/2317)
4. [#2435 - Quoting-Service is incorrectly handling failed responses to FSPs when forwarding requests](https://github.com/mojaloop/project/issues/2435)
5. Test issues causing instability/intermitant failures on Test Case Results
    1. [#2717 - Thirdparty TTK Test-Collection is not repeatable](https://github.com/mojaloop/project/issues/2717)
    2. [#2925 - Helm Test Intermittent failure with 'Generic ID not found](https://github.com/mojaloop/project/issues/2925)

## 8. Contributors

- Organizations: BMGF, InFiTX, MLF
- Individuals: @dependabot[bot], @devarsh10, @geka-evk, @gibaros, @kalinkrustev, @kirgene, @kleyow, @oderayi, @s-prak, @shashi165, @vijayg10

*Note: companies are in alphabetical order, individuals are in no particular order.*

**Full Changelog**: https://github.com/mojaloop/helm/compare/v17.0.0...v17.1.0
