### PR TITLE
feat(mojaloop-simulator): add jws.method certmanager support

### DIFF
--- a/mojaloop-simulator/templates/deployment.yaml
+++ b/mojaloop-simulator/templates/deployment.yaml
@@ -57,7 +57,12 @@ spec:
       {{- if $config.config.schemeAdapter.env.JWS_SIGN }}
       - name: jws-private-key
         secret:
-          {{- if $config.config.schemeAdapter.secrets.jws.privateKeySecret }}
+          {{- if (eq ($config.config.schemeAdapter.secrets.jws.method | default "") "certmanager") }}
+          secretName: {{ $fullName }}-jws
+          items:
+            - key: tls.key
+              path: private.key
+          {{- else if $config.config.schemeAdapter.secrets.jws.privateKeySecret }}
           secretName: {{ $config.config.schemeAdapter.secrets.jws.privateKeySecret.name }}
           items:
             - key: {{ $config.config.schemeAdapter.secrets.jws.privateKeySecret.key }}

--- a/mojaloop-simulator/templates/secret.yaml
+++ b/mojaloop-simulator/templates/secret.yaml
@@ -2,11 +2,30 @@
 {{- range $name, $customConfig := .Values.simulators }}
 {{- $config := merge $customConfig $.Values.defaults }}
 {{- $fullName := printf "%s%s" (include "mojaloop-simulator.prefix" $) $name -}}
-{{- if (and $config.config.schemeAdapter.env.JWS_SIGN (not $config.config.schemeAdapter.secrets.jws.privateKeySecret)) }}
+{{- if $config.config.schemeAdapter.env.JWS_SIGN }}
+{{- if (eq ($config.config.schemeAdapter.secrets.jws.method | default "") "certmanager") }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $fullName }}-jws
+  namespace: {{ $.Release.Namespace }}
+spec:
+  commonName: {{ $fullName }}-jws
+  duration: 8760h0m0s
+  renewBefore: 730h0m0s
+  privateKey:
+    algorithm: RSA
+    size: 4096
+  issuerRef:
+    kind: Issuer
+    name: simulator-ca-issuer
+  secretName: {{ $fullName }}-jws
+---
+{{- else if (not $config.config.schemeAdapter.secrets.jws.privateKeySecret) }}
 # Note that due to a bug with helm 2.9.1 the `required` function in combination with a missing
 # key will not work in place of this if statement.
-{{- if eq $config.config.schemeAdapter.secrets.jws.privateKey "" }}
-  {{ fail (printf "JWS_SIGN enabled- JWS private key required for %s. You need to specify %s.schemeAdapter.secrets.jws.privateKey or %s.schemeAdapter.secrets.jws.privateKeySecret." $name $name) }}
+{{- if eq ($config.config.schemeAdapter.secrets.jws.privateKey | default "") "" }}
+  {{ fail (printf "JWS_SIGN enabled- JWS private key required for %s. You need to specify %s.schemeAdapter.secrets.jws.privateKey or %s.schemeAdapter.secrets.jws.privateKeySecret or set jws.method to certmanager." $name $name $name) }}
 {{- end }}
 apiVersion: v1
 kind: Secret
@@ -18,6 +37,7 @@ metadata:
 data:
   "private.key": {{ $config.config.schemeAdapter.secrets.jws.privateKey | b64enc }}
 ---
+{{- end }}
 {{- end }}
 {{- if (eq $config.config.schemeAdapter.secrets.tls.method "certmanager") }}
 apiVersion: cert-manager.io/v1


### PR DESCRIPTION
Add support for using cert-manager to generate JWS signing keys. When jws.method is set to certmanager, creates a Certificate CR that generates the private key, eliminating the need for manual JWS key provisioning for simulators.