### PR TITLE
feat: add settlement window close delay value

### DIFF
--- a/centralsettlement/chart-service/configs/default.json
+++ b/centralsettlement/chart-service/configs/default.json
@@ -27,7 +27,8 @@
   },
   "WINDOW_AGGREGATION": {
     "RETRY_COUNT": {{ .Values.config.window_aggregation.retry_count }},
-    "RETRY_INTERVAL": {{ .Values.config.window_aggregation.retry_interval }}
+    "RETRY_INTERVAL": {{ .Values.config.window_aggregation.retry_interval }},
+    "CLOSE_DELAY_MS": {{ .Values.config.window_aggregation.close_delay_ms }}
   },
   "TRANSFER_VALIDITY_SECONDS": "432000",
   "HUB_PARTICIPANT": {

--- a/centralsettlement/chart-service/values.yaml
+++ b/centralsettlement/chart-service/values.yaml
@@ -8,7 +8,7 @@ global: {}
 image:
   registry: docker.io
   repository: mojaloop/central-settlement
-  tag: v17.3.4
+  tag: v17.4.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/centralsettlement/chart-service/values.yaml
+++ b/centralsettlement/chart-service/values.yaml
@@ -258,6 +258,7 @@ config:
   window_aggregation:
     retry_count: 3
     retry_interval: 3000
+    close_delay_ms: 0
   hub_participant:
     id: 1
     name: Hub

--- a/centralsettlement/values.yaml
+++ b/centralsettlement/values.yaml
@@ -10,7 +10,7 @@ centralsettlement-service:
   image:
     registry: docker.io
     repository: mojaloop/central-settlement
-    tag: v17.3.4
+    tag: v17.4.0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -403,7 +403,7 @@ centralsettlement-handler-deferredsettlement:
   image:
     registry: docker.io
     repository: mojaloop/central-settlement
-    tag: v17.3.4
+    tag: v17.4.0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -800,7 +800,7 @@ centralsettlement-handler-grosssettlement:
   image:
     registry: docker.io
     repository: mojaloop/central-settlement
-    tag: v17.3.4
+    tag: v17.4.0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1196,7 +1196,7 @@ centralsettlement-handler-rules:
   image:
     registry: docker.io
     repository: mojaloop/central-settlement
-    tag: v17.3.4
+    tag: v17.4.0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/centralsettlement/values.yaml
+++ b/centralsettlement/values.yaml
@@ -253,6 +253,7 @@ centralsettlement-service:
     window_aggregation:
       retry_count: 3
       retry_interval: 3000
+      close_delay_ms: 0
     hub_participant:
       id: 1
       name: Hub
@@ -647,6 +648,7 @@ centralsettlement-handler-deferredsettlement:
     window_aggregation:
       retry_count: 3
       retry_interval: 3000
+      close_delay_ms: 0
     hub_participant:
       id: 1
       name: Hub
@@ -1043,6 +1045,7 @@ centralsettlement-handler-grosssettlement:
     window_aggregation:
       retry_count: 3
       retry_interval: 3000
+      close_delay_ms: 0
     hub_participant:
       id: 1
       name: Hub
@@ -1438,6 +1441,7 @@ centralsettlement-handler-rules:
     window_aggregation:
       retry_count: 3
       retry_interval: 3000
+      close_delay_ms: 0
     hub_participant:
       id: 1
       name: Hub

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -4724,7 +4724,7 @@ centralsettlement:
     image:
       registry: docker.io
       repository: mojaloop/central-settlement
-      tag: v17.3.3
+      tag: v17.4.0
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -5102,7 +5102,7 @@ centralsettlement:
     image:
       registry: docker.io
       repository: mojaloop/central-settlement
-      tag: v17.3.3
+      tag: v17.4.0
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -5484,7 +5484,7 @@ centralsettlement:
     image:
       registry: docker.io
       repository: mojaloop/central-settlement
-      tag: v17.3.3
+      tag: v17.4.0
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -5866,7 +5866,7 @@ centralsettlement:
     image:
       registry: docker.io
       repository: mojaloop/central-settlement
-      tag: v17.3.3
+      tag: v17.4.0
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/mojaloop/values.yaml
+++ b/mojaloop/values.yaml
@@ -4956,6 +4956,7 @@ centralsettlement:
       window_aggregation:
         retry_count: 3
         retry_interval: 3000
+        close_delay_ms: 0
 
       ## Log config
       log_level: info
@@ -5335,6 +5336,7 @@ centralsettlement:
       window_aggregation:
         retry_count: 3
         retry_interval: 3000
+        close_delay_ms: 0
 
       ## Log config
       log_level: info
@@ -5716,6 +5718,7 @@ centralsettlement:
       window_aggregation:
         retry_count: 3
         retry_interval: 3000
+        close_delay_ms: 0
 
       ## Log config
       log_level: info
@@ -6097,6 +6100,7 @@ centralsettlement:
       window_aggregation:
         retry_count: 3
         retry_interval: 3000
+        close_delay_ms: 0
 
       ## Log config
       log_level: info


### PR DESCRIPTION
`WINDOW_AGGREGATION.CLOSE_DELAY_MS`  — Introduces a configurable delay (in milliseconds) between a settlement window transitioning from `PROCESSING` to `CLOSED`. This allows in-flight transfers sufficient time to commit before the window closes, preventing inconsistencies that would otherwise occur if transfers are committed against an already-closed window. Defaults to 0 (no delay).