### PR TITLE
feat: deploy central-settlement services from central-ledger image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ launch.json
 # Helm
 **/charts
 **/tmpcharts
+**/tmpcharts*
 requirements.lock
 Chart.lock
 index.yaml

--- a/account-lookup-service/chart-handler-timeout/values.yaml
+++ b/account-lookup-service/chart-handler-timeout/values.yaml
@@ -21,7 +21,7 @@ image:
   pullSecrets: []
 
 replicaCount: 1
-command: '["node", "src/handlers/index.js", "handlers", "--timeout"]'
+command: '["node", "dist/handlers/index.js", "handlers", "--timeout"]'
 
 ## Enable diagnostic mode in the deployment
 ##

--- a/centralledger/chart-handler-admin-transfer/configs/default.json
+++ b/centralledger/chart-handler-admin-transfer/configs/default.json
@@ -49,6 +49,10 @@
         "PASSWORD": "{{ .Values.config.mongo_password }}",
         "DATABASE": "{{ .Values.config.mongo_database }}"
     },
+    "WINDOW_AGGREGATION": {
+        "RETRY_COUNT": 3,
+        "RETRY_INTERVAL": 3000
+    },
     "HANDLERS": {
         "DISABLED": false,
         "API": {
@@ -58,6 +62,14 @@
             "DISABLED": true,
             "TIMEXP": "*/15 * * * * *",
             "TIMEZONE": "UTC"
+        },
+        "SETTINGS": {
+            "RULES": {
+                "SCRIPTS_FOLDER": "./scripts/transferSettlementTemp",
+                "SCRIPT_TIMEOUT": 100,
+                "CONSUMER_COMMIT": true,
+                "FROM_SWITCH": true
+            }
         }
     },
     "INSTRUMENTATION": {

--- a/centralledger/chart-handler-admin-transfer/configs/default.json
+++ b/centralledger/chart-handler-admin-transfer/configs/default.json
@@ -61,7 +61,17 @@
         "TIMEOUT": {
             "DISABLED": true,
             "TIMEXP": "*/15 * * * * *",
-            "TIMEZONE": "UTC"
+            "TIMEZONE": "UTC",
+            "DIST_LOCK": {
+              "enabled": false,
+              "lockTimeout": 10000,
+              "acquireTimeout": 5000,
+              "driftFactor": 0.01,
+              "retryCount": 3,
+              "retryDelay": 200,
+              "retryJitter": 100,
+              "redisConfigs": [{ "type": "redis-cluster", "cluster": [{ "host": "localhost", "port": 6379 }] }]
+            }
         },
         "SETTINGS": {
             "RULES": {
@@ -103,6 +113,7 @@
         ]
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+    "ENABLE_ON_US_TRANSFERS": false,
     "PAYEE_PARTICIPANT_CURRENCY_VALIDATION_ENABLED": {{ .Values.config.payee_participant_currency_validation_enabled }},
     "CACHE": {
         "CACHE_ENABLED": {{ .Values.config.cache_enabled }},
@@ -112,6 +123,21 @@
     "PROXY_CACHE": {{ .Values.config.proxy_cache | toPrettyJson | nindent 2 }},
     "API_DOC_ENDPOINTS_ENABLED": true,
     "KAFKA": {
+        "EVENT_TYPE_ACTION_TOPIC_MAP" : {
+          "POSITION":{
+            "PREPARE": null,
+            "FX_PREPARE": null,
+            "BULK_PREPARE": null,
+            "COMMIT": null,
+            "BULK_COMMIT": null,
+            "RESERVE": null,
+            "FX_RESERVE": null,
+            "TIMEOUT_RESERVED": null,
+            "FX_TIMEOUT_RESERVED": null,
+            "ABORT": null,
+            "FX_ABORT": null
+          }
+        },
         "TOPIC_TEMPLATES": {
             "PARTICIPANT_TOPIC_TEMPLATE": {
                 "TEMPLATE": "topic-{{"{{"}}participantName{{"}}"}}-{{"{{"}}functionality{{"}}"}}-{{"{{"}}action{{"}}"}}",
@@ -270,6 +296,30 @@
                         }
                     }
                 },
+                "POSITION_BATCH": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-position-batch",
+                            "group.id": "cl-group-transfer-position-batch",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true,
+                            "allow.auto.create.topics": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
                 "FULFIL": {
                     "config": {
                         "options": {
@@ -344,6 +394,58 @@
                         }
                     }
                 }
+            },
+            "NOTIFICATION": {
+              "EVENT": {
+                "config": {
+                  "options": {
+                    "mode": 2,
+                    "batchSize": 1,
+                    "pollFrequency": 10,
+                    "recursiveTimeout": 100,
+                    "messageCharset": "utf8",
+                    "messageAsJSON": true,
+                    "sync": true,
+                    "consumeTimeout": 1000
+                  },
+                  "rdkafkaConf": {
+                    "client.id": "TESTONLY",
+                    "group.id": "TESTONLY",
+                    "metadata.broker.list": "localhost:9092",
+                    "socket.keepalive.enable": true,
+                    "allow.auto.create.topics": true
+                  },
+                  "topicConf": {
+                    "auto.offset.reset": "earliest"
+                  }
+                }
+              }
+            },
+            "DEFERREDSETTLEMENT": {
+              "CLOSE": {
+                "config": {
+                  "options": {
+                    "mode": 2,
+                    "batchSize": 1,
+                    "pollFrequency": 10,
+                    "recursiveTimeout": 100,
+                    "messageCharset": "utf8",
+                    "messageAsJSON": true,
+                    "sync": true,
+                    "consumeTimeout": 1000
+                  },
+                  "rdkafkaConf": {
+                    "client.id": "cs-con-deferredsettlement-close",
+                    "group.id": "cs-group-deferredsettlement-close",
+                    "metadata.broker.list": "localhost:9092",
+                    "socket.keepalive.enable": true,
+                    "allow.auto.create.topics": true
+                  },
+                  "topicConf": {
+                    "auto.offset.reset": "earliest"
+                  }
+                }
+              }
             }
         },
         "PRODUCER": {

--- a/centralledger/chart-handler-admin-transfer/values.yaml
+++ b/centralledger/chart-handler-admin-transfer/values.yaml
@@ -7,14 +7,14 @@ global: {}
 # Declare variables to be passed into your templates.
 
 image:
-  registry: docker.io
-  repository: mojaloop/central-ledger
-  tag: v19.14.0
+  registry: ""
+  repository: central-ledger
+  tag: local
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
-  pullPolicy: IfNotPresent
+  pullPolicy: Never
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/centralledger/chart-handler-admin-transfer/values.yaml
+++ b/centralledger/chart-handler-admin-transfer/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: ""
   repository: central-ledger
-  tag: local
+  tag: local2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -25,7 +25,7 @@ image:
   pullSecrets: []
 
 replicaCount: 1
-command: '["node", "src/handlers/index.js", "handler", "--admin"]'
+command: '["node", "dist/handlers/index.js", "handler", "--admin"]'
 
 rollingUpdate:
   override: true
@@ -46,7 +46,7 @@ diagnosticMode:
   ##
   args:
     - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-    - src/handlers/index.js
+    - dist/handlers/index.js
     - handler
     - '--admin'
 

--- a/centralledger/chart-handler-timeout/configs/default.json
+++ b/centralledger/chart-handler-timeout/configs/default.json
@@ -49,10 +49,22 @@
         "PASSWORD": "{{ .Values.config.mongo_password }}",
         "DATABASE": "{{ .Values.config.mongo_database }}"
     },
+    "WINDOW_AGGREGATION": {
+        "RETRY_COUNT": 3,
+        "RETRY_INTERVAL": 3000
+    },
     "HANDLERS": {
         "DISABLED": false,
         "API": {
             "DISABLED": false
+        },
+        "SETTINGS": {
+            "RULES": {
+                "SCRIPTS_FOLDER": "./scripts/transferSettlementTemp",
+                "SCRIPT_TIMEOUT": 100,
+                "CONSUMER_COMMIT": true,
+                "FROM_SWITCH": true
+            }
         },
         "TIMEOUT": {
             "DISABLED": false,

--- a/centralledger/chart-handler-timeout/configs/default.json
+++ b/centralledger/chart-handler-timeout/configs/default.json
@@ -58,6 +58,21 @@
         "API": {
             "DISABLED": false
         },
+        "TIMEOUT": {
+            "DISABLED": true,
+            "TIMEXP": "*/15 * * * * *",
+            "TIMEZONE": "UTC",
+            "DIST_LOCK": {
+              "enabled": false,
+              "lockTimeout": 10000,
+              "acquireTimeout": 5000,
+              "driftFactor": 0.01,
+              "retryCount": 3,
+              "retryDelay": 200,
+              "retryJitter": 100,
+              "redisConfigs": [{ "type": "redis-cluster", "cluster": [{ "host": "localhost", "port": 6379 }] }]
+            }
+        },
         "SETTINGS": {
             "RULES": {
                 "SCRIPTS_FOLDER": "./scripts/transferSettlementTemp",
@@ -65,12 +80,6 @@
                 "CONSUMER_COMMIT": true,
                 "FROM_SWITCH": true
             }
-        },
-        "TIMEOUT": {
-            "DISABLED": false,
-            "DIST_LOCK": {{ .Values.config.distLockConfig | toPrettyJson | nindent 2 }},
-            "TIMEXP": {{ .Values.config.timeout.expiration | quote }},
-            "TIMEZONE": {{ .Values.config.timeout.timezone | quote }}
         }
     },
     "INSTRUMENTATION": {
@@ -104,7 +113,8 @@
         ]
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
-    "PAYEE_PARTICIPANT_CURRENCY_VALIDATION_ENABLED":  {{ .Values.config.payee_participant_currency_validation_enabled }},
+    "ENABLE_ON_US_TRANSFERS": false,
+    "PAYEE_PARTICIPANT_CURRENCY_VALIDATION_ENABLED": {{ .Values.config.payee_participant_currency_validation_enabled }},
     "CACHE": {
         "CACHE_ENABLED": {{ .Values.config.cache_enabled }},
         "MAX_BYTE_SIZE": {{ .Values.config.cache_max_byte_size }},
@@ -114,10 +124,19 @@
     "API_DOC_ENDPOINTS_ENABLED": true,
     "KAFKA": {
         "EVENT_TYPE_ACTION_TOPIC_MAP" : {
-            "POSITION":{
-                "TIMEOUT_RESERVED": "topic-transfer-position-batch",
-                "FX_TIMEOUT_RESERVED": "topic-transfer-position-batch"
-            }
+          "POSITION":{
+            "PREPARE": null,
+            "FX_PREPARE": null,
+            "BULK_PREPARE": null,
+            "COMMIT": null,
+            "BULK_COMMIT": null,
+            "RESERVE": null,
+            "FX_RESERVE": null,
+            "TIMEOUT_RESERVED": "topic-transfer-position-batch",
+            "FX_TIMEOUT_RESERVED": "topic-transfer-position-batch",
+            "ABORT": null,
+            "FX_ABORT": null
+          }
         },
         "TOPIC_TEMPLATES": {
             "PARTICIPANT_TOPIC_TEMPLATE": {
@@ -277,6 +296,30 @@
                         }
                     }
                 },
+                "POSITION_BATCH": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-position-batch",
+                            "group.id": "cl-group-transfer-position-batch",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true,
+                            "allow.auto.create.topics": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
                 "FULFIL": {
                     "config": {
                         "options": {
@@ -351,6 +394,58 @@
                         }
                     }
                 }
+            },
+            "NOTIFICATION": {
+              "EVENT": {
+                "config": {
+                  "options": {
+                    "mode": 2,
+                    "batchSize": 1,
+                    "pollFrequency": 10,
+                    "recursiveTimeout": 100,
+                    "messageCharset": "utf8",
+                    "messageAsJSON": true,
+                    "sync": true,
+                    "consumeTimeout": 1000
+                  },
+                  "rdkafkaConf": {
+                    "client.id": "TESTONLY",
+                    "group.id": "TESTONLY",
+                    "metadata.broker.list": "localhost:9092",
+                    "socket.keepalive.enable": true,
+                    "allow.auto.create.topics": true
+                  },
+                  "topicConf": {
+                    "auto.offset.reset": "earliest"
+                  }
+                }
+              }
+            },
+            "DEFERREDSETTLEMENT": {
+              "CLOSE": {
+                "config": {
+                  "options": {
+                    "mode": 2,
+                    "batchSize": 1,
+                    "pollFrequency": 10,
+                    "recursiveTimeout": 100,
+                    "messageCharset": "utf8",
+                    "messageAsJSON": true,
+                    "sync": true,
+                    "consumeTimeout": 1000
+                  },
+                  "rdkafkaConf": {
+                    "client.id": "cs-con-deferredsettlement-close",
+                    "group.id": "cs-group-deferredsettlement-close",
+                    "metadata.broker.list": "localhost:9092",
+                    "socket.keepalive.enable": true,
+                    "allow.auto.create.topics": true
+                  },
+                  "topicConf": {
+                    "auto.offset.reset": "earliest"
+                  }
+                }
+              }
             }
         },
         "PRODUCER": {

--- a/centralledger/chart-handler-timeout/values.yaml
+++ b/centralledger/chart-handler-timeout/values.yaml
@@ -7,14 +7,14 @@ global: {}
 # Declare variables to be passed into your templates.
 
 image:
-  registry: docker.io
-  repository: mojaloop/central-ledger
-  tag: v19.14.0
+  registry: ""
+  repository: central-ledger
+  tag: local
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
-  pullPolicy: IfNotPresent
+  pullPolicy: Never
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/centralledger/chart-handler-timeout/values.yaml
+++ b/centralledger/chart-handler-timeout/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: ""
   repository: central-ledger
-  tag: local
+  tag: local2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -25,7 +25,7 @@ image:
   pullSecrets: []
 
 replicaCount: 1
-command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
+command: '["node", "dist/handlers/index.js", "handler", "--timeout"]'
 
 ## Enable diagnostic mode in the deployment
 ##
@@ -41,7 +41,7 @@ diagnosticMode:
   ##
   args:
     - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-    - src/handlers/index.js
+    - dist/handlers/index.js
     - handler
     - '--timeout'
 

--- a/centralledger/chart-handler-transfer-fulfil/configs/default.json
+++ b/centralledger/chart-handler-transfer-fulfil/configs/default.json
@@ -49,6 +49,10 @@
         "PASSWORD": "{{ .Values.config.mongo_password }}",
         "DATABASE": "{{ .Values.config.mongo_database }}"
     },
+    "WINDOW_AGGREGATION": {
+        "RETRY_COUNT": 3,
+        "RETRY_INTERVAL": 3000
+    },
     "HANDLERS": {
         "DISABLED": false,
         "API": {
@@ -58,6 +62,14 @@
             "DISABLED": true,
             "TIMEXP": "*/15 * * * * *",
             "TIMEZONE": "UTC"
+        },
+        "SETTINGS": {
+            "RULES": {
+                "SCRIPTS_FOLDER": "./scripts/transferSettlementTemp",
+                "SCRIPT_TIMEOUT": 100,
+                "CONSUMER_COMMIT": true,
+                "FROM_SWITCH": true
+            }
         }
     },
     "INSTRUMENTATION": {

--- a/centralledger/chart-handler-transfer-fulfil/configs/default.json
+++ b/centralledger/chart-handler-transfer-fulfil/configs/default.json
@@ -61,7 +61,17 @@
         "TIMEOUT": {
             "DISABLED": true,
             "TIMEXP": "*/15 * * * * *",
-            "TIMEZONE": "UTC"
+            "TIMEZONE": "UTC",
+            "DIST_LOCK": {
+              "enabled": false,
+              "lockTimeout": 10000,
+              "acquireTimeout": 5000,
+              "driftFactor": 0.01,
+              "retryCount": 3,
+              "retryDelay": 200,
+              "retryJitter": 100,
+              "redisConfigs": [{ "type": "redis-cluster", "cluster": [{ "host": "localhost", "port": 6379 }] }]
+            }
         },
         "SETTINGS": {
             "RULES": {
@@ -103,6 +113,7 @@
         ]
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+    "ENABLE_ON_US_TRANSFERS": false,
     "PAYEE_PARTICIPANT_CURRENCY_VALIDATION_ENABLED": {{ .Values.config.payee_participant_currency_validation_enabled }},
     "CACHE": {
         "CACHE_ENABLED": {{ .Values.config.cache_enabled }},
@@ -113,14 +124,19 @@
     "API_DOC_ENDPOINTS_ENABLED": true,
     "KAFKA": {
         "EVENT_TYPE_ACTION_TOPIC_MAP" : {
-            "POSITION":{
-                "COMMIT": "topic-transfer-position-batch",
-                "BULK_COMMIT": "topic-transfer-position",
-                "RESERVE": "topic-transfer-position-batch",
-                "FX_RESERVE": "topic-transfer-position-batch",
-                "ABORT": "topic-transfer-position-batch",
-                "FX_ABORT": "topic-transfer-position-batch"
-            }
+          "POSITION":{
+            "PREPARE": null,
+            "FX_PREPARE": null,
+            "BULK_PREPARE": null,
+            "COMMIT": "topic-transfer-position-batch",
+            "BULK_COMMIT": "topic-transfer-position-batch",
+            "RESERVE": "topic-transfer-position-batch",
+            "FX_RESERVE": "topic-transfer-position-batch",
+            "TIMEOUT_RESERVED": "topic-transfer-position-batch",
+            "FX_TIMEOUT_RESERVED": "topic-transfer-position-batch",
+            "ABORT": "topic-transfer-position-batch",
+            "FX_ABORT": "topic-transfer-position-batch"
+          }
         },
         "TOPIC_TEMPLATES": {
             "PARTICIPANT_TOPIC_TEMPLATE": {
@@ -280,6 +296,30 @@
                         }
                     }
                 },
+                "POSITION_BATCH": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-position-batch",
+                            "group.id": "cl-group-transfer-position-batch",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true,
+                            "allow.auto.create.topics": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
                 "FULFIL": {
                     "config": {
                         "options": {
@@ -354,6 +394,58 @@
                         }
                     }
                 }
+            },
+            "NOTIFICATION": {
+              "EVENT": {
+                "config": {
+                  "options": {
+                    "mode": 2,
+                    "batchSize": 1,
+                    "pollFrequency": 10,
+                    "recursiveTimeout": 100,
+                    "messageCharset": "utf8",
+                    "messageAsJSON": true,
+                    "sync": true,
+                    "consumeTimeout": 1000
+                  },
+                  "rdkafkaConf": {
+                    "client.id": "TESTONLY",
+                    "group.id": "TESTONLY",
+                    "metadata.broker.list": "localhost:9092",
+                    "socket.keepalive.enable": true,
+                    "allow.auto.create.topics": true
+                  },
+                  "topicConf": {
+                    "auto.offset.reset": "earliest"
+                  }
+                }
+              }
+            },
+            "DEFERREDSETTLEMENT": {
+              "CLOSE": {
+                "config": {
+                  "options": {
+                    "mode": 2,
+                    "batchSize": 1,
+                    "pollFrequency": 10,
+                    "recursiveTimeout": 100,
+                    "messageCharset": "utf8",
+                    "messageAsJSON": true,
+                    "sync": true,
+                    "consumeTimeout": 1000
+                  },
+                  "rdkafkaConf": {
+                    "client.id": "cs-con-deferredsettlement-close",
+                    "group.id": "cs-group-deferredsettlement-close",
+                    "metadata.broker.list": "localhost:9092",
+                    "socket.keepalive.enable": true,
+                    "allow.auto.create.topics": true
+                  },
+                  "topicConf": {
+                    "auto.offset.reset": "earliest"
+                  }
+                }
+              }
             }
         },
         "PRODUCER": {

--- a/centralledger/chart-handler-transfer-fulfil/values.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/values.yaml
@@ -7,14 +7,14 @@ global: {}
 # Declare variables to be passed into your templates.
 
 image:
-  registry: docker.io
-  repository: mojaloop/central-ledger
-  tag: v19.14.0
+  registry: ""
+  repository: central-ledger
+  tag: local
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
-  pullPolicy: IfNotPresent
+  pullPolicy: Never
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/centralledger/chart-handler-transfer-fulfil/values.yaml
+++ b/centralledger/chart-handler-transfer-fulfil/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: ""
   repository: central-ledger
-  tag: local
+  tag: local2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -25,7 +25,7 @@ image:
   pullSecrets: []
 
 replicaCount: 1
-command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
+command: '["node", "dist/handlers/index.js", "handler", "--fulfil"]'
 
 rollingUpdate:
   override: true
@@ -46,7 +46,7 @@ diagnosticMode:
   ##
   args:
     - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-    - src/handlers/index.js
+    - dist/handlers/index.js
     - handler
     - '--fulfil'
 

--- a/centralledger/chart-handler-transfer-get/configs/default.json
+++ b/centralledger/chart-handler-transfer-get/configs/default.json
@@ -49,6 +49,10 @@
         "PASSWORD": "{{ .Values.config.mongo_password }}",
         "DATABASE": "{{ .Values.config.mongo_database }}"
     },
+    "WINDOW_AGGREGATION": {
+        "RETRY_COUNT": 3,
+        "RETRY_INTERVAL": 3000
+    },
     "HANDLERS": {
         "DISABLED": false,
         "API": {
@@ -58,6 +62,14 @@
             "DISABLED": true,
             "TIMEXP": "*/15 * * * * *",
             "TIMEZONE": "UTC"
+        },
+        "SETTINGS": {
+            "RULES": {
+                "SCRIPTS_FOLDER": "./scripts/transferSettlementTemp",
+                "SCRIPT_TIMEOUT": 100,
+                "CONSUMER_COMMIT": true,
+                "FROM_SWITCH": true
+            }
         }
     },
     "INSTRUMENTATION": {

--- a/centralledger/chart-handler-transfer-get/configs/default.json
+++ b/centralledger/chart-handler-transfer-get/configs/default.json
@@ -61,7 +61,17 @@
         "TIMEOUT": {
             "DISABLED": true,
             "TIMEXP": "*/15 * * * * *",
-            "TIMEZONE": "UTC"
+            "TIMEZONE": "UTC",
+            "DIST_LOCK": {
+              "enabled": false,
+              "lockTimeout": 10000,
+              "acquireTimeout": 5000,
+              "driftFactor": 0.01,
+              "retryCount": 3,
+              "retryDelay": 200,
+              "retryJitter": 100,
+              "redisConfigs": [{ "type": "redis-cluster", "cluster": [{ "host": "localhost", "port": 6379 }] }]
+            }
         },
         "SETTINGS": {
             "RULES": {
@@ -103,6 +113,7 @@
         ]
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+    "ENABLE_ON_US_TRANSFERS": false,
     "PAYEE_PARTICIPANT_CURRENCY_VALIDATION_ENABLED": {{ .Values.config.payee_participant_currency_validation_enabled }},
     "CACHE": {
         "CACHE_ENABLED": {{ .Values.config.cache_enabled }},
@@ -112,6 +123,21 @@
     "PROXY_CACHE": {{ .Values.config.proxy_cache | toPrettyJson | nindent 2 }},
     "API_DOC_ENDPOINTS_ENABLED": true,
     "KAFKA": {
+        "EVENT_TYPE_ACTION_TOPIC_MAP" : {
+          "POSITION":{
+            "PREPARE": null,
+            "FX_PREPARE": null,
+            "BULK_PREPARE": null,
+            "COMMIT": "topic-transfer-position-batch",
+            "BULK_COMMIT": "topic-transfer-position-batch",
+            "RESERVE": "topic-transfer-position-batch",
+            "FX_RESERVE": "topic-transfer-position-batch",
+            "TIMEOUT_RESERVED": "topic-transfer-position-batch",
+            "FX_TIMEOUT_RESERVED": "topic-transfer-position-batch",
+            "ABORT": "topic-transfer-position-batch",
+            "FX_ABORT": "topic-transfer-position-batch"
+          }
+        },
         "TOPIC_TEMPLATES": {
             "PARTICIPANT_TOPIC_TEMPLATE": {
                 "TEMPLATE": "topic-{{"{{"}}participantName{{"}}"}}-{{"{{"}}functionality{{"}}"}}-{{"{{"}}action{{"}}"}}",
@@ -270,6 +296,30 @@
                         }
                     }
                 },
+                "POSITION_BATCH": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-position-batch",
+                            "group.id": "cl-group-transfer-position-batch",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true,
+                            "allow.auto.create.topics": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
                 "FULFIL": {
                     "config": {
                         "options": {
@@ -344,6 +394,58 @@
                         }
                     }
                 }
+            },
+            "NOTIFICATION": {
+              "EVENT": {
+                "config": {
+                  "options": {
+                    "mode": 2,
+                    "batchSize": 1,
+                    "pollFrequency": 10,
+                    "recursiveTimeout": 100,
+                    "messageCharset": "utf8",
+                    "messageAsJSON": true,
+                    "sync": true,
+                    "consumeTimeout": 1000
+                  },
+                  "rdkafkaConf": {
+                    "client.id": "TESTONLY",
+                    "group.id": "TESTONLY",
+                    "metadata.broker.list": "localhost:9092",
+                    "socket.keepalive.enable": true,
+                    "allow.auto.create.topics": true
+                  },
+                  "topicConf": {
+                    "auto.offset.reset": "earliest"
+                  }
+                }
+              }
+            },
+            "DEFERREDSETTLEMENT": {
+              "CLOSE": {
+                "config": {
+                  "options": {
+                    "mode": 2,
+                    "batchSize": 1,
+                    "pollFrequency": 10,
+                    "recursiveTimeout": 100,
+                    "messageCharset": "utf8",
+                    "messageAsJSON": true,
+                    "sync": true,
+                    "consumeTimeout": 1000
+                  },
+                  "rdkafkaConf": {
+                    "client.id": "cs-con-deferredsettlement-close",
+                    "group.id": "cs-group-deferredsettlement-close",
+                    "metadata.broker.list": "localhost:9092",
+                    "socket.keepalive.enable": true,
+                    "allow.auto.create.topics": true
+                  },
+                  "topicConf": {
+                    "auto.offset.reset": "earliest"
+                  }
+                }
+              }
             }
         },
         "PRODUCER": {

--- a/centralledger/chart-handler-transfer-get/values.yaml
+++ b/centralledger/chart-handler-transfer-get/values.yaml
@@ -7,14 +7,14 @@ global: {}
 # Declare variables to be passed into your templates.
 
 image:
-  registry: docker.io
-  repository: mojaloop/central-ledger
-  tag: v19.14.0
+  registry: ""
+  repository: central-ledger
+  tag: local
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
-  pullPolicy: IfNotPresent
+  pullPolicy: Never
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/centralledger/chart-handler-transfer-get/values.yaml
+++ b/centralledger/chart-handler-transfer-get/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: ""
   repository: central-ledger
-  tag: local
+  tag: local2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -25,7 +25,7 @@ image:
   pullSecrets: []
 
 replicaCount: 1
-command: '["node", "src/handlers/index.js", "handler", "--get"]'
+command: '["node", "dist/handlers/index.js", "handler", "--get"]'
 
 rollingUpdate:
   override: true
@@ -46,7 +46,7 @@ diagnosticMode:
   ##
   args:
     - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-    - src/handlers/index.js
+    - dist/handlers/index.js
     - handler
     - '--get'
 

--- a/centralledger/chart-handler-transfer-position-batch/configs/default.json
+++ b/centralledger/chart-handler-transfer-position-batch/configs/default.json
@@ -49,6 +49,10 @@
         "PASSWORD": "{{ .Values.config.mongo_password }}",
         "DATABASE": "{{ .Values.config.mongo_database }}"
     },
+    "WINDOW_AGGREGATION": {
+        "RETRY_COUNT": 3,
+        "RETRY_INTERVAL": 3000
+    },
     "HANDLERS": {
         "DISABLED": false,
         "API": {
@@ -58,6 +62,14 @@
             "DISABLED": true,
             "TIMEXP": "*/15 * * * * *",
             "TIMEZONE": "UTC"
+        },
+        "SETTINGS": {
+            "RULES": {
+                "SCRIPTS_FOLDER": "./scripts/transferSettlementTemp",
+                "SCRIPT_TIMEOUT": 100,
+                "CONSUMER_COMMIT": true,
+                "FROM_SWITCH": true
+            }
         }
     },
     "INSTRUMENTATION": {

--- a/centralledger/chart-handler-transfer-position-batch/configs/default.json
+++ b/centralledger/chart-handler-transfer-position-batch/configs/default.json
@@ -61,7 +61,17 @@
         "TIMEOUT": {
             "DISABLED": true,
             "TIMEXP": "*/15 * * * * *",
-            "TIMEZONE": "UTC"
+            "TIMEZONE": "UTC",
+            "DIST_LOCK": {
+              "enabled": false,
+              "lockTimeout": 10000,
+              "acquireTimeout": 5000,
+              "driftFactor": 0.01,
+              "retryCount": 3,
+              "retryDelay": 200,
+              "retryJitter": 100,
+              "redisConfigs": [{ "type": "redis-cluster", "cluster": [{ "host": "localhost", "port": 6379 }] }]
+            }
         },
         "SETTINGS": {
             "RULES": {
@@ -103,6 +113,7 @@
         ]
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+    "ENABLE_ON_US_TRANSFERS": false,
     "PAYEE_PARTICIPANT_CURRENCY_VALIDATION_ENABLED": {{ .Values.config.payee_participant_currency_validation_enabled }},
     "CACHE": {
         "CACHE_ENABLED": {{ .Values.config.cache_enabled }},
@@ -113,12 +124,19 @@
     "API_DOC_ENDPOINTS_ENABLED": true,
     "KAFKA": {
         "EVENT_TYPE_ACTION_TOPIC_MAP" : {
-            "POSITION":{
-              "PREPARE": "topic-transfer-position-batch",
-              "COMMIT": "topic-transfer-position-batch",
-              "RESERVE": "topic-transfer-position-batch",
-              "FX_RESERVE": "topic-transfer-position-batch"
-            }
+          "POSITION":{
+            "PREPARE": "topic-transfer-position-batch",
+            "COMMIT": "topic-transfer-position-batch",
+            "RESERVE": "topic-transfer-position-batch",
+            "FX_RESERVE": "topic-transfer-position-batch",
+            "FX_PREPARE": null,
+            "BULK_PREPARE": null,
+            "BULK_COMMIT": null,
+            "TIMEOUT_RESERVED": null,
+            "FX_TIMEOUT_RESERVED": null,
+            "ABORT": null,
+            "FX_ABORT": null
+          }
         },
         "TOPIC_TEMPLATES": {
             "PARTICIPANT_TOPIC_TEMPLATE": {
@@ -281,27 +299,27 @@
                 "POSITION_BATCH": {
                     "config": {
                       "options": {
-                        "mode": 2,
-                        "batchSize": {{ .Values.config.batch_size }},
-                        "pollFrequency": 10,
-                        "recursiveTimeout": 100,
-                        "messageCharset": "utf8",
-                        "messageAsJSON": true,
-                        "sync": true,
-                        "consumeTimeout": {{ .Values.config.batch_consume_timeout_in_ms }}
-                      },
-                      "rdkafkaConf": {
-                        "client.id": "cl-con-transfer-position-batch",
-                        "group.id": "cl-group-transfer-position-batch",
-                        "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
-                        "socket.keepalive.enable": true,
-                        "allow.auto.create.topics": true,
-                        "partition.assignment.strategy": "{{ .Values.config.kafka_partition_assignment_strategy }}",
-                        "enable.auto.commit": false
-                      },
-                      "topicConf": {
-                        "auto.offset.reset": "earliest"
-                      }
+                         "mode": 2,
+                         "batchSize": {{ .Values.config.batch_size }},
+                         "pollFrequency": 10,
+                         "recursiveTimeout": 100,
+                         "messageCharset": "utf8",
+                         "messageAsJSON": true,
+                         "sync": true,
+                         "consumeTimeout": {{ .Values.config.batch_consume_timeout_in_ms }}
+                       },
+                       "rdkafkaConf": {
+                         "client.id": "cl-con-transfer-position-batch",
+                         "group.id": "cl-group-transfer-position-batch",
+                         "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                         "socket.keepalive.enable": true,
+                         "allow.auto.create.topics": true,
+                         "partition.assignment.strategy": "{{ .Values.config.kafka_partition_assignment_strategy }}",
+                         "enable.auto.commit": false
+                       },
+                       "topicConf": {
+                         "auto.offset.reset": "earliest"
+                       }
                     }
                 },
                 "FULFIL": {
@@ -378,6 +396,58 @@
                         }
                     }
                 }
+            },
+            "NOTIFICATION": {
+              "EVENT": {
+                "config": {
+                  "options": {
+                    "mode": 2,
+                    "batchSize": 1,
+                    "pollFrequency": 10,
+                    "recursiveTimeout": 100,
+                    "messageCharset": "utf8",
+                    "messageAsJSON": true,
+                    "sync": true,
+                    "consumeTimeout": 1000
+                  },
+                  "rdkafkaConf": {
+                    "client.id": "TESTONLY",
+                    "group.id": "TESTONLY",
+                    "metadata.broker.list": "localhost:9092",
+                    "socket.keepalive.enable": true,
+                    "allow.auto.create.topics": true
+                  },
+                  "topicConf": {
+                    "auto.offset.reset": "earliest"
+                  }
+                }
+              }
+            },
+            "DEFERREDSETTLEMENT": {
+              "CLOSE": {
+                "config": {
+                  "options": {
+                    "mode": 2,
+                    "batchSize": 1,
+                    "pollFrequency": 10,
+                    "recursiveTimeout": 100,
+                    "messageCharset": "utf8",
+                    "messageAsJSON": true,
+                    "sync": true,
+                    "consumeTimeout": 1000
+                  },
+                  "rdkafkaConf": {
+                    "client.id": "cs-con-deferredsettlement-close",
+                    "group.id": "cs-group-deferredsettlement-close",
+                    "metadata.broker.list": "localhost:9092",
+                    "socket.keepalive.enable": true,
+                    "allow.auto.create.topics": true
+                  },
+                  "topicConf": {
+                    "auto.offset.reset": "earliest"
+                  }
+                }
+              }
             }
         },
         "PRODUCER": {

--- a/centralledger/chart-handler-transfer-position-batch/values.yaml
+++ b/centralledger/chart-handler-transfer-position-batch/values.yaml
@@ -9,14 +9,14 @@ global: {}
 nameOverride: "handler-pos-batch"
 
 image:
-  registry: docker.io
-  repository: mojaloop/central-ledger
-  tag: v19.14.0
+  registry: ""
+  repository: central-ledger
+  tag: local
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
-  pullPolicy: IfNotPresent
+  pullPolicy: Never
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/centralledger/chart-handler-transfer-position-batch/values.yaml
+++ b/centralledger/chart-handler-transfer-position-batch/values.yaml
@@ -11,7 +11,7 @@ nameOverride: "handler-pos-batch"
 image:
   registry: ""
   repository: central-ledger
-  tag: local
+  tag: local2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -27,7 +27,7 @@ image:
   pullSecrets: []
 
 replicaCount: 1
-command: '["node", "src/handlers/index.js", "handler", "--positionbatch"]'
+command: '["node", "dist/handlers/index.js", "handler", "--positionbatch"]'
 
 rollingUpdate:
   override: true
@@ -48,7 +48,7 @@ diagnosticMode:
   ##
   args:
     - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-    - src/handlers/index.js
+    - dist/handlers/index.js
     - handler
     - '--positionbatch'
 

--- a/centralledger/chart-handler-transfer-position/configs/default.json
+++ b/centralledger/chart-handler-transfer-position/configs/default.json
@@ -49,6 +49,10 @@
         "PASSWORD": "{{ .Values.config.mongo_password }}",
         "DATABASE": "{{ .Values.config.mongo_database }}"
     },
+    "WINDOW_AGGREGATION": {
+        "RETRY_COUNT": 3,
+        "RETRY_INTERVAL": 3000
+    },
     "HANDLERS": {
         "DISABLED": false,
         "API": {
@@ -58,6 +62,14 @@
             "DISABLED": true,
             "TIMEXP": "*/15 * * * * *",
             "TIMEZONE": "UTC"
+        },
+        "SETTINGS": {
+            "RULES": {
+                "SCRIPTS_FOLDER": "./scripts/transferSettlementTemp",
+                "SCRIPT_TIMEOUT": 100,
+                "CONSUMER_COMMIT": true,
+                "FROM_SWITCH": true
+            }
         }
     },
     "INSTRUMENTATION": {

--- a/centralledger/chart-handler-transfer-position/configs/default.json
+++ b/centralledger/chart-handler-transfer-position/configs/default.json
@@ -61,7 +61,17 @@
         "TIMEOUT": {
             "DISABLED": true,
             "TIMEXP": "*/15 * * * * *",
-            "TIMEZONE": "UTC"
+            "TIMEZONE": "UTC",
+            "DIST_LOCK": {
+              "enabled": false,
+              "lockTimeout": 10000,
+              "acquireTimeout": 5000,
+              "driftFactor": 0.01,
+              "retryCount": 3,
+              "retryDelay": 200,
+              "retryJitter": 100,
+              "redisConfigs": [{ "type": "redis-cluster", "cluster": [{ "host": "localhost", "port": 6379 }] }]
+            }
         },
         "SETTINGS": {
             "RULES": {
@@ -103,6 +113,7 @@
         ]
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+    "ENABLE_ON_US_TRANSFERS": false,
     "PAYEE_PARTICIPANT_CURRENCY_VALIDATION_ENABLED": {{ .Values.config.payee_participant_currency_validation_enabled }},
     "CACHE": {
         "CACHE_ENABLED": {{ .Values.config.cache_enabled }},
@@ -112,6 +123,21 @@
     "PROXY_CACHE": {{ .Values.config.proxy_cache | toPrettyJson | nindent 2 }},
     "API_DOC_ENDPOINTS_ENABLED": true,
     "KAFKA": {
+        "EVENT_TYPE_ACTION_TOPIC_MAP" : {
+          "POSITION":{
+            "PREPARE": null,
+            "FX_PREPARE": null,
+            "BULK_PREPARE": null,
+            "COMMIT": "topic-transfer-position-batch",
+            "BULK_COMMIT": "topic-transfer-position-batch",
+            "RESERVE": "topic-transfer-position-batch",
+            "FX_RESERVE": "topic-transfer-position-batch",
+            "TIMEOUT_RESERVED": "topic-transfer-position-batch",
+            "FX_TIMEOUT_RESERVED": "topic-transfer-position-batch",
+            "ABORT": "topic-transfer-position-batch",
+            "FX_ABORT": "topic-transfer-position-batch"
+          }
+        },
         "TOPIC_TEMPLATES": {
             "PARTICIPANT_TOPIC_TEMPLATE": {
                 "TEMPLATE": "topic-{{"{{"}}participantName{{"}}"}}-{{"{{"}}functionality{{"}}"}}-{{"{{"}}action{{"}}"}}",
@@ -270,6 +296,30 @@
                         }
                     }
                 },
+                "POSITION_BATCH": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-position-batch",
+                            "group.id": "cl-group-transfer-position-batch",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true,
+                            "allow.auto.create.topics": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
                 "FULFIL": {
                     "config": {
                         "options": {
@@ -344,6 +394,58 @@
                         }
                     }
                 }
+            },
+            "NOTIFICATION": {
+              "EVENT": {
+                "config": {
+                  "options": {
+                    "mode": 2,
+                    "batchSize": 1,
+                    "pollFrequency": 10,
+                    "recursiveTimeout": 100,
+                    "messageCharset": "utf8",
+                    "messageAsJSON": true,
+                    "sync": true,
+                    "consumeTimeout": 1000
+                  },
+                  "rdkafkaConf": {
+                    "client.id": "TESTONLY",
+                    "group.id": "TESTONLY",
+                    "metadata.broker.list": "localhost:9092",
+                    "socket.keepalive.enable": true,
+                    "allow.auto.create.topics": true
+                  },
+                  "topicConf": {
+                    "auto.offset.reset": "earliest"
+                  }
+                }
+              }
+            },
+            "DEFERREDSETTLEMENT": {
+              "CLOSE": {
+                "config": {
+                  "options": {
+                    "mode": 2,
+                    "batchSize": 1,
+                    "pollFrequency": 10,
+                    "recursiveTimeout": 100,
+                    "messageCharset": "utf8",
+                    "messageAsJSON": true,
+                    "sync": true,
+                    "consumeTimeout": 1000
+                  },
+                  "rdkafkaConf": {
+                    "client.id": "cs-con-deferredsettlement-close",
+                    "group.id": "cs-group-deferredsettlement-close",
+                    "metadata.broker.list": "localhost:9092",
+                    "socket.keepalive.enable": true,
+                    "allow.auto.create.topics": true
+                  },
+                  "topicConf": {
+                    "auto.offset.reset": "earliest"
+                  }
+                }
+              }
             }
         },
         "PRODUCER": {

--- a/centralledger/chart-handler-transfer-position/values.yaml
+++ b/centralledger/chart-handler-transfer-position/values.yaml
@@ -7,14 +7,14 @@ global: {}
 # Declare variables to be passed into your templates.
 
 image:
-  registry: docker.io
-  repository: mojaloop/central-ledger
-  tag: v19.14.0
+  registry: ""
+  repository: central-ledger
+  tag: local
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
-  pullPolicy: IfNotPresent
+  pullPolicy: Never
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/centralledger/chart-handler-transfer-position/values.yaml
+++ b/centralledger/chart-handler-transfer-position/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: ""
   repository: central-ledger
-  tag: local
+  tag: local2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -25,7 +25,7 @@ image:
   pullSecrets: []
 
 replicaCount: 1
-command: '["node", "src/handlers/index.js", "handler", "--position"]'
+command: '["node", "dist/handlers/index.js", "handler", "--position"]'
 
 rollingUpdate:
   override: true
@@ -46,7 +46,7 @@ diagnosticMode:
   ##
   args:
     - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-    - src/handlers/index.js
+    - dist/handlers/index.js
     - handler
     - '--position'
 

--- a/centralledger/chart-handler-transfer-prepare/configs/default.json
+++ b/centralledger/chart-handler-transfer-prepare/configs/default.json
@@ -49,6 +49,10 @@
         "PASSWORD": "{{ .Values.config.mongo_password }}",
         "DATABASE": "{{ .Values.config.mongo_database }}"
     },
+    "WINDOW_AGGREGATION": {
+        "RETRY_COUNT": 3,
+        "RETRY_INTERVAL": 3000
+    },
     "HANDLERS": {
         "DISABLED": false,
         "API": {
@@ -58,6 +62,14 @@
             "DISABLED": true,
             "TIMEXP": "*/15 * * * * *",
             "TIMEZONE": "UTC"
+        },
+        "SETTINGS": {
+            "RULES": {
+                "SCRIPTS_FOLDER": "./scripts/transferSettlementTemp",
+                "SCRIPT_TIMEOUT": 100,
+                "CONSUMER_COMMIT": true,
+                "FROM_SWITCH": true
+            }
         }
     },
     "INSTRUMENTATION": {

--- a/centralledger/chart-handler-transfer-prepare/values.yaml
+++ b/centralledger/chart-handler-transfer-prepare/values.yaml
@@ -7,14 +7,14 @@ global: {}
 # Declare variables to be passed into your templates.
 
 image:
-  registry: docker.io
-  repository: mojaloop/central-ledger
-  tag: v19.14.0
+  registry: ""
+  repository: central-ledger
+  tag: local
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
-  pullPolicy: IfNotPresent
+  pullPolicy: Never
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/centralledger/chart-handler-transfer-prepare/values.yaml
+++ b/centralledger/chart-handler-transfer-prepare/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: ""
   repository: central-ledger
-  tag: local
+  tag: local2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -25,7 +25,7 @@ image:
   pullSecrets: []
 
 replicaCount: 1
-command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
+command: '["node", "dist/handlers/index.js", "handler", "--prepare"]'
 
 rollingUpdate:
   override: true
@@ -46,7 +46,7 @@ diagnosticMode:
   ##
   args:
     - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-    - src/handlers/index.js
+    - dist/handlers/index.js
     - handler
     - '--prepare'
 

--- a/centralledger/chart-service/configs/default-settlement-example.json
+++ b/centralledger/chart-service/configs/default-settlement-example.json
@@ -1,0 +1,160 @@
+{
+  "PORT": 3007,
+  "HOSTNAME": "central-ledger.local",
+  "DATABASE": {
+    "DIALECT": "mysql2",
+    "HOST": "mysqldb",
+    "PORT": 3306,
+    "USER": "central_ledger",
+    "PASSWORD": "",
+    "SCHEMA": "central_ledger",
+    "POOL_MIN_SIZE": 10,
+    "POOL_MAX_SIZE": 10,
+    "ACQUIRE_TIMEOUT_MILLIS": 30000,
+    "CREATE_TIMEOUT_MILLIS": 30000,
+    "DESTROY_TIMEOUT_MILLIS": 5000,
+    "IDLE_TIMEOUT_MILLIS": 30000,
+    "REAP_INTERVAL_MILLIS": 1000,
+    "CREATE_RETRY_INTERVAL_MILLIS": 200,
+    "DEBUG": false
+  },
+  "WINDOW_AGGREGATION": {
+    "RETRY_COUNT": 3,
+    "RETRY_INTERVAL": 3000
+  },
+  "TRANSFER_VALIDITY_SECONDS": "432000",
+  "HUB_PARTICIPANT": {
+    "ID": 1,
+    "NAME": "Hub"
+  },
+  "HANDLERS": {
+    "DISABLED": false,
+    "API": {
+      "DISABLED": false
+    },
+    "SETTINGS": {
+      "RULES": {
+        "SCRIPTS_FOLDER": "./scripts/transferSettlementTemp",
+        "SCRIPT_TIMEOUT": 100,
+        "CONSUMER_COMMIT": true,
+        "FROM_SWITCH": true
+      }
+    }
+  },
+  "API_DOC_ENDPOINTS_ENABLED": true,
+  "SWITCH_ENDPOINT": "http://ml-api-adapter.local",
+  "AMOUNT": {
+    "PRECISION": 18,
+    "SCALE": 4
+  },
+  "KAFKA": {
+    "TOPIC_TEMPLATES": {
+      "GENERAL_TOPIC_TEMPLATE": {
+        "TEMPLATE": "topic-{{functionality}}-{{action}}",
+        "REGEX": "topic-(.*)-(.*)"
+      }
+    },
+    "CONSUMER": {
+      "DEFERREDSETTLEMENT": {
+        "CLOSE": {
+          "config": {
+            "options": {
+              "mode": 2,
+              "batchSize": 1,
+              "pollFrequency": 10,
+              "recursiveTimeout": 100,
+              "messageCharset": "utf8",
+              "messageAsJSON": true,
+              "sync": true,
+              "consumeTimeout": 1000
+            },
+            "rdkafkaConf": {
+              "client.id": "cs-con-deferredsettlement-close",
+              "group.id": "cs-group-deferredsettlement-close",
+              "metadata.broker.list": "kafka:9092",
+              "socket.keepalive.enable": true,
+              "allow.auto.create.topics": true
+            },
+            "topicConf": {
+              "auto.offset.reset": "earliest"
+            }
+          }
+        }
+      },
+      "NOTIFICATION": {
+        "EVENT": {
+          "config": {
+            "options": {
+              "mode": 2,
+              "batchSize": 1,
+              "pollFrequency": 10,
+              "recursiveTimeout": 100,
+              "messageCharset": "utf8",
+              "messageAsJSON": true,
+              "sync": true,
+              "consumeTimeout": 1000
+            },
+            "rdkafkaConf": {
+              "client.id": "cs-con-notification-event",
+              "group.id": "cs-group-notification-event",
+              "metadata.broker.list": "kafka:9092",
+              "socket.keepalive.enable": true,
+              "allow.auto.create.topics": true
+            },
+            "topicConf": {
+              "auto.offset.reset": "earliest"
+            }
+          }
+        }
+      }
+    },
+    "PRODUCER": {
+      "NOTIFICATION": {
+        "EVENT": {
+          "config": {
+            "options": {
+              "messageCharset": "utf8"
+            },
+            "rdkafkaConf": {
+              "debug": "all",
+              "metadata.broker.list": "kafka:9092",
+              "client.id": "cs-prod-notification-event",
+              "event_cb": true,
+              "compression.codec": "none",
+              "retry.backoff.ms": 100,
+              "message.send.max.retries": 2,
+              "socket.keepalive.enable": true,
+              "queue.buffering.max.messages": 10000000,
+              "batch.num.messages": 100,
+              "dr_cb": true,
+              "socket.blocking.max.ms": 1,
+              "queue.buffering.max.ms": 1,
+              "broker.version.fallback": "0.10.1.0",
+              "api.version.request": true
+            }
+          }
+        }
+      },
+      "DEFERREDSETTLEMENT": {
+        "CLOSE": {
+          "config": {
+            "options": {
+              "messageCharset": "utf8"
+            },
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:9092",
+              "client.id": "cs-prod-deferredsettlement-close",
+              "event_cb": true,
+              "dr_cb": true,
+              "socket.keepalive.enable": true,
+              "queue.buffering.max.messages": 10000000
+            },
+            "topicConf": {
+              "request.required.acks": "all"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/centralledger/chart-service/configs/default.json
+++ b/centralledger/chart-service/configs/default.json
@@ -49,6 +49,10 @@
         "PASSWORD": "{{ .Values.config.mongo_password }}",
         "DATABASE": "{{ .Values.config.mongo_database }}"
     },
+    "WINDOW_AGGREGATION": {
+        "RETRY_COUNT": 3,
+        "RETRY_INTERVAL": 3000
+    },
     "HANDLERS": {
         "DISABLED": true,
         "API": {
@@ -58,6 +62,14 @@
             "DISABLED": true,
             "TIMEXP": "*/15 * * * * *",
             "TIMEZONE": "UTC"
+        },
+        "SETTINGS": {
+            "RULES": {
+                "SCRIPTS_FOLDER": "./scripts/transferSettlementTemp",
+                "SCRIPT_TIMEOUT": 100,
+                "CONSUMER_COMMIT": true,
+                "FROM_SWITCH": true
+            }
         }
     },
     "INSTRUMENTATION": {

--- a/centralledger/chart-service/configs/default.json
+++ b/centralledger/chart-service/configs/default.json
@@ -61,7 +61,17 @@
         "TIMEOUT": {
             "DISABLED": true,
             "TIMEXP": "*/15 * * * * *",
-            "TIMEZONE": "UTC"
+            "TIMEZONE": "UTC",
+            "DIST_LOCK": {
+              "enabled": false,
+              "lockTimeout": 10000,
+              "acquireTimeout": 5000,
+              "driftFactor": 0.01,
+              "retryCount": 3,
+              "retryDelay": 200,
+              "retryJitter": 100,
+              "redisConfigs": [{ "type": "redis-cluster", "cluster": [{ "host": "localhost", "port": 6379 }] }]
+            }
         },
         "SETTINGS": {
             "RULES": {
@@ -103,6 +113,7 @@
         ]
     },
     "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+    "ENABLE_ON_US_TRANSFERS": false,
     "PAYEE_PARTICIPANT_CURRENCY_VALIDATION_ENABLED": {{ .Values.config.payee_participant_currency_validation_enabled }},
     "CACHE": {
         "CACHE_ENABLED": {{ .Values.config.cache_enabled }},
@@ -112,6 +123,21 @@
     "PROXY_CACHE": {{ .Values.config.proxy_cache | toPrettyJson | nindent 2 }},
     "API_DOC_ENDPOINTS_ENABLED": true,
     "KAFKA": {
+        "EVENT_TYPE_ACTION_TOPIC_MAP" : {
+          "POSITION":{
+            "PREPARE": null,
+            "FX_PREPARE": null,
+            "BULK_PREPARE": null,
+            "COMMIT": null,
+            "BULK_COMMIT": null,
+            "RESERVE": null,
+            "FX_RESERVE": null,
+            "TIMEOUT_RESERVED": null,
+            "FX_TIMEOUT_RESERVED": null,
+            "ABORT": null,
+            "FX_ABORT": null
+          }
+        },
         "TOPIC_TEMPLATES": {
             "PARTICIPANT_TOPIC_TEMPLATE": {
                 "TEMPLATE": "topic-{{"{{"}}participantName{{"}}"}}-{{"{{"}}functionality{{"}}"}}-{{"{{"}}action{{"}}"}}",
@@ -270,6 +296,30 @@
                         }
                     }
                 },
+                "POSITION_BATCH": {
+                    "config": {
+                        "options": {
+                            "mode": 2,
+                            "batchSize": 1,
+                            "pollFrequency": 10,
+                            "recursiveTimeout": 100,
+                            "messageCharset": "utf8",
+                            "messageAsJSON": true,
+                            "sync": true,
+                            "consumeTimeout": 1000
+                        },
+                        "rdkafkaConf": {
+                            "client.id": "cl-con-transfer-position-batch",
+                            "group.id": "cl-group-transfer-position-batch",
+                            "metadata.broker.list": "{{ (default .Values.config.kafka_host $kafkaHost) }}:{{ .Values.config.kafka_port }}",
+                            "socket.keepalive.enable": true,
+                            "allow.auto.create.topics": true
+                        },
+                        "topicConf": {
+                            "auto.offset.reset": "earliest"
+                        }
+                    }
+                },
                 "FULFIL": {
                     "config": {
                         "options": {
@@ -344,6 +394,58 @@
                         }
                     }
                 }
+            },
+            "NOTIFICATION": {
+              "EVENT": {
+                "config": {
+                  "options": {
+                    "mode": 2,
+                    "batchSize": 1,
+                    "pollFrequency": 10,
+                    "recursiveTimeout": 100,
+                    "messageCharset": "utf8",
+                    "messageAsJSON": true,
+                    "sync": true,
+                    "consumeTimeout": 1000
+                  },
+                  "rdkafkaConf": {
+                    "client.id": "TESTONLY",
+                    "group.id": "TESTONLY",
+                    "metadata.broker.list": "localhost:9092",
+                    "socket.keepalive.enable": true,
+                    "allow.auto.create.topics": true
+                  },
+                  "topicConf": {
+                    "auto.offset.reset": "earliest"
+                  }
+                }
+              }
+            },
+            "DEFERREDSETTLEMENT": {
+              "CLOSE": {
+                "config": {
+                  "options": {
+                    "mode": 2,
+                    "batchSize": 1,
+                    "pollFrequency": 10,
+                    "recursiveTimeout": 100,
+                    "messageCharset": "utf8",
+                    "messageAsJSON": true,
+                    "sync": true,
+                    "consumeTimeout": 1000
+                  },
+                  "rdkafkaConf": {
+                    "client.id": "cs-con-deferredsettlement-close",
+                    "group.id": "cs-group-deferredsettlement-close",
+                    "metadata.broker.list": "localhost:9092",
+                    "socket.keepalive.enable": true,
+                    "allow.auto.create.topics": true
+                  },
+                  "topicConf": {
+                    "auto.offset.reset": "earliest"
+                  }
+                }
+              }
             }
         },
         "PRODUCER": {

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -7,14 +7,14 @@ global: {}
 # Declare variables to be passed into your templates.
 
 image:
-  registry: docker.io
-  repository: mojaloop/central-ledger
-  tag: v19.14.0
+  registry: ""
+  repository: central-ledger
+  tag: local
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
-  pullPolicy: IfNotPresent
+  pullPolicy: Never
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -9,7 +9,7 @@ global: {}
 image:
   registry: ""
   repository: central-ledger
-  tag: local
+  tag: local2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/centralledger/chart-service/values.yaml
+++ b/centralledger/chart-service/values.yaml
@@ -25,7 +25,7 @@ image:
   pullSecrets: []
 
 replicaCount: 1
-command: '["node", "src/api/index.js"]'
+command: '["node", "dist/api/index.js"]'
 
 ## Enable diagnostic mode in the deployment
 ##
@@ -41,7 +41,7 @@ diagnosticMode:
   ##
   args:
     - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-    - src/api/index.js
+    - dist/api/index.js
 
   ## @param diagnosticMode.debug config to override all debug information
   ##

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -393,7 +393,7 @@ centralledger-handler-transfer-prepare:
     pullSecrets: []
 
   replicaCount: 1
-  command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
+  command: '["node", "dist/handlers/index.js", "handler", "--prepare"]'
 
   # Mount configuration files in the app folder for overriding defaults
   # configOverride:
@@ -419,7 +419,7 @@ centralledger-handler-transfer-prepare:
     ##
     args:
       - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-      - src/handlers/index.js
+      - dist/handlers/index.js
       - handler
       - '--prepare'
 
@@ -758,7 +758,7 @@ centralledger-handler-transfer-position:
     pullSecrets: []
 
   replicaCount: 1
-  command: '["node", "src/handlers/index.js", "handler", "--position"]'
+  command: '["node", "dist/handlers/index.js", "handler", "--position"]'
 
   # Mount configuration files in the app folder for overriding defaults
   # configOverride:
@@ -784,7 +784,7 @@ centralledger-handler-transfer-position:
     ##
     args:
       - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-      - src/handlers/index.js
+      - dist/handlers/index.js
       - handler
       - '--position'
 
@@ -1120,7 +1120,7 @@ centralledger-handler-transfer-position-batch:
     pullSecrets: []
 
   replicaCount: 1
-  command: '["node", "src/handlers/index.js", "handler", "--positionbatch"]'
+  command: '["node", "dist/handlers/index.js", "handler", "--positionbatch"]'
 
   # Mount configuration files in the app folder for overriding defaults
   # configOverride:
@@ -1146,7 +1146,7 @@ centralledger-handler-transfer-position-batch:
     ##
     args:
       - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-      - src/handlers/index.js
+      - dist/handlers/index.js
       - handler
       - '--positionbatch'
 
@@ -1488,7 +1488,7 @@ centralledger-handler-transfer-get:
     pullSecrets: []
 
   replicaCount: 1
-  command: '["node", "src/handlers/index.js", "handler", "--get"]'
+  command: '["node", "dist/handlers/index.js", "handler", "--get"]'
 
   # Mount configuration files in the app folder for overriding defaults
   # configOverride:
@@ -1514,7 +1514,7 @@ centralledger-handler-transfer-get:
     ##
     args:
       - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-      - src/handlers/index.js
+      - dist/handlers/index.js
       - handler
       - '--get'
 
@@ -1850,7 +1850,7 @@ centralledger-handler-transfer-fulfil:
     pullSecrets: []
 
   replicaCount: 1
-  command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
+  command: '["node", "dist/handlers/index.js", "handler", "--fulfil"]'
 
   # Mount configuration files in the app folder for overriding defaults
   # configOverride:
@@ -1876,7 +1876,7 @@ centralledger-handler-transfer-fulfil:
     ##
     args:
       - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-      - src/handlers/index.js
+      - dist/handlers/index.js
       - handler
       - '--fulfil'
 
@@ -2212,7 +2212,7 @@ centralledger-handler-timeout:
     pullSecrets: []
 
   replicaCount: 1
-  command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
+  command: '["node", "dist/handlers/index.js", "handler", "--timeout"]'
 
   # Mount configuration files in the app folder for overriding defaults
   # configOverride:
@@ -2238,7 +2238,7 @@ centralledger-handler-timeout:
     ##
     args:
       - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-      - src/handlers/index.js
+      - dist/handlers/index.js
       - handler
       - '--timeout'
 
@@ -2579,7 +2579,7 @@ centralledger-handler-admin-transfer:
     pullSecrets: []
 
   replicaCount: 1
-  command: '["node", "src/handlers/index.js", "handler", "--admin"]'
+  command: '["node", "dist/handlers/index.js", "handler", "--admin"]'
 
   # Mount configuration files in the app folder for overriding defaults
   # configOverride:
@@ -2605,7 +2605,7 @@ centralledger-handler-admin-transfer:
     ##
     args:
       - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-      - src/handlers/index.js
+      - dist/handlers/index.js
       - handler
       - '--admin'
 

--- a/centralledger/values.yaml
+++ b/centralledger/values.yaml
@@ -32,7 +32,7 @@ centralledger-service:
     pullSecrets: []
 
   replicaCount: 1
-  command: '["node", "src/api/index.js"]'
+  command: '["node", "dist/api/index.js"]'
 
   # Mount configuration files in the app folder for overriding defaults
   # configOverride:
@@ -58,7 +58,7 @@ centralledger-service:
     ##
     args:
       - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-      - src/api/index.js
+      - dist/api/index.js
 
     ## @param diagnosticMode.debug config to override all debug information
     ##

--- a/centralsettlement/chart-service/configs/default-example.json
+++ b/centralsettlement/chart-service/configs/default-example.json
@@ -1,0 +1,487 @@
+{
+  "PORT": 3007,
+  "HOSTNAME": "central-settlement.local",
+  "MIGRATIONS": {
+    "DISABLED": true,
+    "RUN_DATA_MIGRATIONS": true
+  },
+  "AMOUNT": {
+    "PRECISION": 18,
+    "SCALE": 4
+  },
+  "ERROR_HANDLING": {
+    "includeCauseExtension": false,
+    "truncateExtensions": true
+  },
+  "SIDECAR": {
+    "DISABLED": true,
+    "HOST": "dev-forensicloggingsidecar-ledger",
+    "PORT": 5678,
+    "CONNECT_TIMEOUT": 45000,
+    "RECONNECT_INTERVAL": 5000
+  },
+  "DATABASE": {
+    "DIALECT": "mysql2",
+    "HOST": "mysqldb",
+    "PORT": 3306,
+    "USER": "central_ledger",
+    "PASSWORD": "",
+    "SCHEMA": "central_ledger",
+    "POOL_MIN_SIZE": 10,
+    "POOL_MAX_SIZE": 30,
+    "ACQUIRE_TIMEOUT_MILLIS": 30000,
+    "CREATE_TIMEOUT_MILLIS": 30000,
+    "DESTROY_TIMEOUT_MILLIS": 5000,
+    "IDLE_TIMEOUT_MILLIS": 30000,
+    "REAP_INTERVAL_MILLIS": 1000,
+    "CREATE_RETRY_INTERVAL_MILLIS": 200,
+    "DEBUG": false,
+    "ADDITIONAL_CONNECTION_OPTIONS": {}
+  },
+  "MONGODB": {
+    "DISABLED": true,
+    "HOST": "cep-mongodb",
+    "PORT": "27017",
+    "USER": "mojaloop",
+    "PASSWORD": "",
+    "DATABASE": "mlos"
+  },
+  "HANDLERS": {
+    "DISABLED": true,
+    "API": {
+      "DISABLED": false
+    },
+    "TIMEOUT": {
+      "DISABLED": true,
+      "TIMEXP": "*/15 * * * * *",
+      "TIMEZONE": "UTC"
+    }
+  },
+  "INSTRUMENTATION": {
+    "METRICS": {
+      "DISABLED": false,
+      "labels": {
+        "fspId": "*"
+      },
+      "config": {
+        "timeout": 5000,
+        "prefix": "moja_",
+        "defaultLabels": {
+          "serviceName": "central-service"
+        }
+      }
+    }
+  },
+  "EMAIL_USER": "user",
+  "EMAIL_PASSWORD": "password",
+  "EMAIL_SMTP": "smtp.local",
+  "PARTICIPANT_INITIAL_POSITION": 0,
+  "HUB_PARTICIPANT": {
+    "ID": 1,
+    "NAME": "Hub",
+    "ACCOUNTS": [
+      "HUB_RECONCILIATION",
+      "HUB_MULTILATERAL_SETTLEMENT",
+      "HUB_FEE"
+    ]
+  },
+  "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+  "PAYEE_PARTICIPANT_CURRENCY_VALIDATION_ENABLED": true,
+  "CACHE": {
+    "CACHE_ENABLED": false,
+    "MAX_BYTE_SIZE": 10000000,
+    "EXPIRES_IN_MS": 1000
+  },
+  "PROXY_CACHE": {
+    "enabled": false,
+    "proxyConfig": {
+      "cluster": [
+        {
+          "host": "proxy-cache-redis",
+          "port": 6379
+        }
+      ]
+    },
+    "type": "redis-cluster"
+  },
+  "API_DOC_ENDPOINTS_ENABLED": true,
+  "KAFKA": {
+    "TOPIC_TEMPLATES": {
+      "PARTICIPANT_TOPIC_TEMPLATE": {
+        "TEMPLATE": "topic-{{participantName}}-{{functionality}}-{{action}}",
+        "REGEX": "topic-(.*)-(.*)-(.*)"
+      },
+      "GENERAL_TOPIC_TEMPLATE": {
+        "TEMPLATE": "topic-{{functionality}}-{{action}}",
+        "REGEX": "topic-(.*)-(.*)"
+      }
+    },
+    "CONSUMER": {
+      "BULK": {
+        "PREPARE": {
+          "config": {
+            "options": {
+              "mode": 2,
+              "batchSize": 1,
+              "pollFrequency": 10,
+              "recursiveTimeout": 100,
+              "messageCharset": "utf8",
+              "messageAsJSON": true,
+              "sync": true,
+              "consumeTimeout": 1000
+            },
+            "rdkafkaConf": {
+              "client.id": "cl-con-bulk-prepare",
+              "group.id": "cl-group-bulk-prepare",
+              "metadata.broker.list": "kafka:9092",
+              "socket.keepalive.enable": true,
+              "allow.auto.create.topics": true
+            },
+            "topicConf": {
+              "auto.offset.reset": "earliest"
+            }
+          }
+        },
+        "PROCESSING": {
+          "config": {
+            "options": {
+              "mode": 2,
+              "batchSize": 1,
+              "pollFrequency": 10,
+              "recursiveTimeout": 100,
+              "messageCharset": "utf8",
+              "messageAsJSON": true,
+              "sync": true,
+              "consumeTimeout": 1000
+            },
+            "rdkafkaConf": {
+              "client.id": "cl-con-bulk-processing",
+              "group.id": "cl-group-bulk-processing",
+              "metadata.broker.list": "kafka:9092",
+              "socket.keepalive.enable": true,
+              "allow.auto.create.topics": true
+            },
+            "topicConf": {
+              "auto.offset.reset": "earliest"
+            }
+          }
+        },
+        "FULFIL": {
+          "config": {
+            "options": {
+              "mode": 2,
+              "batchSize": 1,
+              "pollFrequency": 10,
+              "recursiveTimeout": 100,
+              "messageCharset": "utf8",
+              "messageAsJSON": true,
+              "sync": true,
+              "consumeTimeout": 1000
+            },
+            "rdkafkaConf": {
+              "client.id": "cl-con-bulk-fulfil",
+              "group.id": "cl-group-bulk-fulfil",
+              "metadata.broker.list": "kafka:9092",
+              "socket.keepalive.enable": true,
+              "allow.auto.create.topics": true
+            },
+            "topicConf": {
+              "auto.offset.reset": "earliest"
+            }
+          }
+        },
+        "GET": {
+          "config": {
+            "options": {
+              "mode": 2,
+              "batchSize": 1,
+              "pollFrequency": 10,
+              "recursiveTimeout": 100,
+              "messageCharset": "utf8",
+              "messageAsJSON": true,
+              "sync": true,
+              "consumeTimeout": 1000
+            },
+            "rdkafkaConf": {
+              "client.id": "cl-con-bulk-get",
+              "group.id": "cl-group-bulk-get",
+              "metadata.broker.list": "kafka:9092",
+              "socket.keepalive.enable": true,
+              "allow.auto.create.topics": true
+            },
+            "topicConf": {
+              "auto.offset.reset": "earliest"
+            }
+          }
+        }
+      },
+      "TRANSFER": {
+        "PREPARE": {
+          "config": {
+            "options": {
+              "mode": 2,
+              "batchSize": 1,
+              "pollFrequency": 10,
+              "recursiveTimeout": 100,
+              "messageCharset": "utf8",
+              "messageAsJSON": true,
+              "sync": true,
+              "consumeTimeout": 1000
+            },
+            "rdkafkaConf": {
+              "client.id": "cl-con-transfer-prepare",
+              "group.id": "cl-group-transfer-prepare",
+              "metadata.broker.list": "kafka:9092",
+              "socket.keepalive.enable": true,
+              "allow.auto.create.topics": true
+            },
+            "topicConf": {
+              "auto.offset.reset": "earliest"
+            }
+          }
+        },
+        "POSITION": {
+          "config": {
+            "options": {
+              "mode": 2,
+              "batchSize": 1,
+              "pollFrequency": 10,
+              "recursiveTimeout": 100,
+              "messageCharset": "utf8",
+              "messageAsJSON": true,
+              "sync": true,
+              "consumeTimeout": 1000
+            },
+            "rdkafkaConf": {
+              "client.id": "cl-con-transfer-position",
+              "group.id": "cl-group-transfer-position",
+              "metadata.broker.list": "kafka:9092",
+              "socket.keepalive.enable": true,
+              "allow.auto.create.topics": true
+            },
+            "topicConf": {
+              "auto.offset.reset": "earliest"
+            }
+          }
+        },
+        "FULFIL": {
+          "config": {
+            "options": {
+              "mode": 2,
+              "batchSize": 1,
+              "pollFrequency": 10,
+              "recursiveTimeout": 100,
+              "messageCharset": "utf8",
+              "messageAsJSON": true,
+              "sync": true,
+              "consumeTimeout": 1000
+            },
+            "rdkafkaConf": {
+              "client.id": "cl-con-transfer-fulfil",
+              "group.id": "cl-group-transfer-fulfil",
+              "metadata.broker.list": "kafka:9092",
+              "socket.keepalive.enable": true,
+              "allow.auto.create.topics": true
+            },
+            "topicConf": {
+              "auto.offset.reset": "earliest"
+            }
+          }
+        },
+        "GET": {
+          "config": {
+            "options": {
+              "mode": 2,
+              "batchSize": 1,
+              "pollFrequency": 10,
+              "recursiveTimeout": 100,
+              "messageCharset": "utf8",
+              "messageAsJSON": true,
+              "sync": true,
+              "consumeTimeout": 1000
+            },
+            "rdkafkaConf": {
+              "client.id": "cl-con-transfer-get",
+              "group.id": "cl-group-transfer-get",
+              "metadata.broker.list": "kafka:9092",
+              "socket.keepalive.enable": true,
+              "allow.auto.create.topics": true
+            },
+            "topicConf": {
+              "auto.offset.reset": "earliest"
+            }
+          }
+        }
+      },
+      "ADMIN": {
+        "TRANSFER": {
+          "config": {
+            "options": {
+              "mode": 2,
+              "batchSize": 1,
+              "pollFrequency": 10,
+              "recursiveTimeout": 100,
+              "messageCharset": "utf8",
+              "messageAsJSON": true,
+              "sync": true,
+              "consumeTimeout": 1000
+            },
+            "rdkafkaConf": {
+              "client.id": "cl-con-transfer-admin",
+              "group.id": "cl-group-transfer-admin",
+              "metadata.broker.list": "kafka:9092",
+              "socket.keepalive.enable": true,
+              "allow.auto.create.topics": true
+            },
+            "topicConf": {
+              "auto.offset.reset": "earliest"
+            }
+          }
+        }
+      }
+    },
+    "PRODUCER": {
+      "BULK": {
+        "PROCESSING": {
+          "config": {
+            "options": {
+              "messageCharset": "utf8"
+            },
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:9092",
+              "client.id": "cl-prod-bulk-processing",
+              "event_cb": true,
+              "dr_cb": false,
+              "socket.keepalive.enable": true,
+              "queue.buffering.max.messages": 10000000
+            },
+            "topicConf": {
+              "request.required.acks": "all",
+              "partitioner": "murmur2_random"
+            }
+          }
+        }
+      },
+      "TRANSFER": {
+        "PREPARE": {
+          "config": {
+            "options": {
+              "messageCharset": "utf8"
+            },
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:9092",
+              "client.id": "cl-prod-transfer-prepare",
+              "event_cb": true,
+              "dr_cb": false,
+              "socket.keepalive.enable": true,
+              "queue.buffering.max.messages": 10000000
+            },
+            "topicConf": {
+              "request.required.acks": "all",
+              "partitioner": "murmur2_random"
+            }
+          }
+        },
+        "POSITION": {
+          "config": {
+            "options": {
+              "messageCharset": "utf8"
+            },
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:9092",
+              "client.id": "cl-prod-transfer-position",
+              "event_cb": true,
+              "dr_cb": false,
+              "socket.keepalive.enable": true,
+              "queue.buffering.max.messages": 10000000
+            },
+            "topicConf": {
+              "request.required.acks": "all",
+              "partitioner": "murmur2_random"
+            }
+          }
+        },
+        "FULFIL": {
+          "config": {
+            "options": {
+              "messageCharset": "utf8"
+            },
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:9092",
+              "client.id": "cl-prod-transfer-fulfil",
+              "event_cb": true,
+              "dr_cb": false,
+              "socket.keepalive.enable": true,
+              "queue.buffering.max.messages": 10000000
+            },
+            "topicConf": {
+              "request.required.acks": "all",
+              "partitioner": "murmur2_random"
+            }
+          }
+        },
+        "GET": {
+          "config": {
+            "options": {
+              "messageCharset": "utf8"
+            },
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:9092",
+              "client.id": "cl-prod-transfer-get",
+              "event_cb": true,
+              "dr_cb": false,
+              "socket.keepalive.enable": true,
+              "queue.buffering.max.messages": 10000000
+            },
+            "topicConf": {
+              "request.required.acks": "all",
+              "partitioner": "murmur2_random"
+            }
+          }
+        }
+      },
+      "NOTIFICATION": {
+        "EVENT": {
+          "config": {
+            "options": {
+              "messageCharset": "utf8"
+            },
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:9092",
+              "client.id": "cl-prod-notification-event",
+              "event_cb": true,
+              "dr_cb": false,
+              "socket.keepalive.enable": true,
+              "queue.buffering.max.messages": 10000000
+            },
+            "topicConf": {
+              "request.required.acks": "all",
+              "partitioner": "murmur2_random"
+            }
+          }
+        }
+      },
+      "ADMIN": {
+        "TRANSFER": {
+          "config": {
+            "options": {
+              "messageCharset": "utf8"
+            },
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:9092",
+              "client.id": "admin-transfer-produce",
+              "event_cb": true,
+              "dr_cb": false,
+              "socket.keepalive.enable": true,
+              "queue.buffering.max.messages": 10000000
+            },
+            "topicConf": {
+              "request.required.acks": "all",
+              "partitioner": "murmur2_random"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/centralsettlement/chart-service/configs/default-settlement-example.json
+++ b/centralsettlement/chart-service/configs/default-settlement-example.json
@@ -1,0 +1,160 @@
+{
+  "PORT": 3007,
+  "HOSTNAME": "central-settlement.local",
+  "DATABASE": {
+    "DIALECT": "mysql2",
+    "HOST": "mysqldb",
+    "PORT": 3306,
+    "USER": "central_ledger",
+    "PASSWORD": "",
+    "SCHEMA": "central_ledger",
+    "POOL_MIN_SIZE": 10,
+    "POOL_MAX_SIZE": 10,
+    "ACQUIRE_TIMEOUT_MILLIS": 30000,
+    "CREATE_TIMEOUT_MILLIS": 30000,
+    "DESTROY_TIMEOUT_MILLIS": 5000,
+    "IDLE_TIMEOUT_MILLIS": 30000,
+    "REAP_INTERVAL_MILLIS": 1000,
+    "CREATE_RETRY_INTERVAL_MILLIS": 200,
+    "DEBUG": false
+  },
+  "WINDOW_AGGREGATION": {
+    "RETRY_COUNT": 3,
+    "RETRY_INTERVAL": 3000
+  },
+  "TRANSFER_VALIDITY_SECONDS": "432000",
+  "HUB_PARTICIPANT": {
+    "ID": 1,
+    "NAME": "Hub"
+  },
+  "HANDLERS": {
+    "DISABLED": false,
+    "API": {
+      "DISABLED": false
+    },
+    "SETTINGS": {
+      "RULES": {
+        "SCRIPTS_FOLDER": "./scripts/transferSettlementTemp",
+        "SCRIPT_TIMEOUT": 100,
+        "CONSUMER_COMMIT": true,
+        "FROM_SWITCH": true
+      }
+    }
+  },
+  "API_DOC_ENDPOINTS_ENABLED": true,
+  "SWITCH_ENDPOINT": "http://ml-api-adapter.local",
+  "AMOUNT": {
+    "PRECISION": 18,
+    "SCALE": 4
+  },
+  "KAFKA": {
+    "TOPIC_TEMPLATES": {
+      "GENERAL_TOPIC_TEMPLATE": {
+        "TEMPLATE": "topic-{{functionality}}-{{action}}",
+        "REGEX": "topic-(.*)-(.*)"
+      }
+    },
+    "CONSUMER": {
+      "DEFERREDSETTLEMENT": {
+        "CLOSE": {
+          "config": {
+            "options": {
+              "mode": 2,
+              "batchSize": 1,
+              "pollFrequency": 10,
+              "recursiveTimeout": 100,
+              "messageCharset": "utf8",
+              "messageAsJSON": true,
+              "sync": true,
+              "consumeTimeout": 1000
+            },
+            "rdkafkaConf": {
+              "client.id": "cs-con-deferredsettlement-close",
+              "group.id": "cs-group-deferredsettlement-close",
+              "metadata.broker.list": "kafka:9092",
+              "socket.keepalive.enable": true,
+              "allow.auto.create.topics": true
+            },
+            "topicConf": {
+              "auto.offset.reset": "earliest"
+            }
+          }
+        }
+      },
+      "NOTIFICATION": {
+        "EVENT": {
+          "config": {
+            "options": {
+              "mode": 2,
+              "batchSize": 1,
+              "pollFrequency": 10,
+              "recursiveTimeout": 100,
+              "messageCharset": "utf8",
+              "messageAsJSON": true,
+              "sync": true,
+              "consumeTimeout": 1000
+            },
+            "rdkafkaConf": {
+              "client.id": "cs-con-notification-event",
+              "group.id": "cs-group-notification-event",
+              "metadata.broker.list": "kafka:9092",
+              "socket.keepalive.enable": true,
+              "allow.auto.create.topics": true
+            },
+            "topicConf": {
+              "auto.offset.reset": "earliest"
+            }
+          }
+        }
+      }
+    },
+    "PRODUCER": {
+      "NOTIFICATION": {
+        "EVENT": {
+          "config": {
+            "options": {
+              "messageCharset": "utf8"
+            },
+            "rdkafkaConf": {
+              "debug": "all",
+              "metadata.broker.list": "kafka:9092",
+              "client.id": "cs-prod-notification-event",
+              "event_cb": true,
+              "compression.codec": "none",
+              "retry.backoff.ms": 100,
+              "message.send.max.retries": 2,
+              "socket.keepalive.enable": true,
+              "queue.buffering.max.messages": 10000000,
+              "batch.num.messages": 100,
+              "dr_cb": true,
+              "socket.blocking.max.ms": 1,
+              "queue.buffering.max.ms": 1,
+              "broker.version.fallback": "0.10.1.0",
+              "api.version.request": true
+            }
+          }
+        }
+      },
+      "DEFERREDSETTLEMENT": {
+        "CLOSE": {
+          "config": {
+            "options": {
+              "messageCharset": "utf8"
+            },
+            "rdkafkaConf": {
+              "metadata.broker.list": "kafka:9092",
+              "client.id": "cs-prod-deferredsettlement-close",
+              "event_cb": true,
+              "dr_cb": true,
+              "socket.keepalive.enable": true,
+              "queue.buffering.max.messages": 10000000
+            },
+            "topicConf": {
+              "request.required.acks": "all"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/centralsettlement/chart-service/configs/default.json
+++ b/centralsettlement/chart-service/configs/default.json
@@ -25,6 +25,14 @@
     "DEBUG": {{ .Values.config.db_debug }},
     "ADDITIONAL_CONNECTION_OPTIONS": {{ .Values.config.db_additional_connection_options | toPrettyJson | nindent 4 }}
   },
+  "MONGODB": {
+    "DISABLED": true,
+    "HOST": "mongodb",
+    "PORT": "27017",
+    "USER": "",
+    "PASSWORD": "",
+    "DATABASE": "mlos"
+  },
   "WINDOW_AGGREGATION": {
     "RETRY_COUNT": {{ .Values.config.window_aggregation.retry_count }},
     "RETRY_INTERVAL": {{ .Values.config.window_aggregation.retry_interval }}
@@ -32,12 +40,22 @@
   "TRANSFER_VALIDITY_SECONDS": "432000",
   "HUB_PARTICIPANT": {
       "ID": {{ .Values.config.hub_participant.id }},
-      "NAME": "{{ .Values.config.hub_participant.name }}"
+      "NAME": "{{ .Values.config.hub_participant.name }}",
+      "ACCOUNTS": [
+        "HUB_RECONCILIATION",
+        "HUB_MULTILATERAL_SETTLEMENT",
+        "HUB_FEE"
+      ]
   },
   "HANDLERS": {
     "DISABLED": {{ .Values.config.handlers.disabled }},
     "API": {
       "DISABLED": {{ .Values.config.handlers.api.disabled }}
+    },
+    "TIMEOUT": {
+      "DISABLED": true,
+      "TIMEXP": "*/15 * * * * *",
+      "TIMEZONE": "UTC"
     },
     "SETTINGS": {
       "RULES": {
@@ -46,6 +64,51 @@
         "CONSUMER_COMMIT": true,
         "FROM_SWITCH": true
     }
+    }
+  },
+  "INSTRUMENTATION": {
+    "METRICS": {
+      "DISABLED": true,
+      "labels": {
+        "fspId": "*"
+      },
+      "config": {
+        "timeout": 5000,
+        "prefix": "moja_",
+        "defaultLabels": {
+          "serviceName": "central-settlement"
+        }
+      }
+    }
+  },
+  "MIGRATIONS": {
+    "DISABLED": true,
+    "RUN_DATA_MIGRATIONS": true
+  },
+  "AMOUNT": {
+    "PRECISION": 18,
+    "SCALE": 4
+  },
+  "SIDECAR": {
+    "DISABLED": true,
+    "HOST": "localhost",
+    "PORT": 5678,
+    "CONNECT_TIMEOUT": 45000,
+    "RECONNECT_INTERVAL": 5000
+  },
+  "PARTICIPANT_INITIAL_POSITION": 0,
+  "INTERNAL_TRANSFER_VALIDITY_SECONDS": "432000",
+  "PAYEE_PARTICIPANT_CURRENCY_VALIDATION_ENABLED": true,
+  "CACHE": {
+    "CACHE_ENABLED": false,
+    "MAX_BYTE_SIZE": 10000000,
+    "EXPIRES_IN_MS": 1000
+  },
+  "PROXY_CACHE": {
+    "enabled": false,
+    "type": "redis-cluster",
+    "proxyConfig": {
+      "cluster": []
     }
   },
   "API_DOC_ENDPOINTS_ENABLED": true,

--- a/centralsettlement/chart-service/configs/knex-example.js
+++ b/centralsettlement/chart-service/configs/knex-example.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const migrationsDirectory = '/opt/app/migrations'
+const seedsDirectory = '/opt/app/seeds'
+
+const Config = require('/opt/app/src/lib/config')
+
+module.exports = {
+    ...Config.DATABASE,
+    migrations: {
+        directory: migrationsDirectory,
+        tableName: 'migration',
+        stub: `${migrationsDirectory}/migration.template`
+    },
+    seeds: {
+        directory: seedsDirectory,
+        loadExtensions: ['.js']
+    }
+}

--- a/centralsettlement/chart-service/templates/config.yaml
+++ b/centralsettlement/chart-service/templates/config.yaml
@@ -10,6 +10,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 data:
   default.json: {{ (tpl (.Files.Get "configs/default.json") . ) | quote }}
+  knexfile.js: {{ .Files.Get "configs/knex-example.js" | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/centralsettlement/chart-service/templates/deployment.yaml
+++ b/centralsettlement/chart-service/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
             {{- end }}
           {{- include "mojaloop-common.probes" . | nindent 10 }}
           env:
-            - name: CSET_DATABASE__PASSWORD
+            - name: CLEDG_DATABASE__PASSWORD
             {{- if .Values.config.db_secret }}
               valueFrom:
                 secretKeyRef:
@@ -103,10 +103,10 @@ spec:
               value: {{ .Values.config.db_password }}
             {{- end }}
             {{- if .Values.config.db_ssl_enabled }}
-            - name: CSET_DATABASE__ADDITIONAL_CONNECTION_OPTIONS__ssl__rejectUnauthorized
+            - name: CLEDG_DATABASE__ADDITIONAL_CONNECTION_OPTIONS__ssl__rejectUnauthorized
               value: {{ .Values.config.db_ssl_verify | quote}}
             {{- if .Values.config.db_ssl_ca_secret }}
-            - name: CSET_DATABASE__ADDITIONAL_CONNECTION_OPTIONS__ssl__ca
+            - name: CLEDG_DATABASE__ADDITIONAL_CONNECTION_OPTIONS__ssl__ca
               valueFrom:
                 secretKeyRef:
                   name: '{{ .Values.config.db_ssl_ca_secret.name }}'
@@ -186,8 +186,8 @@ spec:
             items:
             - key: default.json
               path: default.json
-    #            - key: knexfile.js
-    #              path: knexfile.js
+            - key: knexfile.js
+              path: knexfile.js
         {{- if .Values.sidecar.enabled }}
         - name: {{ template "centralsettlement-service.fullname" . }}-sidecar-vol
           configMap:

--- a/centralsettlement/chart-service/values.yaml
+++ b/centralsettlement/chart-service/values.yaml
@@ -6,14 +6,14 @@ global: {}
 
 # Declare variables to be passed into your templates.
 image:
-  registry: docker.io
-  repository: mojaloop/central-settlement
-  tag: v17.3.4
+  registry: ""
+  repository: central-ledger
+  tag: local
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
-  pullPolicy: IfNotPresent
+  pullPolicy: Never
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/centralsettlement/chart-service/values.yaml
+++ b/centralsettlement/chart-service/values.yaml
@@ -8,7 +8,7 @@ global: {}
 image:
   registry: ""
   repository: central-ledger
-  tag: local
+  tag: local2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/centralsettlement/values.yaml
+++ b/centralsettlement/values.yaml
@@ -26,7 +26,7 @@ centralsettlement-service:
     pullSecrets: []
 
   replicaCount: 1
-  command: '["node", "src/api/index.js"]'
+  command: '["node", "src/settlement/api/index.js"]'
 
   # Mount configuration files in the app folder for overriding defaults
   # configOverride:
@@ -457,14 +457,14 @@ centralsettlement-handler-deferredsettlement:
   readinessProbe:
     enabled: true
     httpGet:
-      path: /v2/health
+      path: /health
     initialDelaySeconds: 60
     periodSeconds: 15
 
   livenessProbe:
     enabled: true
     httpGet:
-      path: /v2/health
+      path: /health
     initialDelaySeconds: 60
     periodSeconds: 15
 
@@ -853,14 +853,14 @@ centralsettlement-handler-grosssettlement:
   readinessProbe:
     enabled: true
     httpGet:
-      path: /v2/health
+      path: /health
     initialDelaySeconds: 60
     periodSeconds: 15
 
   livenessProbe:
     enabled: true
     httpGet:
-      path: /v2/health
+      path: /health
     initialDelaySeconds: 60
     periodSeconds: 15
 
@@ -1248,14 +1248,14 @@ centralsettlement-handler-rules:
   readinessProbe:
     enabled: true
     httpGet:
-      path: /v2/health
+      path: /health
     initialDelaySeconds: 60
     periodSeconds: 15
 
   livenessProbe:
     enabled: true
     httpGet:
-      path: /v2/health
+      path: /health
     initialDelaySeconds: 60
     periodSeconds: 15
 

--- a/example-mojaloop-backend/values.yaml
+++ b/example-mojaloop-backend/values.yaml
@@ -341,16 +341,18 @@ mysql:
 ## Reference: https://github.com/bitnami/charts/blob/main/bitnami/mongodb/values.yaml
 cl-mongodb:
   enabled: true
-  
-  ## Image overrides for bitnamilegacy
+
+  ## Image overrides for ARM64 compatibility (Apple Silicon)
+  ## See: https://github.com/dlavrenuek/bitnami-mongodb-arm
   image:
     registry: docker.io
-    repository: bitnamilegacy/mongodb
+    repository: dlavrenuek/bitnami-mongodb-arm
+    tag: "7.0"
   metrics:
     enabled: false
     image:
       registry: docker.io
-      repository: bitnamilegacy/mongodb-exporter
+      repository: bitnami/mongodb-exporter
 
   ## @param fullnameOverride String to fully override mongodb.fullname template
   ##
@@ -419,16 +421,18 @@ cl-mongodb:
 ## Reference: https://github.com/bitnami/charts/blob/main/bitnami/mongodb/values.yaml
 cep-mongodb:
   enabled: false
-  
-  ## Image overrides for bitnamilegacy
+
+  ## Image overrides for ARM64 compatibility (Apple Silicon)
+  ## See: https://github.com/dlavrenuek/bitnami-mongodb-arm
   image:
     registry: docker.io
-    repository: bitnamilegacy/mongodb
+    repository: dlavrenuek/bitnami-mongodb-arm
+    tag: "7.0"
   metrics:
     enabled: false
     image:
       registry: docker.io
-      repository: bitnamilegacy/mongodb-exporter
+      repository: bitnami/mongodb-exporter
 
   ## @param fullnameOverride String to fully override mongodb.fullname template (will maintain the release name)
   ##
@@ -492,16 +496,18 @@ cep-mongodb:
 ## Reference: https://github.com/bitnami/charts/blob/main/bitnami/mongodb/values.yaml
 ttk-mongodb:
   enabled: true
-  
-  ## Image overrides for bitnamilegacy
+
+  ## Image overrides for ARM64 compatibility (Apple Silicon)
+  ## See: https://github.com/dlavrenuek/bitnami-mongodb-arm
   image:
     registry: docker.io
-    repository: bitnamilegacy/mongodb
+    repository: dlavrenuek/bitnami-mongodb-arm
+    tag: "7.0"
   metrics:
     enabled: false
     image:
       registry: docker.io
-      repository: bitnamilegacy/mongodb-exporter
+      repository: bitnami/mongodb-exporter
 
   ## @param fullnameOverride String to fully override mongodb.fullname template
   ##

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2406,14 +2406,14 @@ centralledger:
 
     # Declare variables to be passed into your templates.
     image:
-      registry: docker.io
-      repository: mojaloop/central-ledger
-      tag: v19.14.0
+      registry: ""
+      repository: central-ledger
+      tag: local
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
       ##
-      pullPolicy: IfNotPresent
+      pullPolicy: Never
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -2699,14 +2699,14 @@ centralledger:
     enabled: true
 
     image:
-      registry: docker.io
-      repository: mojaloop/central-ledger
-      tag: v19.14.0
+      registry: ""
+      repository: central-ledger
+      tag: local
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
       ##
-      pullPolicy: IfNotPresent
+      pullPolicy: Never
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -2989,14 +2989,14 @@ centralledger:
     enabled: true
 
     image:
-      registry: docker.io
-      repository: mojaloop/central-ledger
-      tag: v19.14.0
+      registry: ""
+      repository: central-ledger
+      tag: local
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
       ##
-      pullPolicy: IfNotPresent
+      pullPolicy: Never
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -3211,7 +3211,7 @@ centralledger:
       sessionAffinityConfig: {}
 
     ingress:
-      enabled: true
+      enabled: false
       ## @param ingress.pathType Ingress path type
       ##
       pathType: ImplementationSpecific
@@ -3277,14 +3277,14 @@ centralledger:
     enabled: true
 
     image:
-      registry: docker.io
-      repository: mojaloop/central-ledger
-      tag: v19.14.0
+      registry: ""
+      repository: central-ledger
+      tag: local
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
       ##
-      pullPolicy: IfNotPresent
+      pullPolicy: Never
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -3505,7 +3505,7 @@ centralledger:
       sessionAffinityConfig: {}
 
     ingress:
-      enabled: true
+      enabled: false
       ## @param ingress.pathType Ingress path type
       ##
       pathType: ImplementationSpecific
@@ -3570,14 +3570,14 @@ centralledger:
     enabled: true
 
     image:
-      registry: docker.io
-      repository: mojaloop/central-ledger
-      tag: v19.14.0
+      registry: ""
+      repository: central-ledger
+      tag: local
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
       ##
-      pullPolicy: IfNotPresent
+      pullPolicy: Never
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -3857,14 +3857,14 @@ centralledger:
     enabled: true
 
     image:
-      registry: docker.io
-      repository: mojaloop/central-ledger
-      tag: v19.14.0
+      registry: ""
+      repository: central-ledger
+      tag: local
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
       ##
-      pullPolicy: IfNotPresent
+      pullPolicy: Never
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -4144,14 +4144,14 @@ centralledger:
     enabled: true
 
     image:
-      registry: docker.io
-      repository: mojaloop/central-ledger
-      tag: v19.14.0
+      registry: ""
+      repository: central-ledger
+      tag: local
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
       ##
-      pullPolicy: IfNotPresent
+      pullPolicy: Never
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -4436,14 +4436,14 @@ centralledger:
     enabled: true
 
     image:
-      registry: docker.io
-      repository: mojaloop/central-ledger
-      tag: v19.14.0
+      registry: ""
+      repository: central-ledger
+      tag: local
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
       ##
-      pullPolicy: IfNotPresent
+      pullPolicy: Never
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -4722,14 +4722,14 @@ centralsettlement:
     enabled: true
 
     image:
-      registry: docker.io
-      repository: mojaloop/central-settlement
-      tag: v17.3.3
+      registry: ""
+      repository: central-ledger
+      tag: local
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
       ##
-      pullPolicy: IfNotPresent
+      pullPolicy: Never
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -4767,14 +4767,14 @@ centralsettlement:
     readinessProbe:
       enabled: true
       httpGet:
-        path: /v2/health
+        path: /health
       initialDelaySeconds: 60
       periodSeconds: 15
 
     livenessProbe:
       enabled: true
       httpGet:
-        path: /v2/health
+        path: /health
       initialDelaySeconds: 60
       periodSeconds: 15
 
@@ -5099,14 +5099,14 @@ centralsettlement:
     enabled: true
 
     image:
-      registry: docker.io
-      repository: mojaloop/central-settlement
-      tag: v17.3.3
+      registry: ""
+      repository: central-ledger
+      tag: local
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
       ##
-      pullPolicy: IfNotPresent
+      pullPolicy: Never
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -5480,14 +5480,14 @@ centralsettlement:
     enabled: false
 
     image:
-      registry: docker.io
-      repository: mojaloop/central-settlement
-      tag: v17.3.3
+      registry: ""
+      repository: central-ledger
+      tag: local
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
       ##
-      pullPolicy: IfNotPresent
+      pullPolicy: Never
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -5861,14 +5861,14 @@ centralsettlement:
     enabled: true
 
     image:
-      registry: docker.io
-      repository: mojaloop/central-settlement
-      tag: v17.3.3
+      registry: ""
+      repository: central-ledger
+      tag: local
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
       ##
-      pullPolicy: IfNotPresent
+      pullPolicy: Never
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -12701,7 +12701,7 @@ ml-ttk-cronjob-cleanup:
 
 ml-ttk-test-setup:
   tests:
-    enabled: true
+    enabled: false
     weight: -9
   config:
     ## Test-case archive zip for test-cases: https://github.com/mojaloop/testing-toolkit-test-cases

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2717,7 +2717,7 @@ centralledger:
       pullSecrets: []
 
     replicaCount: 1
-    command: '["node", "src/handlers/index.js", "handler", "--prepare"]'
+    command: '["node", "dist/handlers/index.js", "handler", "--prepare"]'
 
     ## Enable diagnostic mode in the deployment
     ##
@@ -2733,7 +2733,7 @@ centralledger:
       ##
       args:
         - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-        - src/handlers/index.js
+        - dist/handlers/index.js
         - handler
         - '--prepare'
 
@@ -3007,7 +3007,7 @@ centralledger:
       pullSecrets: []
 
     replicaCount: 1
-    command: '["node", "src/handlers/index.js", "handler", "--position"]'
+    command: '["node", "dist/handlers/index.js", "handler", "--position"]'
 
     ## Enable diagnostic mode in the deployment
     ##
@@ -3023,7 +3023,7 @@ centralledger:
       ##
       args:
         - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-        - src/handlers/index.js
+        - dist/handlers/index.js
         - handler
         - '--position'
 
@@ -3295,7 +3295,7 @@ centralledger:
       pullSecrets: []
 
     replicaCount: 1
-    command: '["node", "src/handlers/index.js", "handler", "--positionbatch"]'
+    command: '["node", "dist/handlers/index.js", "handler", "--positionbatch"]'
 
     ## Enable diagnostic mode in the deployment
     ##
@@ -3311,7 +3311,7 @@ centralledger:
       ##
       args:
         - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-        - src/handlers/index.js
+        - dist/handlers/index.js
         - handler
         - '--positionbatch'
 
@@ -3588,7 +3588,7 @@ centralledger:
       pullSecrets: []
 
     replicaCount: 1
-    command: '["node", "src/handlers/index.js", "handler", "--get"]'
+    command: '["node", "dist/handlers/index.js", "handler", "--get"]'
 
     ## Enable diagnostic mode in the deployment
     ##
@@ -3604,7 +3604,7 @@ centralledger:
       ##
       args:
         - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-        - src/handlers/index.js
+        - dist/handlers/index.js
         - handler
         - '--get'
 
@@ -3875,7 +3875,7 @@ centralledger:
       pullSecrets: []
 
     replicaCount: 1
-    command: '["node", "src/handlers/index.js", "handler", "--fulfil"]'
+    command: '["node", "dist/handlers/index.js", "handler", "--fulfil"]'
 
     ## Enable diagnostic mode in the deployment
     ##
@@ -3891,7 +3891,7 @@ centralledger:
       ##
       args:
         - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-        - src/handlers/index.js
+        - dist/handlers/index.js
         - handler
         - '--fulfil'
 
@@ -4162,7 +4162,7 @@ centralledger:
       pullSecrets: []
 
     replicaCount: 1
-    command: '["node", "src/handlers/index.js", "handler", "--timeout"]'
+    command: '["node", "dist/handlers/index.js", "handler", "--timeout"]'
 
     ## Enable diagnostic mode in the deployment
     ##
@@ -4178,7 +4178,7 @@ centralledger:
       ##
       args:
         - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-        - src/handlers/index.js
+        - dist/handlers/index.js
         - handler
         - '--timeout'
 
@@ -4454,7 +4454,7 @@ centralledger:
       pullSecrets: []
 
     replicaCount: 1
-    command: '["node", "src/handlers/index.js", "handler", "--admin"]'
+    command: '["node", "dist/handlers/index.js", "handler", "--admin"]'
 
     ## Enable diagnostic mode in the deployment
     ##
@@ -4470,7 +4470,7 @@ centralledger:
       ##
       args:
         - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-        - src/handlers/index.js
+        - dist/handlers/index.js
         - handler
         - '--admin'
 
@@ -5117,7 +5117,7 @@ centralsettlement:
       pullSecrets: []
 
     replicaCount: 1
-    command: '["node", "src/handlers/index.js", "h", "--deferredSettlement"]'
+    command: '["node", "dist/handlers/index.js", "h", "--deferredSettlement"]'
 
     ## Enable diagnostic mode in the deployment
     ##
@@ -5133,7 +5133,7 @@ centralsettlement:
       ##
       args:
         - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-        - src/handlers/index.js
+        - dist/handlers/index.js
         - h
         - "--deferredSettlement"
 
@@ -5498,7 +5498,7 @@ centralsettlement:
       pullSecrets: []
 
     replicaCount: 1
-    command: '["node", "src/handlers/index.js", "h", "--grossSettlement"]'
+    command: '["node", "dist/handlers/index.js", "h", "--grossSettlement"]'
 
     ## Enable diagnostic mode in the deployment
     ##
@@ -5510,7 +5510,7 @@ centralsettlement:
       ##
       command:
         - node
-        - src/handlers/index.js
+        - dist/handlers/index.js
         - h
         - "--grossSettlement"
       ## @param diagnosticMode.args Args to override all containers in the deployment
@@ -5879,7 +5879,7 @@ centralsettlement:
       pullSecrets: []
 
     replicaCount: 1
-    command: '["node", "src/handlers/index.js", "h", "--rules"]'
+    command: '["node", "dist/handlers/index.js", "h", "--rules"]'
 
     ## Enable diagnostic mode in the deployment
     ##
@@ -5891,7 +5891,7 @@ centralsettlement:
       ##
       command:
         - node
-        - src/handlers/index.js
+        - dist/handlers/index.js
         - h
         - "--rules"
       ## @param diagnosticMode.args Args to override all containers in the deployment
@@ -11106,7 +11106,7 @@ mojaloop-bulk:
         pullSecrets: []
 
       replicaCount: 1
-      command: '["node", "src/handlers/index.js", "handler", "--bulkprepare"]'
+      command: '["node", "dist/handlers/index.js", "handler", "--bulkprepare"]'
 
       ## Enable diagnostic mode in the deployment
       ##
@@ -11118,7 +11118,7 @@ mojaloop-bulk:
         ##
         command:
           - node
-          - src/handlers/index.js
+          - dist/handlers/index.js
           - handler
           - '--bulkprepare'
         ## @param diagnosticMode.args Args to override all containers in the deployment
@@ -11390,7 +11390,7 @@ mojaloop-bulk:
         pullSecrets: []
 
       replicaCount: 1
-      command: '["node", "src/handlers/index.js", "handler", "--bulkfulfil"]'
+      command: '["node", "dist/handlers/index.js", "handler", "--bulkfulfil"]'
 
       ## Enable diagnostic mode in the deployment
       ##
@@ -11402,7 +11402,7 @@ mojaloop-bulk:
         ##
         command:
           - node
-          - src/handlers/index.js
+          - dist/handlers/index.js
           - handler
           - '--bulkfulfil'
         ## @param diagnosticMode.args Args to override all containers in the deployment
@@ -11671,7 +11671,7 @@ mojaloop-bulk:
         pullSecrets: []
 
       replicaCount: 1
-      command: '["node", "src/handlers/index.js", "handler", "--bulkprocessing"]'
+      command: '["node", "dist/handlers/index.js", "handler", "--bulkprocessing"]'
 
       ## Enable diagnostic mode in the deployment
       ##
@@ -11683,7 +11683,7 @@ mojaloop-bulk:
         ##
         command:
           - node
-          - src/handlers/index.js
+          - dist/handlers/index.js
           - handler
           - '--bulkprocessing'
         ## @param diagnosticMode.args Args to override all containers in the deployment
@@ -11952,7 +11952,7 @@ mojaloop-bulk:
         pullSecrets: []
 
       replicaCount: 1
-      command: '["node", "src/handlers/index.js", "handler", "--bulkget"]'
+      command: '["node", "dist/handlers/index.js", "handler", "--bulkget"]'
 
       ## Enable diagnostic mode in the deployment
       ##
@@ -11964,7 +11964,7 @@ mojaloop-bulk:
         ##
         command:
           - node
-          - src/handlers/index.js
+          - dist/handlers/index.js
           - handler
           - '--bulkget'
         ## @param diagnosticMode.args Args to override all containers in the deployment

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2408,7 +2408,7 @@ centralledger:
     image:
       registry: ""
       repository: central-ledger
-      tag: local
+      tag: local2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2701,7 +2701,7 @@ centralledger:
     image:
       registry: ""
       repository: central-ledger
-      tag: local
+      tag: local2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2991,7 +2991,7 @@ centralledger:
     image:
       registry: ""
       repository: central-ledger
-      tag: local
+      tag: local2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -3279,7 +3279,7 @@ centralledger:
     image:
       registry: ""
       repository: central-ledger
-      tag: local
+      tag: local2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -3572,7 +3572,7 @@ centralledger:
     image:
       registry: ""
       repository: central-ledger
-      tag: local
+      tag: local2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -3859,7 +3859,7 @@ centralledger:
     image:
       registry: ""
       repository: central-ledger
-      tag: local
+      tag: local2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -4146,7 +4146,7 @@ centralledger:
     image:
       registry: ""
       repository: central-ledger
-      tag: local
+      tag: local2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -4438,7 +4438,7 @@ centralledger:
     image:
       registry: ""
       repository: central-ledger
-      tag: local
+      tag: local2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -4724,7 +4724,7 @@ centralsettlement:
     image:
       registry: ""
       repository: central-ledger
-      tag: local
+      tag: local2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -5101,7 +5101,7 @@ centralsettlement:
     image:
       registry: ""
       repository: central-ledger
-      tag: local
+      tag: local2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -5482,7 +5482,7 @@ centralsettlement:
     image:
       registry: ""
       repository: central-ledger
-      tag: local
+      tag: local2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -5863,7 +5863,7 @@ centralsettlement:
     image:
       registry: ""
       repository: central-ledger
-      tag: local
+      tag: local2
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -2424,7 +2424,7 @@ centralledger:
       pullSecrets: []
 
     replicaCount: 1
-    command: '["node", "src/api/index.js"]'
+    command: '["node", "dist/api/index.js"]'
 
     ## Enable diagnostic mode in the deployment
     ##
@@ -2440,7 +2440,7 @@ centralledger:
       ##
       args:
         - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-        - src/api/index.js
+        - dist/api/index.js
 
       ## @param diagnosticMode.debug config to override all debug information
       ##
@@ -4740,7 +4740,7 @@ centralsettlement:
       pullSecrets: []
 
     replicaCount: 1
-    command: '["node", "src/api/index.js"]'
+    command: '["node", "dist/api/index.js"]'
 
     ## Enable diagnostic mode in the deployment
     ##
@@ -4756,7 +4756,7 @@ centralsettlement:
       ##
       args:
         - --inspect=0.0.0.0:{{ .Values.diagnosticMode.debug.port }}
-        - src/api/index.js
+        - dist/api/index.js
 
       ## @param diagnosticMode.debug config to override all debug information
       ##


### PR DESCRIPTION
This is an example patch which uses the `central-ledger` image from `mojaloop/central-ledger#1286  to run the central-settlement services.

To keep separation of services, centralsettlement services are kept separate, but use the same underlying central-ledger image.

Once mojaloop/central-ledger#1286 is merged in and deployed, we will need to apply this to Helm in order to deploy the new settlements apis and handlers.

For local testing, I've made the following change to the central-ledger and central-settlement images, which needs to be reverted before merging this PR

`mojaloop/values.yaml`:
```yaml
image:
      registry: ""
      repository: central-ledger
      tag: local
```


GP tests running on my local machine:
```
--------------------FINAL REPORT--------------------

Test Suite:GP Tests
Environment:Development
┌───────────────────────────────────────────────────┐
│                      SUMMARY                      │
├───────────────────┬───────────────────────────────┤
│ Total assertions  │ 2714                          │
├───────────────────┼───────────────────────────────┤
│ Passed assertions │ 2714                          │
├───────────────────┼───────────────────────────────┤
│ Failed assertions │ 0                             │
├───────────────────┼───────────────────────────────┤
│ Total requests    │ 680                           │
├───────────────────┼───────────────────────────────┤
│ Total test cases  │ 153                           │
├───────────────────┼───────────────────────────────┤
│ Passed percentage │ 100.00%                       │
├───────────────────┼───────────────────────────────┤
│ Started time      │ Tue, 19 May 2026 13:44:08 GMT │
├───────────────────┼───────────────────────────────┤
│ Completed time    │ 2026-05-19T13:50:56.234Z      │
├───────────────────┼───────────────────────────────┤
│ Runtime duration  │ 407986 ms                     │
└───────────────────┴───────────────────────────────┘
```